### PR TITLE
fix: PR-27 follow-up (tasks 6–7, docs, rate-limiting, .gitignore)

### DIFF
--- a/.cursor/dev-planning/code-review/v1.0.0/PR-27-review.md
+++ b/.cursor/dev-planning/code-review/v1.0.0/PR-27-review.md
@@ -1,0 +1,85 @@
+# Code Review: PR #27
+
+| **PR** | #27 |
+|:---:|:---|
+| **Title** | test: property-based, load, chaos, and contract tests (P7–P8) |
+| **Status** | ✅ **APPROVED** (with Warnings) |
+| **Risk** | 🟡 **Low/Medium** (Documentation updates safe, but uncovered risks in existing code) |
+
+---
+
+## 1. Executive Summary
+
+This PR marks the completion of **Sprint P7 (Property & Load Testing)** and **Sprint P8 (Chaos & Contract Testing)**. It primarily introduces new test suites and documentation updates, with no changes to the core `src/` logic.
+
+### Key Highlights
+*   **Protocol Compliance:** The documentation accurately reflects the "Burst Allowance" decision (`10/second;100/minute`) recorded in `DD-012`.
+*   **Test Capabilities:** Adds significant resilience testing (Chaos) and backward compatibility assurances (Contract).
+*   **Verification:** Verified that the documented rate limits match the default values in `middleware.py` and `server.py`.
+
+---
+
+## 2. Red Team Analysis (Security & Stability)
+
+**Status:** ⚠️ **WARNINGS FOUND**
+
+While this PR itself is safe, the deep-dive analysis triggered by it uncovered potential risks in the existing codebase that should be addressed in follow-up tasks.
+
+### 🚨 Risk 1: Blocking I/O in Async Auth Path
+*   **Severity:** **Medium** (Performance Risk)
+*   **Location:** `src/asap/transport/middleware.py:501` (`AuthenticationMiddleware.verify_authentication`)
+*   **Finding:** The `TokenValidator` protocol enforces a synchronous call (`self.validator(token)`) within an `async` path.
+*   **Impact:** If a user implements a validator that performs network I/O (e.g., checking Redis/DB), it will **block the main event loop**, pausing all concurrent requests.
+*   **Recommendation:** Update `TokenValidator` to return `Awaitable[str | None]` or force execution in a thread pool.
+
+### 🚨 Risk 2: Rate Limit Isolation via Memory Storage
+*   **Severity:** **Low** (Deployment Configuration Risk)
+*   **Location:** `src/asap/transport/middleware.py:181` (`create_limiter`)
+*   **Finding:** The default `storage_uri="memory://"` creates isolated state per worker.
+*   **Impact:** In a multi-worker deployment (e.g., Gunicorn with 4 workers), the effective rate limit is multiplied by the number of workers (e.g., `10/s` -> `40/s`), potentially under-protecting backends.
+*   **Recommendation:** Explicitly document this behavior or recommend Redis for production deployments.
+
+---
+
+## 3. QA Lead Audit (Testing Strategy)
+
+**Status:** ✅ **PASSING**
+
+The testing strategy introduced in this PR is robust and adheres to project standards.
+
+### ✅ Coverage & Hygiene
+*   **Gap Analysis:** No logic changes in `src/`, so no regression risk. The PR *is* the tests.
+*   **Async Hygiene:** Proper use of `async/await` and `httpx.MockTransport` in Chaos tests.
+*   **Standard Compliance:** Adheres to `testing-standards.mdc`.
+
+### 🔧 Refactoring Opportunities
+*   **Fixture Duplication:** `sample_request_envelope` factories are duplicated across Chaos tests (`tests/chaos/`).
+    *   *Action:* Consider consolidating into `tests/chaos/conftest.py`.
+
+### 🧪 Verification
+Run the new suites to confirm health:
+```bash
+uv run pytest tests/chaos/ tests/contract/ -v
+```
+
+---
+
+## 4. Improvements & Nitpicks
+
+### Traceability (Strongly Recommended)
+**File:** `src/asap/transport/server.py:1356`
+```diff
+    if rate_limit is None:
+-       rate_limit_str = os.getenv("ASAP_RATE_LIMIT", "10/second;100/minute")
++       # Default matches DD-012: Burst allowance for better UX with bursty agent traffic
++       rate_limit_str = os.getenv("ASAP_RATE_LIMIT", "10/second;100/minute")
+```
+*Context:* Explicitly link the default value to the Architecture Decision Record (DD-012) for long-term maintainability.
+
+---
+
+## 5. Conclusion
+
+**Verdict:** **MERGE**
+
+The PR is solid. The "WARNINGS" found in the Red Team analysis are **existing architectural issues**, not regressions introduced by this PR. They should be converted into issues/tasks for the next Sprint but do not block this merge.

