### PR TITLE
test(errors,transport): regression coverage + CVE-2026-4539 fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ docs = [
     "ghp-import>=2.1.0",
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.27",
+    "pymdown-extensions>=10.21",
 ]
 dns-sd = [
     "zeroconf>=0.80",
@@ -110,6 +111,7 @@ Issues = "https://github.com/adriannoes/asap-protocol/issues"
 # - pillow>=12.2.0 for CVE-2026-40192 (transitive, e.g. pdf/vision stacks)
 # - pytest>=9.0.3 for CVE-2025-71176 (dev)
 # - python-multipart>=0.0.26 for CVE-2026-40347 (FastAPI stack)
+# - pygments>=2.20.0 for CVE-2026-4539
 [tool.uv]
 override-dependencies = [
     "pyjwt>=2.12.0",
@@ -120,6 +122,7 @@ override-dependencies = [
     "pillow>=12.2.0",
     "pytest>=9.0.3",
     "python-multipart>=0.0.26",
+    "pygments>=2.20.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ Issues = "https://github.com/adriannoes/asap-protocol/issues"
 # - pytest>=9.0.3 for CVE-2025-71176 (dev)
 # - python-multipart>=0.0.26 for CVE-2026-40347 (FastAPI stack)
 # - pygments>=2.20.0 for CVE-2026-4539
+# - langsmith>=0.7.31 for GHSA-rr7j-v2q5-chgv
 [tool.uv]
 override-dependencies = [
     "pyjwt>=2.12.0",
@@ -123,6 +124,7 @@ override-dependencies = [
     "pytest>=9.0.3",
     "python-multipart>=0.0.26",
     "pygments>=2.20.0",
+    "langsmith>=0.7.31",
 ]
 
 [project.scripts]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,14 +2,20 @@
 
 from asap.errors import (
     ASAPError,
+    RPC_CONNECTION_ERROR,
     InvalidTransitionError,
     MalformedEnvelopeError,
     RPC_REMOTE_GENERIC,
     RecoverableError,
+    RemoteFatalRPCError,
+    RemoteRecoverableRPCError,
     TaskNotFoundError,
     TaskAlreadyCompletedError,
     ThreadPoolExhaustedError,
     ASAPConnectionError,
+    is_asap_json_rpc_code,
+    jsonrpc_error_data_for_asap_exception,
+    remote_rpc_error_from_json,
 )
 
 
@@ -294,3 +300,101 @@ class TestThreadPoolExhaustedError:
         assert result["details"]["max_threads"] == 15
         assert result["details"]["active_threads"] == 15
         assert result.get("retry_after_ms") is not None
+
+
+class TestJsonRpcErrorInterop:
+    """Tests for JSON-RPC interop and metadata shaping."""
+
+    def test_asap_json_rpc_code_boundaries(self) -> None:
+        """ASAP JSON-RPC helper accepts only reserved code range."""
+        assert is_asap_json_rpc_code(-32059) is True
+        assert is_asap_json_rpc_code(-32000) is True
+        assert is_asap_json_rpc_code(-31999) is False
+        assert is_asap_json_rpc_code(-32060) is False
+
+    def test_asap_error_rejects_out_of_range_rpc_code(self) -> None:
+        """Base ASAPError rejects JSON-RPC codes outside ASAP reserved slot."""
+        import pytest
+
+        with pytest.raises(ValueError, match="rpc_code must be in"):
+            ASAPError(code="asap:test/error", message="bad rpc", rpc_code=-32603)
+
+    def test_remote_rpc_error_from_json_returns_recoverable_and_strips_meta(self) -> None:
+        """Recoverable remote payload is typed and metadata fields are normalized."""
+        err = remote_rpc_error_from_json(
+            rpc_code=-32033,
+            message="remote timeout",
+            data={
+                "recoverable": True,
+                "retry_after_ms": 250,
+                "alternative_agents": ["urn:asap:agent:secondary"],
+                "fallback_action": "retry_with_backoff",
+                "asap_taxonomy_code": "asap:transport/timeout",
+                "rpc_code": -32033,
+                "upstream": "worker-1",
+            },
+        )
+
+        assert isinstance(err, RemoteRecoverableRPCError)
+        assert err.rpc_code == -32033
+        assert err.json_rpc_code == -32033
+        assert err.code == "asap:transport/timeout"
+        assert err.retry_after_ms == 250
+        assert err.alternative_agents == ["urn:asap:agent:secondary"]
+        assert err.fallback_action == "retry_with_backoff"
+        assert err.details == {"upstream": "worker-1"}
+
+    def test_remote_rpc_error_from_json_uses_code_field_fallback(self) -> None:
+        """A taxonomy-like `code` field in data overrides default taxonomy mapping."""
+        err = remote_rpc_error_from_json(
+            rpc_code=-32040,
+            message="resource exhausted",
+            data={
+                "recoverable": False,
+                "code": "asap:resource/exhausted",
+                "queue_depth": 11,
+            },
+        )
+
+        assert isinstance(err, RemoteFatalRPCError)
+        assert err.code == "asap:resource/exhausted"
+        assert err.details == {"queue_depth": 11}
+
+    def test_remote_rpc_error_preserves_wire_code_but_normalizes_internal_slot(self) -> None:
+        """Non-ASAP wire code is preserved while internal rpc_code uses remote-generic slot."""
+        err = remote_rpc_error_from_json(
+            rpc_code=-32603,
+            message="internal error",
+            data={"recoverable": False, "foo": "bar"},
+        )
+
+        assert isinstance(err, RemoteFatalRPCError)
+        assert err.json_rpc_code == -32603
+        assert err.rpc_code == RPC_REMOTE_GENERIC
+        assert err.details == {"foo": "bar"}
+
+    def test_jsonrpc_error_data_for_recoverable_exception(self) -> None:
+        """Server-side JSON-RPC data payload includes taxonomy and recoverability hints."""
+        err = ASAPConnectionError(
+            "connection refused",
+            url="https://agent.example.test/asap",
+            rpc_code=RPC_CONNECTION_ERROR,
+            retry_after_ms=500,
+            alternative_agents=["urn:asap:agent:fallback"],
+        )
+
+        payload = jsonrpc_error_data_for_asap_exception(err)
+        assert payload["code"] == "asap:transport/connection_error"
+        assert payload["rpc_code"] == RPC_CONNECTION_ERROR
+        assert payload["recoverable"] is True
+        assert payload["asap_taxonomy_code"] == "asap:transport/connection_error"
+        assert payload["retry_after_ms"] == 500
+        assert payload["alternative_agents"] == ["urn:asap:agent:fallback"]
+
+    def test_connection_error_message_not_duplicated_when_verify_text_present(self) -> None:
+        """Connection errors with existing troubleshooting guidance are not duplicated."""
+        err = ASAPConnectionError(
+            "Verify service availability before retrying.",
+            url="https://agent.example.test/asap",
+        )
+        assert str(err) == "Verify service availability before retrying."

--- a/tests/transport/test_streaming.py
+++ b/tests/transport/test_streaming.py
@@ -9,12 +9,13 @@ import httpx
 import pytest
 from httpx import ASGITransport
 
+from asap.models.constants import ASAP_DEFAULT_TRANSPORT_VERSION, ASAP_VERSION_HEADER
 from asap.models.entities import Manifest
 from asap.models.envelope import Envelope
 from asap.models.enums import TaskStatus
 from asap.models.payloads import TaskRequest, TaskStream
 from asap.transport.handlers import HandlerRegistry, create_echo_handler
-from asap.transport.jsonrpc import ASAP_METHOD
+from asap.transport.jsonrpc import ASAP_METHOD, VERSION_INCOMPATIBLE
 from asap.transport.server import create_app
 
 if TYPE_CHECKING:
@@ -119,3 +120,113 @@ async def test_asap_stream_sse_endpoint(
     assert events[0].payload_dict.get("final") is False
     assert events[-1].payload_dict.get("final") is True
     assert events[-1].payload_dict.get("status") == "completed"
+
+
+@pytest.mark.anyio
+async def test_asap_stream_negotiates_first_supported_wire_version(
+    sample_manifest: Manifest,
+    isolated_rate_limiter: ASAPRateLimiter | None,
+) -> None:
+    """`/asap/stream` uses the first supported ASAP-Version token and echoes it."""
+    registry = HandlerRegistry()
+    registry.register("task.request", create_echo_handler())
+    registry.register_streaming_handler("task.request", _word_stream_handler)
+    app = create_app(sample_manifest, registry, rate_limit="999999/minute")
+    if isolated_rate_limiter is not None:
+        app.state.limiter = isolated_rate_limiter
+
+    env = Envelope(
+        asap_version="0.1",
+        sender="urn:asap:agent:client",
+        recipient=sample_manifest.id,
+        payload_type="task.request",
+        payload=TaskRequest(
+            conversation_id="conv-version-stream-ok",
+            skill_id="echo",
+            input={"text": "one two"},
+        ).model_dump(),
+        correlation_id="corr-version-stream-ok",
+    )
+    rpc = {
+        "jsonrpc": "2.0",
+        "method": ASAP_METHOD,
+        "params": {"envelope": env.model_dump(mode="json")},
+        "id": 2,
+    }
+
+    transport = ASGITransport(app=app)
+    async with (
+        httpx.AsyncClient(transport=transport, base_url="http://test") as client,
+        client.stream(
+            "POST",
+            "/asap/stream",
+            json=rpc,
+            headers={ASAP_VERSION_HEADER: "2.2, 2.1"},
+        ) as response,
+    ):
+        assert response.status_code == 200
+        assert response.headers.get(ASAP_VERSION_HEADER) == "2.2"
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+        buf = ""
+        events: list[Envelope] = []
+        async for chunk in response.aiter_text():
+            buf += chunk
+            while "\n\n" in buf:
+                raw_event, buf = buf.split("\n\n", 1)
+                for line in raw_event.split("\n"):
+                    stripped = line.strip()
+                    if stripped.startswith("data:"):
+                        payload_json = stripped[5:].strip()
+                        events.append(Envelope.model_validate(json.loads(payload_json)))
+
+    assert len(events) == 2
+    assert events[-1].payload_dict.get("final") is True
+
+
+@pytest.mark.anyio
+async def test_asap_stream_rejects_incompatible_wire_version(
+    sample_manifest: Manifest,
+    isolated_rate_limiter: ASAPRateLimiter | None,
+) -> None:
+    """`/asap/stream` returns JSON-RPC VERSION_INCOMPATIBLE when header has no match."""
+    registry = HandlerRegistry()
+    registry.register("task.request", create_echo_handler())
+    registry.register_streaming_handler("task.request", _word_stream_handler)
+    app = create_app(sample_manifest, registry, rate_limit="999999/minute")
+    if isolated_rate_limiter is not None:
+        app.state.limiter = isolated_rate_limiter
+
+    env = Envelope(
+        asap_version="0.1",
+        sender="urn:asap:agent:client",
+        recipient=sample_manifest.id,
+        payload_type="task.request",
+        payload=TaskRequest(
+            conversation_id="conv-version-stream-bad",
+            skill_id="echo",
+            input={"text": "one two"},
+        ).model_dump(),
+        correlation_id="corr-version-stream-bad",
+    )
+    rpc = {
+        "jsonrpc": "2.0",
+        "method": ASAP_METHOD,
+        "params": {"envelope": env.model_dump(mode="json")},
+        "id": 3,
+    }
+
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/asap/stream",
+            json=rpc,
+            headers={ASAP_VERSION_HEADER: "9.9"},
+        )
+
+    assert response.status_code == 200
+    assert response.headers.get(ASAP_VERSION_HEADER) == ASAP_DEFAULT_TRANSPORT_VERSION
+    assert response.headers["content-type"].startswith("application/json")
+    payload = response.json()
+    assert payload.get("error", {}).get("code") == VERSION_INCOMPATIBLE
+    assert payload.get("error", {}).get("data", {}).get("requested") == "9.9"

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,7 @@ overrides = [
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pyasn1", specifier = ">=0.6.3" },
+    { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "python-multipart", specifier = ">=0.0.26" },
@@ -256,6 +257,7 @@ docs = [
     { name = "ghp-import" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pymdown-extensions" },
 ]
 langchain = [
     { name = "langchain-core" },
@@ -322,6 +324,7 @@ requires-dist = [
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-ai", marker = "extra == 'pydanticai'", specifier = ">=0.2" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.1" },
@@ -4088,11 +4091,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -4106,15 +4109,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.20"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/35/e3814a5b7df295df69d035cfb8aab78b2967cdf11fcfae7faed726b66664/pymdown_extensions-10.20.tar.gz", hash = "sha256:5c73566ab0cf38c6ba084cb7c5ea64a119ae0500cce754ccb682761dfea13a52", size = 852774, upload-time = "2025-12-31T19:59:42.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/10/47caf89cbb52e5bb764696fd52a8c591a2f0e851a93270c05a17f36000b5/pymdown_extensions-10.20-py3-none-any.whl", hash = "sha256:ea9e62add865da80a271d00bfa1c0fa085b20d133fb3fc97afdc88e682f60b2f", size = 268733, upload-time = "2025-12-31T19:59:40.652Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -5,6 +5,7 @@ requires-python = ">=3.13"
 [manifest]
 overrides = [
     { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "langsmith", specifier = ">=0.7.31" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pyasn1", specifier = ">=0.6.3" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -2218,7 +2219,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.7.9"
+version = "0.7.32"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2231,9 +2232,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/01/c26b1d3a68764acd050cbb98f3ca922a25b3e4ece5768ee868f56206b4d4/langsmith-0.7.9.tar.gz", hash = "sha256:c6dfcc4cb8fea249714ac60a1963faa84cc59ded9cd1882794ffce8a8d1d1588", size = 1136295, upload-time = "2026-02-27T22:37:59.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/b4/a0b4a501bee6b8a741ce29f8c48155b132118483cddc6f9247735ddb38fa/langsmith-0.7.32.tar.gz", hash = "sha256:b59b8e106d0e4c4842e158229296086e2aa7c561e3f602acda73d3ad0062e915", size = 1184518, upload-time = "2026-04-15T23:42:41.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/c9/2d5e5f654f97a4d38a0ff1b3004751c2cd81ceca05d603174e49f942b196/langsmith-0.7.9-py3-none-any.whl", hash = "sha256:e73478f4c4ae9b7407e0fcdced181f9f8b0e024c62a1552dbf0667ef6b19e82d", size = 344099, upload-time = "2026-02-27T22:37:57.497Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bc/148f98ac7dad73ac5e1b1c985290079cfeeb9ba13d760a24f25002beb2c9/langsmith-0.7.32-py3-none-any.whl", hash = "sha256:e1fde928990c4c52f47dc5132708cec674355d9101723d564183e965f383bf5f", size = 378272, upload-time = "2026-04-15T23:42:39.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Consolidates PR #111 and PR #116 into a single, clean PR with correct authorship:

- **test(errors)**: Regression tests for remote JSON-RPC error mapping — metadata parsing, recoverable vs fatal classification, taxonomy fallback, and code slot normalization
- **test(transport)**: ASAP stream version-negotiation coverage — comma-separated `ASAP-Version` header support and fail-closed `VERSION_INCOMPATIBLE` behavior
- **build(deps)**: Override `pygments>=2.20.0` for CVE-2026-4539 and pin `pymdown-extensions>=10.21` for compatibility

## Supersedes

- Closes #111
- Closes #116

## Test plan

- [x] `ruff check .` — no issues
- [x] `ruff format --check .` — all formatted
- [x] `mypy src/ scripts/ tests/` — no issues (342 files)
- [x] Full test suite: **2906 passed**, 7 skipped, **90.61% coverage**