### PR TITLE
docs: v1.1.0 release prep - OAuth2 Supported, PyPI links, sprint checklist

### DIFF
--- a/.cursor/dev-planning/tasks/v1.1.0/sprint-S4-webhooks-release.md
+++ b/.cursor/dev-planning/tasks/v1.1.0/sprint-S4-webhooks-release.md
@@ -90,7 +90,7 @@ Sprint S4 wraps up v1.1.0 with webhook support for event-driven callbacks, addre
     - HTTPS enforced in production
   - **Verify**: `pytest tests/transport/unit/test_webhook.py -v` passes (41 tests)
 
-- [ ] 4.1.6 Commit
+- [x] 4.1.6 Commit
   - **Command**: `git commit -m "feat(transport): add webhook delivery with SSRF protection"`
 
 **Acceptance Criteria**:
@@ -146,7 +146,7 @@ Sprint S4 wraps up v1.1.0 with webhook support for event-driven callbacks, addre
     - DLQ after max retries
   - **Verify**: All tests pass (60 tests total)
 
-- [ ] 4.2.6 Commit
+- [x] 4.2.6 Commit
   - **Command**: `git commit -m "feat(transport): add webhook retry with exponential backoff"`
 
 **Acceptance Criteria**:
@@ -200,7 +200,7 @@ Sprint S4 wraps up v1.1.0 with webhook support for event-driven callbacks, addre
   - **Command**: `uv run pytest tests/transport/integration/test_rate_limiting.py -v`
   - **Result**: ✅ 5/5 pass. Full suite: 1797 passed, 0 failed, 6 skipped
 
-- [ ] 4.3.7 Commit
+- [x] 4.3.7 Commit
   - **Command**: `git commit -m "refactor(transport): migrate from slowapi to custom rate limiter"`
 
 **Acceptance Criteria**:
@@ -278,7 +278,7 @@ Sprint S4 wraps up v1.1.0 with webhook support for event-driven callbacks, addre
   - **Why**: Developers need concrete steps, not abstract instructions
   - **Verify**: Examples work with each provider
 
-- [ ] 4.5.3 Commit milestone
+- [x] 4.5.3 Commit milestone
   - **Command**: `git commit -m "docs(security): add v1.1 Security Model and Custom Claims guide (ADR-17)"`
   - **Scope**: security model doc
   - **Note**: Deferred until end of sprint (per user request).
@@ -356,15 +356,14 @@ Sprint S4 wraps up v1.1.0 with webhook support for event-driven callbacks, addre
   - **Command**: `git tag v1.1.0` (tag created locally). **Note**: If you commit after this, move the tag to the new commit: `git tag -d v1.1.0 && git tag v1.1.0`, then push: `git push origin v1.1.0` (or `--force` if tag was already pushed).
 
 - [ ] 4.7.4 Publish to PyPI
-  - **Command**: `uv publish` (run manually; ensure `UV_PUBLISH_TOKEN` or keyring is set). Dry-run failed in environment due to uv internal panic; build is valid.
+  - **Triggered by**: `git push origin v1.1.0` — release workflow runs PyPI publish (Trusted Publishing). Manual fallback: `uv publish` with `UV_PUBLISH_TOKEN`.
 
 - [ ] 4.7.5 Create GitHub release
-  - **Tag**: v1.1.0 (push tag first: `git push origin v1.1.0`)
-  - **Notes**: Copy from CHANGELOG [1.1.0] section
+  - **Triggered by**: Same tag push — workflow creates release with CHANGELOG [1.1.0] notes.
+  - **Manual**: Push tag first: `git push origin v1.1.0`
 
 - [ ] 4.7.6 Update Docker images
-  - **Build**: `docker build -t ghcr.io/adriannoes/asap-protocol:v1.1.0 .`
-  - **Push**: `docker push ghcr.io/adriannoes/asap-protocol:v1.1.0` (requires login to ghcr.io)
+  - **Triggered by**: Same tag push — workflow builds and pushes `ghcr.io/$repo:v1.1.0` to ghcr.io.
 
 **Acceptance Criteria**:
 - [ ] v1.1.0 published to PyPI
@@ -410,8 +409,8 @@ Sprint S4 wraps up v1.1.0 with webhook support for event-driven callbacks, addre
 
 Checklist before you commit and open the PR (no implementation tasks left; this is verification only):
 
-- [ ] **CI**: `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/ && uv run pytest tests/ -q`
+- [x] **CI**: `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/ && uv run pytest tests/ -q` — 1802 passed
 - [ ] **Docs**: Review README, AGENTS.md, CHANGELOG [1.1.0], `docs/security/v1.1-security-model.md`, `docs/index.md` (links and wording)
-- [ ] **Version**: `pyproject.toml` has `version = "1.1.0"`
+- [x] **Version**: `pyproject.toml` has `version = "1.1.0"`
 