--- a/.cursor/rules/testing-rate-limiting.mdc
+++ b/.cursor/rules/testing-rate-limiting.mdc
@@ -1,6 +1,6 @@
 # Rate Limiting Testing Pattern
 
-> Quick reference for testing with slowapi rate limiting. For detailed documentation, see: `.cursor/dev-planning/code-review/v1.0.0/rate-limiting-testing-patterns.md`
+> Quick reference for testing with slowapi rate limiting. Full documentation: `.cursor/docs/rate-limiting-testing-patterns.md`
 
 ## Problem
 
@@ -136,7 +136,7 @@ pytest -n 0
 
 ## When in Doubt
 
-1. Read the detailed documentation: `.cursor/dev-planning/code-review/v1.0.0/rate-limiting-testing-patterns.md`
+1. Read the full documentation: `.cursor/docs/rate-limiting-testing-patterns.md`
 2. Check existing examples: `tests/transport/test_server.py::TestDebugLogMode`
 3. Check v0.5.0 fixtures: `tests/transport/conftest.py`
 

--- a/.cursor/rules/testing-standards.mdc
+++ b/.cursor/rules/testing-standards.mdc
@@ -28,3 +28,11 @@ alwaysApply: false
 ## 4. Anti-Patterns
 - Never use `time.sleep()`. Use `asyncio.sleep()`.
 - Do not bypass `ruff` or `mypy` checks in tests.
+
+## 5. CI and pytest-xdist
+
+When running tests in parallel (`-n auto`), follow these rules to avoid INTERNALERROR (exit code 3) and flaky CI:
+
+- **Rate limiter isolation:** The global rate limiter (slowapi) is shared across workers. `tests/conftest.py` provides an autouse fixture `_isolate_rate_limiter` that replaces it with an isolated instance per test. Do not remove this fixture; tests that need specific rate limits (e.g. `tests/transport/integration/test_rate_limiting.py`) skip isolation via `request.fspath` check.
+- **Coverage and xdist:** Do NOT add `--cov=src` or `--cov-report=*` to pytest `addopts` in `pyproject.toml`. Running coverage with pytest-xdist can cause INTERNALERROR. Run coverage only in a dedicated CI job without `-n auto` (e.g. `uv run pytest --cov=src --cov-report=xml`).
+- **Benchmarks and testpaths:** `testpaths` must include only `tests/`, not `benchmarks/`. The benchmarks use Locust, which monkey-patches gevent/ssl on import; that conflicts with pytest-xdist workers. Run benchmarks separately when needed: `uv run pytest benchmarks/` or `uv run locust -f benchmarks/load_test.py`.

--- a/.gitignore
+++ b/.gitignore
@@ -160,8 +160,14 @@ cython_debug/
 .vscode/
 *.swp
 *.swo
+*~
 
-# Project specific
+# Temporary / backup
+*.tmp
+*.temp
+*.bak
+
+# Project specific (Cursor: keep .cursor/ tracked; ignore local-only paths)
 !/.cursor/
 .cursor/docs/design-decisions.md
 .cursor/docs/wiki

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Transport:
 
 ### Development: Handler hot reload (`ASAP_HOT_RELOAD`)
 
-When running the server during development, you can enable **handler hot reload** so that changes to the handlers module are picked up without restarting the process. This is a **development-only** feature and must not be used in production.
+**Development only** — Do not enable `ASAP_HOT_RELOAD` in production. It is intended for local development so that changes to the handlers module are picked up without restarting the process.
 
 - Set the environment variable `ASAP_HOT_RELOAD=1` (or `true` / `yes`) before starting the server.
 - The implementation uses a **background thread** that watches the handlers file and reloads the registry when it changes. The server continues serving requests while the watcher runs.

--- a/src/asap/examples/orchestration.py
+++ b/src/asap/examples/orchestration.py
@@ -190,6 +190,8 @@ async def run_orchestration(
 
     bind_context(trace_id=trace_id, correlation_id=conversation_id)
     try:
+        # One ASAPClient per worker for the full run: reuses HTTP session/connection pool
+        # instead of creating a new client per request (efficiency).
         async with ASAPClient(worker_a_url) as client_a, ASAPClient(worker_b_url) as client_b:
             # Step 1: send to sub-agent A (reuse client_a)
             state.step = "sent_to_a"

--- a/src/asap/state/machine.py
+++ b/src/asap/state/machine.py
@@ -15,6 +15,7 @@ from asap.errors import InvalidTransitionError
 from asap.models.entities import Task
 from asap.models.enums import TaskStatus
 
+__all__ = ["TaskStatus", "can_transition", "transition", "VALID_TRANSITIONS"]
 
 # Valid state transitions mapping
 VALID_TRANSITIONS: dict[TaskStatus, set[TaskStatus]] = {

--- a/src/asap/transport/handlers.py
+++ b/src/asap/transport/handlers.py
@@ -439,18 +439,19 @@ class HandlerRegistry:
             return list(self._handlers.keys())
 
 
-def create_echo_handler() -> Handler:
-    """Create an echo handler that echoes TaskRequest input.
+def create_echo_handler() -> SyncHandler:
+    """Create a synchronous echo handler that echoes TaskRequest input.
 
     The echo handler is a simple implementation that:
     - Receives a TaskRequest envelope
     - Returns a TaskResponse with the input echoed back
     - Preserves trace_id and sets correlation_id
 
+    Returns SyncHandler (not Handler) so tests can use it without casting.
     This is useful for testing and as a base for custom handlers.
 
     Returns:
-        Handler function that echoes TaskRequest input
+        SyncHandler that echoes TaskRequest input
 
     Example:
         >>> handler = create_echo_handler()

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -1,0 +1,79 @@
+"""Shared fixtures for chaos engineering tests.
+
+This module provides reusable fixtures and helpers for tests in tests/chaos/:
+- sample_request_envelope: Canonical request envelope for chaos scenarios
+- sample_response_envelope: Response envelope correlated with request
+- create_mock_response: Helper to build httpx responses from envelopes
+"""
+
+import httpx
+import pytest
+
+from asap.models.envelope import Envelope
+from asap.models.enums import TaskStatus
+from asap.models.payloads import TaskRequest, TaskResponse
+
+
+def create_mock_response(envelope: Envelope, request_id: str | int = "req-1") -> httpx.Response:
+    """Create a mock HTTP response with JSON-RPC wrapped envelope.
+
+    Args:
+        envelope: ASAP envelope to wrap in JSON-RPC result
+        request_id: JSON-RPC request id for correlation
+
+    Returns:
+        httpx.Response with status 200 and JSON-RPC formatted body
+    """
+    json_rpc_response = {
+        "jsonrpc": "2.0",
+        "result": {"envelope": envelope.model_dump(mode="json")},
+        "id": request_id,
+    }
+    return httpx.Response(
+        status_code=200,
+        json=json_rpc_response,
+    )
+
+
+@pytest.fixture
+def sample_request_envelope() -> Envelope:
+    """Create a canonical request envelope for chaos testing.
+
+    Returns:
+        Envelope with task.request payload for echo skill
+    """
+    return Envelope(
+        asap_version="0.1",
+        sender="urn:asap:agent:client",
+        recipient="urn:asap:agent:server",
+        payload_type="task.request",
+        payload=TaskRequest(
+            conversation_id="conv_chaos_001",
+            skill_id="echo",
+            input={"message": "Chaos test"},
+        ).model_dump(),
+    )
+
+
+@pytest.fixture
+def sample_response_envelope(sample_request_envelope: Envelope) -> Envelope:
+    """Create a response envelope correlated with sample_request_envelope.
+
+    Args:
+        sample_request_envelope: Request envelope to correlate with
+
+    Returns:
+        Envelope with task.response payload
+    """
+    return Envelope(
+        asap_version="0.1",
+        sender="urn:asap:agent:server",
+        recipient="urn:asap:agent:client",
+        payload_type="task.response",
+        payload=TaskResponse(
+            task_id="task_chaos_001",
+            status=TaskStatus.COMPLETED,
+            result={"echoed": {"message": "Chaos test"}},
+        ).model_dump(),
+        correlation_id=sample_request_envelope.id,
+    )

--- a/tests/examples/test_examples_dx.py
+++ b/tests/examples/test_examples_dx.py
@@ -271,10 +271,10 @@ class TestMultiStepWorkflowExample:
     def test_run_workflow_applies_steps_in_order(self) -> None:
         """run_workflow applies steps and returns final state."""
 
-        def step_a(data: dict) -> dict:
+        def step_a(data: dict[str, object]) -> dict[str, object]:
             return {"a": 1}
 
-        def step_b(data: dict) -> dict:
+        def step_b(data: dict[str, object]) -> dict[str, object]:
             return {**data, "b": 2}
 
         steps = [

--- a/tests/models/test_payloads.py
+++ b/tests/models/test_payloads.py
@@ -1,5 +1,7 @@
 """Tests for Task payload models (requests, responses, updates, cancellations)."""
 
+from asap.models.enums import MessageRole, TaskStatus, UpdateType
+
 
 class TestTaskRequest:
     """Test suite for TaskRequest payload model."""
@@ -82,7 +84,7 @@ class TestTaskResponse:
         """Test creating a TaskResponse with minimal required fields."""
         from asap.models.payloads import TaskResponse
 
-        response = TaskResponse(task_id="task_01HX5K4N", status="completed")
+        response = TaskResponse(task_id="task_01HX5K4N", status=TaskStatus.COMPLETED)
 
         assert response.task_id == "task_01HX5K4N"
         assert response.status == "completed"
@@ -96,7 +98,7 @@ class TestTaskResponse:
 
         result = {"summary": "Analysis complete with 3 key findings", "artifacts": ["art_01HX5K6Q"]}
 
-        response = TaskResponse(task_id="task_123", status="completed", result=result)
+        response = TaskResponse(task_id="task_123", status=TaskStatus.COMPLETED, result=result)
 
         assert response.result is not None
         assert response.result["summary"] == "Analysis complete with 3 key findings"
@@ -108,7 +110,9 @@ class TestTaskResponse:
 
         final_state = {"version": 5, "data": {"completed": True, "findings": 3}}
 
-        response = TaskResponse(task_id="task_123", status="completed", final_state=final_state)
+        response = TaskResponse(
+            task_id="task_123", status=TaskStatus.COMPLETED, final_state=final_state
+        )
 
         assert response.final_state is not None
         assert response.final_state["version"] == 5
@@ -119,7 +123,7 @@ class TestTaskResponse:
 
         metrics = {"duration_ms": 45000, "tokens_used": 12500}
 
-        response = TaskResponse(task_id="task_123", status="completed", metrics=metrics)
+        response = TaskResponse(task_id="task_123", status=TaskStatus.COMPLETED, metrics=metrics)
 
         assert response.metrics is not None
         assert response.metrics["duration_ms"] == 45000
@@ -154,7 +158,10 @@ class TestTaskUpdate:
         }
 
         update = TaskUpdate(
-            task_id="task_123", update_type="progress", status="working", progress=progress
+            task_id="task_123",
+            update_type=UpdateType.PROGRESS,
+            status=TaskStatus.WORKING,
+            progress=progress,
         )
 
         assert update.task_id == "task_123"
@@ -179,8 +186,8 @@ class TestTaskUpdate:
 
         update = TaskUpdate(
             task_id="task_123",
-            update_type="input_required",
-            status="input_required",
+            update_type=UpdateType.INPUT_REQUIRED,
+            status=TaskStatus.INPUT_REQUIRED,
             input_request=input_request,
         )
 
@@ -215,8 +222,8 @@ class TestTaskUpdate:
         with pytest.raises(ValueError, match="progress.percent must be a number"):
             TaskUpdate(
                 task_id="task_123",
-                update_type="progress",
-                status="working",
+                update_type=UpdateType.PROGRESS,
+                status=TaskStatus.WORKING,
                 progress={"percent": "fifty"},  # String instead of number
             )
 
@@ -229,16 +236,16 @@ class TestTaskUpdate:
         with pytest.raises(ValueError, match="progress.percent must be between 0 and 100"):
             TaskUpdate(
                 task_id="task_123",
-                update_type="progress",
-                status="working",
+                update_type=UpdateType.PROGRESS,
+                status=TaskStatus.WORKING,
                 progress={"percent": 150},  # Over 100
             )
 
         with pytest.raises(ValueError, match="progress.percent must be between 0 and 100"):
             TaskUpdate(
                 task_id="task_123",
-                update_type="progress",
-                status="working",
+                update_type=UpdateType.PROGRESS,
+                status=TaskStatus.WORKING,
                 progress={"percent": -10},  # Negative
             )
 
@@ -248,8 +255,8 @@ class TestTaskUpdate:
 
         update = TaskUpdate(
             task_id="task_123",
-            update_type="progress",
-            status="working",
+            update_type=UpdateType.PROGRESS,
+            status=TaskStatus.WORKING,
             progress={"message": "Working..."},  # No percent field
         )
 
@@ -261,16 +268,16 @@ class TestTaskUpdate:
 
         update_zero = TaskUpdate(
             task_id="task_123",
-            update_type="progress",
-            status="working",
+            update_type=UpdateType.PROGRESS,
+            status=TaskStatus.WORKING,
             progress={"percent": 0},
         )
         assert update_zero.progress["percent"] == 0
 
         update_hundred = TaskUpdate(
             task_id="task_456",
-            update_type="progress",
-            status="working",
+            update_type=UpdateType.PROGRESS,
+            status=TaskStatus.WORKING,
             progress={"percent": 100},
         )
         assert update_hundred.progress["percent"] == 100
@@ -322,7 +329,7 @@ class TestMessageSend:
             task_id="task_123",
             message_id="msg_456",
             sender="urn:asap:agent:coordinator",
-            role="user",
+            role=MessageRole.USER,
             parts=["part_789"],
         )
 
@@ -340,7 +347,7 @@ class TestMessageSend:
             task_id="task_123",
             message_id="msg_456",
             sender="urn:asap:agent:assistant",
-            role="assistant",
+            role=MessageRole.ASSISTANT,
             parts=["part_1", "part_2", "part_3"],
         )
 