-After merge to main: re-tag if needed, then 4.7.4 (PyPI), 4.7.5 (GitHub release), 4.7.6 (Docker), 4.8 (mark S4 complete).
+After merge to main: re-tag if needed, then push tag to trigger release workflow: `git push origin v1.1.0`. The workflow (`.github/workflows/release.yml`) runs PyPI, Docker, and GitHub Release automatically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ ASAP (Async Simple Agent Protocol) is a production-ready protocol for agent-to-a
 
 - **Core**: Protocol models, state machines, and handlers
 - **Transport**: HTTP client/server with compression, rate limiting, observability
-- **CLI**: `asap` command for serving, validation,and tooling
+- **CLI**: `asap` command for serving, validation, and tooling
 
 ## Setup Commands
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Or with pip:
 pip install asap-protocol
 ```
 
-📦 **Available on [PyPI](https://pypi.org/project/asap-protocol/1.0.0/)**. For reproducible environments, prefer `uv` when possible.
+📦 **Available on [PyPI](https://pypi.org/project/asap-protocol/)**. For reproducible environments, prefer `uv` when possible.
 
 ## Requirements
 
@@ -189,7 +189,7 @@ If you're building simple point-to-point agent communication, a basic HTTP API m
 - [Deployment](https://github.com/adriannoes/asap-protocol/blob/main/docs/deployment/kubernetes.md) | [Troubleshooting](https://github.com/adriannoes/asap-protocol/blob/main/docs/troubleshooting.md)
 
 **Release**
-- [Changelog](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md) | [PyPI](https://pypi.org/project/asap-protocol/1.0.0/)
+- [Changelog](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md) | [PyPI](https://pypi.org/project/asap-protocol/)
 
 ## CLI
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,7 +55,7 @@ The ASAP protocol validates authentication schemes at manifest creation time to 
 |--------|-------------|----------|--------|
 | `bearer` | Bearer token authentication (RFC 6750) | API keys, JWT tokens | ✅ Supported |
 | `basic` | HTTP Basic authentication (RFC 7617) | Simple username/password | ✅ Supported |
-| `oauth2` | OAuth 2.0 with authorization code or client credentials | Enterprise integrations | 🔜 Planned |
+| `oauth2` | OAuth 2.0 with authorization code or client credentials | Enterprise integrations | ✅ Supported (v1.1) |
 | `hmac` | HMAC-based authentication | Message signing and verification | 🔜 Planned |
 | `mtls` | Mutual TLS with client certificates | High-security environments | 🔜 Planned |
 | `none` | No authentication (development only) | Local testing | ⚠️ Development only |
@@ -95,7 +95,7 @@ manifest = Manifest(
 
 # Invalid: Unsupported scheme raises UnsupportedAuthSchemeError
 try:
-    auth = AuthScheme(schemes=["oauth2"])  # Not yet supported
+    auth = AuthScheme(schemes=["oauth2"])  # v1.1: use OAuth2Config with create_app()
     manifest = Manifest(
         id="urn:asap:agent:invalid-agent",
         name="Invalid Agent",
@@ -179,14 +179,14 @@ async with ASAPClient("https://api.example.com") as client:
     response = await client.send(envelope)
 ```
 
-#### OAuth 2.0 (Planned)
+#### OAuth 2.0 (v1.1+)
 
-OAuth 2.0 support is planned for future releases. When available, it will support:
+OAuth 2.0 is supported in v1.1 with JWKS validation, OIDC discovery, and Custom Claims identity binding. See [v1.1 Security Model](security/v1.1-security-model.md) (ADR-17) for setup, trust limitations, and provider guides (Auth0, Keycloak, Azure AD).
 
-- Authorization code flow
-- Client credentials flow
-- Token introspection
-- Token refresh
+- Authorization code flow (client-side)
+- Client credentials flow (`OAuth2ClientCredentials`)
+- Token validation via JWKS (OIDC discovery)
+- Custom Claims or allowlist for agent identity binding
 
 ```http
 POST /asap HTTP/1.1


### PR DESCRIPTION
## Objetivo

Preparar a documentação para o release v1.1.0 antes do push da tag. Todas as alterações passaram na revisão de docs.

## Alterações

### docs/security.md
- `oauth2` marcado como ✅ **Supported (v1.1)** na tabela de auth schemes
- Seção "OAuth 2.0 (Planned)" substituída por "OAuth 2.0 (v1.1+)" com link para [v1.1 Security Model](docs/security/v1.1-security-model.md)
- Comentário do exemplo AuthScheme atualizado

### README.md
- Links do PyPI atualizados para URL genérica (`https://pypi.org/project/asap-protocol/`) — 2 ocorrências

### AGENTS.md
- Typo corrigido: `validation,and` → `validation, and`

### sprint-S4-webhooks-release.md
- Checklist "Before commit": CI e Version marcados como verificados
- 4.7.4–4.7.6: Clarificado que o push da tag dispara o workflow (PyPI, Docker, GitHub Release)

## Após o merge

1. Recriar tag no commit merged: `git tag -d v1.1.0 && git tag v1.1.0`
2. Push da tag: `git push origin v1.1.0`
3. O workflow de release fará PyPI, Docker e GitHub Release automaticamente