--- a/tests/testing/test_assertions.py
+++ b/tests/testing/test_assertions.py
@@ -3,6 +3,7 @@
 import pytest
 
 from asap.models.envelope import Envelope
+from asap.models.enums import TaskStatus
 from asap.models.payloads import TaskRequest, TaskResponse
 from asap.testing.assertions import (
     assert_envelope_valid,
@@ -19,7 +20,7 @@ def _make_request_envelope(
 ) -> Envelope:
     """Build a minimal valid request envelope."""
     payload = (
-        TaskResponse(task_id="t1", status="completed").model_dump()
+        TaskResponse(task_id="t1", status=TaskStatus.COMPLETED).model_dump()
         if payload_type == "TaskResponse"
         else TaskRequest(conversation_id="c", skill_id="echo", input={}).model_dump()
     )
@@ -93,7 +94,7 @@ class TestAssertTaskCompleted:
             sender="urn:asap:agent:b",
             recipient="urn:asap:agent:a",
             payload_type="TaskResponse",
-            payload=TaskResponse(task_id="t1", status="completed").model_dump(),
+            payload=TaskResponse(task_id="t1", status=TaskStatus.COMPLETED).model_dump(),
             correlation_id="req_01",
         )
         assert_task_completed(envelope)
@@ -118,7 +119,7 @@ class TestAssertResponseCorrelates:
             sender="urn:asap:agent:b",
             recipient="urn:asap:agent:a",
             payload_type="TaskResponse",
-            payload=TaskResponse(task_id="t1", status="completed").model_dump(),
+            payload=TaskResponse(task_id="t1", status=TaskStatus.COMPLETED).model_dump(),
             correlation_id=request.id,
         )
         assert_response_correlates(request, response)
@@ -131,7 +132,7 @@ class TestAssertResponseCorrelates:
             sender="urn:asap:agent:b",
             recipient="urn:asap:agent:a",
             payload_type="TaskResponse",
-            payload=TaskResponse(task_id="t1", status="completed").model_dump(),
+            payload=TaskResponse(task_id="t1", status=TaskStatus.COMPLETED).model_dump(),
             correlation_id="other_id",
         )
         with pytest.raises(
@@ -148,7 +149,7 @@ class TestAssertResponseCorrelates:
             sender="urn:asap:agent:b",
             recipient="urn:asap:agent:a",
             payload_type="TaskResponse",
-            payload=TaskResponse(task_id="t1", status="completed").model_dump(),
+            payload=TaskResponse(task_id="t1", status=TaskStatus.COMPLETED).model_dump(),
             correlation_id="req_01HX5K4N",
         )
         with pytest.raises(AssertionError, match="Request envelope must have"):

--- a/tests/testing/test_mocks.py
+++ b/tests/testing/test_mocks.py
@@ -3,6 +3,7 @@
 import pytest
 
 from asap.models.envelope import Envelope
+from asap.models.enums import TaskStatus
 from asap.models.payloads import TaskRequest, TaskResponse
 from asap.testing.mocks import MockAgent
 
@@ -13,7 +14,7 @@ class TestMockAgent:
     def test_set_response_and_handle_returns_envelope(self) -> None:
         """Handle returns envelope built from pre-set response for skill_id."""
         agent = MockAgent("urn:asap:agent:mock")
-        resp_payload = TaskResponse(task_id="task_1", status="completed").model_dump()
+        resp_payload = TaskResponse(task_id="task_1", status=TaskStatus.COMPLETED).model_dump()
         agent.set_response("echo", resp_payload)
         req = Envelope(
             asap_version="0.1",
@@ -50,7 +51,7 @@ class TestMockAgent:
     def test_set_default_response_used_when_no_skill_match(self) -> None:
         """Default response is used when skill_id has no specific response."""
         agent = MockAgent()
-        default = TaskResponse(task_id="task_1", status="completed").model_dump()
+        default = TaskResponse(task_id="task_1", status=TaskStatus.COMPLETED).model_dump()
         agent.set_default_response(default)
         req = Envelope(
             asap_version="0.1",
@@ -91,7 +92,9 @@ class TestMockAgent:
     def test_set_failure_raises_on_handle(self) -> None:
         """When set_failure is set, handle raises after recording request."""
         agent = MockAgent()
-        agent.set_response("echo", TaskResponse(task_id="1", status="completed").model_dump())
+        agent.set_response(
+            "echo", TaskResponse(task_id="1", status=TaskStatus.COMPLETED).model_dump()
+        )
         agent.set_failure(ValueError("simulated failure"))
         req = Envelope(
             asap_version="0.1",
@@ -110,7 +113,9 @@ class TestMockAgent:
     def test_set_delay_sleeps_before_return(self) -> None:
         """set_delay causes handle to sleep before returning."""
         agent = MockAgent()
-        agent.set_response("echo", TaskResponse(task_id="1", status="completed").model_dump())
+        agent.set_response(
+            "echo", TaskResponse(task_id="1", status=TaskStatus.COMPLETED).model_dump()
+        )
         agent.set_delay(0.05)
         req = Envelope(
             asap_version="0.1",
@@ -130,7 +135,9 @@ class TestMockAgent:
     def test_clear_resets_requests_and_responses(self) -> None:
         """clear() empties requests and pre-set responses."""
         agent = MockAgent()
-        agent.set_response("echo", TaskResponse(task_id="1", status="completed").model_dump())
+        agent.set_response(
+            "echo", TaskResponse(task_id="1", status=TaskStatus.COMPLETED).model_dump()
+        )
         req = Envelope(
             asap_version="0.1",
             sender="urn:asap:agent:a",
@@ -147,7 +154,9 @@ class TestMockAgent:
     def test_reset_clears_internal_state_for_isolation(self) -> None:
         """reset() clears registry and requests so no state leaks between scenarios."""
         agent = MockAgent("urn:asap:agent:isolated")
-        agent.set_response("echo", TaskResponse(task_id="1", status="completed").model_dump())
+        agent.set_response(
+            "echo", TaskResponse(task_id="1", status=TaskStatus.COMPLETED).model_dump()
+        )
         req = Envelope(
             asap_version="0.1",
             sender="urn:asap:agent:a",
@@ -161,7 +170,9 @@ class TestMockAgent:
         assert len(agent.requests) == 0
         assert agent.handle(req) is None
         # After reset, same agent can be reused with new responses
-        agent.set_response("echo", TaskResponse(task_id="2", status="completed").model_dump())
+        agent.set_response(
+            "echo", TaskResponse(task_id="2", status=TaskStatus.COMPLETED).model_dump()
+        )
         out = agent.handle(req)
         assert out is not None
         assert len(agent.requests) == 2  # one from handle after reset (None), one from this handle


### PR DESCRIPTION
## Summary

Follow-up to PR #27: changes that were not committed before the merge.

- **Task 6:** Orchestration session reuse comment; `create_echo_handler` → `SyncHandler`; MockAgent.reset already present.
- **Task 7:** ASAP_HOT_RELOAD documented as dev-only in README; watchfiles graceful degradation docstring in server.
- **Chaos fixtures:** `tests/chaos/conftest.py` with `sample_request_envelope`, `sample_response_envelope`, `create_mock_response`.
- **Rate-limiting:** Doc moved to `.cursor/docs/`, rule links fixed; doc defers to rule for canonical pattern.
- **.gitignore:** Temp/backup patterns, project-specific comment; PR-27 review doc added.