### PR TITLE
feat(openapi): OpenAPI 3.x adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - **Transport**: JSON-RPC 2.0 over HTTP/WebSocket.
 - **Status**: v2.2.1 (Released); next planning focus is the v2.3.x adoption train.
 - **Framework Integrations**: LangChain, CrewAI, PydanticAI, LlamaIndex, SmolAgents, Vercel AI SDK, MCP, OpenClaw, A2H.
+- **General contact** (humans coordinating on the protocol; not security): [info@asap-protocol.com](mailto:info@asap-protocol.com) — vulnerabilities: [SECURITY.md](SECURITY.md).
 
 ## Quick Start
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -13,6 +13,6 @@ We are committed to making participation in this project a harassment-free exper
 
 ## Enforcement
 
-If you see behavior that violates these rules, please report it to the maintainers (e.g., via private email or GitHub issue if appropriate). Violators may be warned or banned from the project at the maintainers' discretion.
+If you see behavior that violates these rules, please report it to the maintainers via **[info@asap-protocol.com](mailto:info@asap-protocol.com)** (or use a GitHub issue if the report is not sensitive). **Security vulnerabilities** must not be sent by email — use [SECURITY.md](SECURITY.md). Violators may be warned or banned from the project at the maintainers' discretion.
 
 Basically: **Don't be a jerk.** :)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,8 @@ Understanding the "why" behind our code is crucial. Please review:
 
 Check [Discussions](https://github.com/adriannoes/asap-protocol/discussions) or open an [Issue](https://github.com/adriannoes/asap-protocol/issues).
 
+For **general, non-security inquiries** (coordination, integrations, press), you can reach maintainers at **[info@asap-protocol.com](mailto:info@asap-protocol.com)**. **Do not** use this address for vulnerability reports — follow [SECURITY.md](SECURITY.md) instead.
+
 **Using AI coding tools?** See [AGENTS.md](AGENTS.md) for project-specific instructions optimized for Cursor, Copilot, Codex and other AI assistants.
 
 By contributing, you agree to the [Code of Conduct](CODE_OF_CONDUCT.md) and license your code under Apache 2.0.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 
 > A production-ready protocol for agent-to-agent communication and task coordination.
 
-**Quick Info**: `v2.2.1` | `Apache 2.0` | `Python 3.13+` | [Documentation](https://github.com/adriannoes/asap-protocol/blob/main/docs/index.md) | [PyPI](https://pypi.org/project/asap-protocol/) | [Changelog](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md)
+**Quick Info**: `v2.2.1` | `Apache 2.0` | `Python 3.13+` | [Documentation](https://github.com/adriannoes/asap-protocol/blob/main/docs/index.md) | **[Protocol package on PyPI (`asap-protocol`)](https://pypi.org/project/asap-protocol/)** | [Changelog](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md)
 
-> 🚀 **Live now** our [**agentic marketplace**](https://asap-protocol.vercel.app/) — browse agents, register yours, request verification.
+> 📦 Install the ASAP **Python SDK / protocol** from **`https://pypi.org/project/asap-protocol/`** — package name **`asap-protocol`** on [PyPI](https://pypi.org/project/asap-protocol/).
+
+> 🚀 **Live now** our [**agentic marketplace**](https://asap-protocol.com/) — browse agents, register yours, request verification.
 
 ## Why ASAP?
 
@@ -51,7 +53,7 @@ Or with pip:
 pip install asap-protocol
 ```
 
-📦 **Available on [PyPI](https://pypi.org/project/asap-protocol/)** — for reproducible environments, prefer `uv` when possible.
+📦 **Canonical listing:** **[https://pypi.org/project/asap-protocol/](https://pypi.org/project/asap-protocol/)** — package **`asap-protocol`** (`pip install asap-protocol`). Prefer `uv` for reproducible environments when possible.
 
 ## Quick Start
 
@@ -110,7 +112,7 @@ See [Compliance Testing Guide](https://github.com/adriannoes/asap-protocol/blob/
 - [Deployment](https://github.com/adriannoes/asap-protocol/blob/main/docs/deployment/kubernetes.md) | [Troubleshooting](https://github.com/adriannoes/asap-protocol/blob/main/docs/troubleshooting.md)
 
 **Release**
-- [Changelog](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md) | [PyPI](https://pypi.org/project/asap-protocol/)
+- [Changelog](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md) | **[PyPI listing](https://pypi.org/project/asap-protocol/)** — `https://pypi.org/project/asap-protocol/` (install: `pip install asap-protocol`)
 
 ## CLI
 
@@ -154,6 +156,14 @@ ASAP is evolving toward an **Agent Marketplace** — an open ecosystem where AI 
 Every contribution, from bug reports to feature suggestions, documentation improvements and code contributions, makes a real difference.
 
 Check out our [contributing guidelines](https://github.com/adriannoes/asap-protocol/blob/main/CONTRIBUTING.md) to get started. It's easier than you think! 🚀
+
+## Contact
+
+For **general questions** about the protocol, the marketplace, partnerships, or press (not security vulnerabilities — use [SECURITY.md](https://github.com/adriannoes/asap-protocol/blob/main/SECURITY.md) for those):
+
+- **Email:** [info@asap-protocol.com](mailto:info@asap-protocol.com)
+
+You can also use [GitHub Discussions](https://github.com/adriannoes/asap-protocol/discussions) or [Issues](https://github.com/adriannoes/asap-protocol/issues) for public project topics.
 
 ## License
 

--- a/apps/example-agent/uv.lock
+++ b/apps/example-agent/uv.lock
@@ -96,6 +96,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.1" },
+    { name = "openapi-pydantic", marker = "extra == 'openapi'", specifier = ">=0.5" },
     { name = "openclaw-sdk", marker = "extra == 'openclaw'", specifier = ">=2.0" },
     { name = "opentelemetry-api", specifier = ">=1.20" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20" },
@@ -125,7 +126,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=12.0" },
     { name = "zeroconf", marker = "extra == 'dns-sd'", specifier = ">=0.80" },
 ]
-provides-extras = ["dev", "docs", "dns-sd", "redis", "webauthn", "mcp", "langchain", "crewai", "llamaindex", "smolagents", "pydanticai", "openclaw"]
+provides-extras = ["dev", "docs", "dns-sd", "redis", "webauthn", "mcp", "langchain", "crewai", "llamaindex", "smolagents", "pydanticai", "openclaw", "openapi"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -16,7 +16,7 @@ GITHUB_CLIENT_SECRET=
 # -----------------------------------------------------------------------------
 # Registry & Revoked List
 # -----------------------------------------------------------------------------
-# URL to fetch registry.json (GitHub Pages or raw URL)
+# URL to fetch registry.json (GitHub Pages or raw URL).
 REGISTRY_URL=
 # URL to fetch revoked_agents.json
 REVOKED_URL=
@@ -26,7 +26,8 @@ REGISTRY_REVALIDATE_SECONDS=
 # -----------------------------------------------------------------------------
 # Public URLs (exposed to client bundle)
 # -----------------------------------------------------------------------------
-# Base URL of this app (e.g. https://asap-protocol.com or http://localhost:3000)
+# Base URL of this app (e.g. https://asap-protocol.com or http://localhost:3000).
+# In development, API CORS also accepts any Origin on localhost/127.0.0.1 so alternate ports work.
 NEXT_PUBLIC_APP_URL=
 # Agent Builder URL for cross-platform navigation (SSO + redirect after login)
 # Default: https://open-agentic-flow.vercel.app

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,6 +3,8 @@ import path from "path";
 const appRoot = path.resolve(__dirname, "./");
 
 const nextConfig = {
+  /** Avoid the bottom-left dev badge reading as a persistent “error” state in local runs. */
+  devIndicators: false,
   turbopack: {
     // Set root to current directory to ensure local package resolution
     root: appRoot,

--- a/apps/web/public/registry.json
+++ b/apps/web/public/registry.json
@@ -22,7 +22,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -74,7 +74,7 @@
         "other",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -99,7 +99,7 @@
         "search",
         "research"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -124,7 +124,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -149,7 +149,7 @@
         "data",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -202,7 +202,7 @@
         "qa",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -227,7 +227,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "Custom",
@@ -252,7 +252,7 @@
         "code-review",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -278,7 +278,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -331,7 +331,7 @@
         "research",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -355,7 +355,7 @@
         "analyze",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -380,7 +380,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -406,7 +406,7 @@
         "productivity",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -458,7 +458,7 @@
         "documentation",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -484,7 +484,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -508,7 +508,7 @@
         "summarize",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -534,7 +534,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -587,7 +587,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -611,7 +611,7 @@
         "synthesize",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -637,7 +637,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -662,7 +662,7 @@
         "coding",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -715,7 +715,7 @@
         "code-review",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -740,7 +740,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "Custom",
@@ -764,7 +764,7 @@
         "translate",
         "other"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -791,7 +791,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -843,7 +843,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -868,7 +868,7 @@
         "planning",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -893,7 +893,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -918,7 +918,7 @@
         "productivity",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -971,7 +971,7 @@
         "summarize",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -996,7 +996,7 @@
         "other",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -1021,7 +1021,7 @@
         "search",
         "research"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1047,7 +1047,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1100,7 +1100,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1124,7 +1124,7 @@
         "qa",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -1149,7 +1149,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1175,7 +1175,7 @@
         "coding",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1227,7 +1227,7 @@
         "translate",
         "other"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1253,7 +1253,7 @@
         "research",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "Custom",
@@ -1277,7 +1277,7 @@
         "analyze",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1303,7 +1303,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1356,7 +1356,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1380,7 +1380,7 @@
         "documentation",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -1406,7 +1406,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1431,7 +1431,7 @@
         "productivity",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1484,7 +1484,7 @@
         "search",
         "research"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1509,7 +1509,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -1533,7 +1533,7 @@
         "synthesize",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1560,7 +1560,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1612,7 +1612,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1637,7 +1637,7 @@
         "code-review",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -1662,7 +1662,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1687,7 +1687,7 @@
         "other",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1740,7 +1740,7 @@
         "analyze",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1765,7 +1765,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "Custom",
@@ -1790,7 +1790,7 @@
         "planning",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1816,7 +1816,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1869,7 +1869,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1893,7 +1893,7 @@
         "summarize",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -1918,7 +1918,7 @@
         "other",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1944,7 +1944,7 @@
         "research",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1996,7 +1996,7 @@
         "synthesize",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2022,7 +2022,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -2046,7 +2046,7 @@
         "qa",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2072,7 +2072,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2125,7 +2125,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2149,7 +2149,7 @@
         "translate",
         "other"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -2175,7 +2175,7 @@
         "research",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2200,7 +2200,7 @@
         "data",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2253,7 +2253,7 @@
         "planning",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2278,7 +2278,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "Custom",
@@ -2302,7 +2302,7 @@
         "documentation",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2329,7 +2329,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2381,7 +2381,7 @@
         "other",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2406,7 +2406,7 @@
         "search",
         "research"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -2431,7 +2431,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2456,7 +2456,7 @@
         "data",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2509,7 +2509,7 @@
         "qa",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2534,7 +2534,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -2559,7 +2559,7 @@
         "code-review",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2585,7 +2585,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2638,7 +2638,7 @@
         "research",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2662,7 +2662,7 @@
         "analyze",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -2687,7 +2687,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2713,7 +2713,7 @@
         "productivity",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2765,7 +2765,7 @@
         "documentation",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2791,7 +2791,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "Custom",
@@ -2815,7 +2815,7 @@
         "summarize",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2841,7 +2841,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2894,7 +2894,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2918,7 +2918,7 @@
         "synthesize",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -2944,7 +2944,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2969,7 +2969,7 @@
         "coding",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -3022,7 +3022,7 @@
         "code-review",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -3047,7 +3047,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -3071,7 +3071,7 @@
         "translate",
         "other"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",

--- a/apps/web/src/app/agents/[id]/agent-connect-actions.tsx
+++ b/apps/web/src/app/agents/[id]/agent-connect-actions.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { Check, ChevronDown, Code2, Copy } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+interface AgentConnectActionsProps {
+    endpoint: string | undefined | null;
+}
+
+/**
+ * Sidebar integration panel: primary action is copying the endpoint (concrete).
+ * Snippet jump is a text link on the same page — avoids a misleading "connect" CTA
+ * that reads like navigation to another app or OAuth flow.
+ */
+export function AgentConnectActions({ endpoint }: AgentConnectActionsProps) {
+    const [copied, setCopied] = useState(false);
+
+    const copyEndpoint = useCallback(async () => {
+        if (!endpoint) return;
+        await navigator.clipboard.writeText(endpoint);
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 2000);
+    }, [endpoint]);
+
+    return (
+        <div className="flex flex-col gap-3 w-full">
+            <div>
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Integration
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground/90 leading-snug">
+                    Copy the ASAP endpoint URL or open ready-to-use integration examples below.
+                </p>
+            </div>
+            <Button
+                type="button"
+                className="w-full gap-2 font-semibold shadow-md"
+                size="lg"
+                disabled={!endpoint}
+                onClick={() => void copyEndpoint()}
+            >
+                {copied ? (
+                    <>
+                        <Check className="w-4 h-4 text-emerald-500" /> Copied to clipboard
+                    </>
+                ) : (
+                    <>
+                        <Copy className="w-4 h-4" /> Copy ASAP endpoint
+                    </>
+                )}
+            </Button>
+            <a
+                href="#integration"
+                className="inline-flex w-full items-center justify-center gap-1.5 rounded-md py-2 text-sm text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background"
+            >
+                <Code2 className="h-4 w-4 shrink-0 opacity-80" aria-hidden />
+                View integration snippets
+                <ChevronDown className="h-4 w-4 shrink-0 opacity-60" aria-hidden />
+            </a>
+        </div>
+    );
+}

--- a/apps/web/src/app/agents/[id]/agent-detail-client.tsx
+++ b/apps/web/src/app/agents/[id]/agent-detail-client.tsx
@@ -5,8 +5,9 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
-import { ArrowLeft, ExternalLink, ShieldAlert, ShieldCheck, TerminalSquare } from 'lucide-react';
+import { ArrowLeft, ExternalLink, ShieldAlert, ShieldCheck } from 'lucide-react';
 import Link from 'next/link';
+import { AgentConnectActions } from './agent-connect-actions';
 import { UsageSnippets } from './usage-snippets';
 
 interface AgentDetailClientProps {
@@ -23,6 +24,7 @@ function safeAuthHref(url: unknown): string {
 
 export function AgentDetailClient({ agent, isRevoked }: AgentDetailClientProps) {
     const agentEndpoint = agent.endpoints?.asap ?? (agent.endpoints as { http?: string })?.http;
+    const protocolVersion = agent.capabilities?.asap_version ?? agent.version;
 
     const renderBooleanBadge = (value: boolean | undefined | null, label: string) => {
         if (value === undefined || value === null) return null;
@@ -60,9 +62,9 @@ export function AgentDetailClient({ agent, isRevoked }: AgentDetailClientProps) 
                             <Badge variant="outline" className="text-xs font-mono py-1">
                                 {agent.id}
                             </Badge>
-                            {agent.version && (
-                                <Badge variant="secondary" className="text-xs">
-                                    v{agent.version}
+                            {protocolVersion && (
+                                <Badge variant="secondary" className="text-xs font-mono">
+                                    ASAP {protocolVersion}
                                 </Badge>
                             )}
                             {agent.built_with && (
@@ -87,11 +89,14 @@ export function AgentDetailClient({ agent, isRevoked }: AgentDetailClientProps) 
                     </div>
 
                     <div className="flex flex-col gap-3 min-w-48 shrink-0">
-                        <Button className="w-full font-semibold shadow-md gap-2" size="lg">
-                            <TerminalSquare className="w-4 h-4" /> Connect Agent
-                        </Button>
-                        <div className="p-3 bg-muted/50 border rounded-md text-xs font-mono break-all selection:bg-indigo-500/30">
-                            {agent.endpoints?.asap ?? (agent.endpoints as { http?: string })?.http}
+                        <AgentConnectActions endpoint={agentEndpoint} />
+                        <div>
+                            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-1.5">
+                                Endpoint URL
+                            </p>
+                            <div className="p-3 bg-muted/50 border rounded-md text-xs font-mono break-all selection:bg-indigo-500/30">
+                                {agent.endpoints?.asap ?? (agent.endpoints as { http?: string })?.http}
+                            </div>
                         </div>
                         {(agent.repository_url || agent.documentation_url) && (
                             <div className="flex flex-wrap gap-2">
@@ -124,15 +129,15 @@ export function AgentDetailClient({ agent, isRevoked }: AgentDetailClientProps) 
                             <CardTitle>Capabilities & Skills</CardTitle>
                             <CardDescription>
                                 Discover what this agent can do via ASAP Protocol.
+                                {protocolVersion ? (
+                                    <> Negotiates protocol version {protocolVersion}.</>
+                                ) : null}
                             </CardDescription>
                         </CardHeader>
                         <CardContent className="space-y-6">
                             <div className="flex flex-wrap gap-2 mb-4 cursor-default">
                                 {renderBooleanBadge(agent.capabilities?.state_persistence, 'State Persistence')}
                                 {renderBooleanBadge(agent.capabilities?.streaming, 'Streaming')}
-                                {agent.capabilities?.asap_version && (
-                                    <Badge variant="outline">ASAP Protocol {agent.capabilities.asap_version}</Badge>
-                                )}
                             </div>
 
                             <Separator />

--- a/apps/web/src/app/agents/[id]/usage-snippets.tsx
+++ b/apps/web/src/app/agents/[id]/usage-snippets.tsx
@@ -50,7 +50,7 @@ export function UsageSnippets({ agentId, agent }: UsageSnippetsProps) {
         setTimeout(() => setOpenclawCopied(false), 2000);
     }, [agentId, agent]);
     return (
-        <Card className="border-indigo-500/20 shadow-sm shadow-indigo-500/5">
+        <Card id="integration" className="scroll-mt-24 border-indigo-500/20 shadow-sm shadow-indigo-500/5">
             <CardHeader className="pb-3">
                 <CardTitle className="text-lg flex items-center gap-2">
                     <Code2 className="w-5 h-5 text-indigo-400" />
@@ -61,8 +61,8 @@ export function UsageSnippets({ agentId, agent }: UsageSnippetsProps) {
                 </CardDescription>
             </CardHeader>
             <CardContent>
-                <Tabs defaultValue="node" className="w-full">
-                    <TabsList className="flex flex-wrap h-auto w-full justify-start gap-1 p-1">
+                <Tabs defaultValue="node" className="w-full gap-0">
+                    <TabsList className="flex flex-wrap h-auto w-full justify-start gap-x-5 gap-y-4 p-2">
                         <TabsTrigger value="node" className="flex-grow sm:flex-grow-0">Node.js</TabsTrigger>
                         <TabsTrigger value="langchain">LangChain</TabsTrigger>
                         <TabsTrigger value="llamaindex">LlamaIndex</TabsTrigger>
@@ -73,7 +73,7 @@ export function UsageSnippets({ agentId, agent }: UsageSnippetsProps) {
                         <TabsTrigger value="mcp">MCP</TabsTrigger>
                     </TabsList>
 
-                    <TabsContent value="node" className="mt-4">
+                    <TabsContent value="node" className="mt-6 sm:mt-7">
                         <div className="group relative rounded-md bg-zinc-950 p-4 font-mono text-sm text-zinc-300 border border-zinc-800 overflow-x-auto">
                             <pre className="leading-relaxed">
                                 <span className="text-zinc-500"># 1. Install the client</span>{'\n'}
@@ -90,7 +90,7 @@ export function UsageSnippets({ agentId, agent }: UsageSnippetsProps) {
                         </div>
                     </TabsContent>
 
-                    <TabsContent value="langchain" className="mt-4">
+                    <TabsContent value="langchain" className="mt-6 sm:mt-7">
                         <div className="group relative rounded-md bg-zinc-950 p-4 font-mono text-sm text-zinc-300 border border-zinc-800 overflow-x-auto">
                             <pre className="leading-relaxed">
                                 <span className="text-zinc-500"># 1. Install the provider</span>{'\n'}
@@ -105,7 +105,7 @@ export function UsageSnippets({ agentId, agent }: UsageSnippetsProps) {
                         </div>
                     </TabsContent>
 
-                    <TabsContent value="llamaindex" className="mt-4">
+                    <TabsContent value="llamaindex" className="mt-6 sm:mt-7">
                         <div className="group relative rounded-md bg-zinc-950 p-4 font-mono text-sm text-zinc-300 border border-zinc-800 overflow-x-auto">
                             <pre className="leading-relaxed">
                                 <span className="text-zinc-500"># 1. Install the provider</span>{'\n'}
@@ -120,7 +120,7 @@ export function UsageSnippets({ agentId, agent }: UsageSnippetsProps) {
                         </div>
                     </TabsContent>
 
-                    <TabsContent value="crewai" className="mt-4">
+                    <TabsContent value="crewai" className="mt-6 sm:mt-7">
                         <div className="group relative rounded-md bg-zinc-950 p-4 font-mono text-sm text-zinc-300 border border-zinc-800 overflow-x-auto">
                             <pre className="leading-relaxed">
                                 <span className="text-zinc-500"># 1. Install the provider</span>{'\n'}
@@ -136,7 +136,7 @@ export function UsageSnippets({ agentId, agent }: UsageSnippetsProps) {
                         </div>
                     </TabsContent>
 
-                    <TabsContent value="smolagents" className="mt-4">
+                    <TabsContent value="smolagents" className="mt-6 sm:mt-7">
                         <div className="group relative rounded-md bg-zinc-950 p-4 font-mono text-sm text-zinc-300 border border-zinc-800 overflow-x-auto">
                             <pre className="leading-relaxed">
                                 <span className="text-zinc-500"># 1. Install the provider</span>{'\n'}
@@ -149,7 +149,7 @@ export function UsageSnippets({ agentId, agent }: UsageSnippetsProps) {
                         </div>
                     </TabsContent>
 
-                    <TabsContent value="pydanticai" className="mt-4">
+                    <TabsContent value="pydanticai" className="mt-6 sm:mt-7">
                         <div className="group relative rounded-md bg-zinc-950 p-4 font-mono text-sm text-zinc-300 border border-zinc-800 overflow-x-auto">
                             <pre className="leading-relaxed">
                                 <span className="text-zinc-500"># 1. Install the provider</span>{'\n'}
@@ -164,7 +164,7 @@ export function UsageSnippets({ agentId, agent }: UsageSnippetsProps) {
                         </div>
                     </TabsContent>
 
-                    <TabsContent value="openclaw" className="mt-4">
+                    <TabsContent value="openclaw" className="mt-6 sm:mt-7">
                         <div className="group relative rounded-md bg-zinc-950 p-4 font-mono text-sm text-zinc-300 border border-zinc-800 overflow-x-auto">
                             <Button
                                 variant="ghost"
@@ -194,7 +194,7 @@ export function UsageSnippets({ agentId, agent }: UsageSnippetsProps) {
                         </div>
                     </TabsContent>
 
-                    <TabsContent value="mcp" className="mt-4">
+                    <TabsContent value="mcp" className="mt-6 sm:mt-7">
                         <div className="group relative rounded-md bg-zinc-950 p-4 font-mono text-sm text-zinc-300 border border-zinc-800 overflow-x-auto">
                             <pre className="leading-relaxed">
                                 <span className="text-zinc-500"># Use ASAP Protocol as an MCP Server (e.g. Claude Desktop)</span>{'\n'}

--- a/apps/web/src/app/api/fixtures/registry/route.ts
+++ b/apps/web/src/app/api/fixtures/registry/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { asapVersionForFixtureIndex } from '@/lib/protocol-versions';
+
 const MAX_FIXTURE_AGENTS = 2000;
 
 function buildFixtureAgents(count: number): Record<string, unknown>[] {
@@ -17,7 +19,7 @@ function buildFixtureAgents(count: number): Record<string, unknown>[] {
         http: `https://example.com/agents/${i}/asap`,
       },
       skills: skillsPool.slice(0, 2 + (i % 3)),
-      asap_version: '1.0',
+      asap_version: asapVersionForFixtureIndex(i),
       verification: i % 5 === 0 ? { status: 'verified' } : null,
     });
   }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
       <body suppressHydrationWarning className={`${geistSans.variable} ${geistMono.variable} antialiased selection:bg-indigo-500/30`}>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
           <TooltipProvider>
-          <div className="relative flex min-h-screen flex-col">
+          <div className="relative flex min-h-screen flex-col bg-background">
             <Header />
             <div className="flex-1">{children}</div>
             <Footer />

--- a/apps/web/src/components/landing/FeaturedAgents.tsx
+++ b/apps/web/src/components/landing/FeaturedAgents.tsx
@@ -32,8 +32,8 @@ export function FeaturedAgents({ agents }: FeaturedAgentsProps) {
           </p>
         </div>
 
-        <div className="mx-auto max-w-5xl px-8">
-          {/* We add px-8 to Carousel wrapper so arrows have space without overlapping cards */}
+        <div className="mx-auto max-w-5xl px-12 md:px-16">
+          {/* We add px-12 to Carousel wrapper so arrows have space without overlapping cards */}
           <Carousel
             opts={{
               align: 'start',
@@ -48,7 +48,7 @@ export function FeaturedAgents({ agents }: FeaturedAgentsProps) {
                   className="basis-full pl-2 md:basis-1/2 md:pl-4 lg:basis-1/3"
                 >
                   <div className="p-1">
-                    <Card className="border-zinc-800 bg-zinc-950/50 backdrop-blur-sm transition-all hover:border-indigo-500/30 hover:bg-zinc-900/80">
+                    <Card className="border-white/10 bg-zinc-950/50 backdrop-blur-sm transition-all hover:border-indigo-500/30 hover:bg-zinc-900/80 shadow-[0_0_15px_rgba(0,0,0,0.5)]">
                       <CardHeader className="pb-4">
                         <div className="mb-2 flex items-start justify-between">
                           <CardTitle className="line-clamp-1 text-xl text-white">
@@ -86,8 +86,8 @@ export function FeaturedAgents({ agents }: FeaturedAgentsProps) {
                 </CarouselItem>
               ))}
             </CarouselContent>
-            <CarouselPrevious className="border-zinc-800 bg-zinc-950 text-white hover:bg-zinc-800 hover:text-white" />
-            <CarouselNext className="border-zinc-800 bg-zinc-950 text-white hover:bg-zinc-800 hover:text-white" />
+            <CarouselPrevious className="border-white/10 bg-zinc-950 text-white hover:bg-zinc-800 hover:text-white sm:-left-12 -left-4" />
+            <CarouselNext className="border-white/10 bg-zinc-950 text-white hover:bg-zinc-800 hover:text-white sm:-right-12 -right-4" />
           </Carousel>
         </div>
       </div>

--- a/apps/web/src/components/landing/HeroTerminal.tsx
+++ b/apps/web/src/components/landing/HeroTerminal.tsx
@@ -4,14 +4,14 @@ import { Terminal } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 const TERMINAL_LINES = [
-  { text: '[SYSTEM] ASAP Protocol v2.2.1 init — Protocol Hardening + real WebAuthn', color: 'text-zinc-500', delay: 400 },
-  { text: '[IDENTITY] Host authenticated · Agent Ed25519 key issued (typ: agent+jwt)', color: 'text-indigo-400', delay: 1000 },
-  { text: '-> POST /asap { "method": "capability.describe", "name": "transfer_funds" }', color: 'text-cyan-400', delay: 1800 },
-  { text: '<- RESP constraints: { amount: { max: 1000 }, currency: { in: ["USD","EUR"] } }', color: 'text-purple-400', delay: 2800 },
-  { text: '[APPROVAL] user_code AB-CD-34 via RFC 8628 Device Authorization', color: 'text-amber-400', delay: 3800 },
-  { text: '-> POST /asap/stream  Accept: text/event-stream  ASAP-Version: 2.2', color: 'text-indigo-400', delay: 4800 },
-  { text: 'event: task_stream  data: { chunk: "partial result...", progress: 0.5 }', color: 'text-emerald-400', delay: 6000 },
-  { text: 'event: task_stream  data: { final: true, status: "completed" }', color: 'text-emerald-400', delay: 7200 },
+  { text: '[SYSTEM] ASAP Protocol v2.2.1 init — Protocol Hardening + real WebAuthn', color: 'text-zinc-400', delay: 400 },
+  { text: '[IDENTITY] Host authenticated · Agent Ed25519 key issued (typ: agent+jwt)', color: 'text-indigo-300', delay: 1000 },
+  { text: '-> POST /asap { "method": "capability.describe", "name": "transfer_funds" }', color: 'text-cyan-300', delay: 1800 },
+  { text: '<- RESP constraints: { amount: { max: 1000 }, currency: { in: ["USD","EUR"] } }', color: 'text-purple-300', delay: 2800 },
+  { text: '[APPROVAL] user_code AB-CD-34 via RFC 8628 Device Authorization', color: 'text-amber-300', delay: 3800 },
+  { text: '-> POST /asap/stream  Accept: text/event-stream  ASAP-Version: 2.2', color: 'text-indigo-300', delay: 4800 },
+  { text: 'event: task_stream  data: { chunk: "partial result...", progress: 0.5 }', color: 'text-emerald-300', delay: 6000 },
+  { text: 'event: task_stream  data: { final: true, status: "completed" }', color: 'text-emerald-300', delay: 7200 },
   { text: '[AUDIT] 3 writes appended (hash chain verified) · latency 38ms', color: 'text-zinc-500', delay: 8200 },
 ];
 

--- a/apps/web/src/components/layout/Footer.tsx
+++ b/apps/web/src/components/layout/Footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
         </div>
 
         <div className="mt-16 pt-8 border-t border-zinc-900 flex flex-col md:flex-row items-center justify-between gap-4 text-xs text-zinc-600">
-          <p>© {new Date().getFullYear()} ASAP Protocol Authors.</p>
+          <p>© {new Date().getFullYear()} ASAP Protocol contributors.</p>
           <div className="flex items-center gap-4">
             <span>From agents, for agents. Delivering reliability, as soon as possible.</span>
           </div>

--- a/apps/web/src/components/layout/header-content.tsx
+++ b/apps/web/src/components/layout/header-content.tsx
@@ -37,12 +37,13 @@ export function HeaderContent({ session }: HeaderContentProps) {
         <div className="flex items-center gap-2">
           <Link
             href="/"
-            className="flex items-center gap-2 text-white hover:text-indigo-400 transition-colors"
+            aria-label="ASAP Protocol — home"
+            className="flex items-center gap-1 md:gap-2 text-white hover:text-indigo-400 transition-colors"
           >
             <div className="bg-indigo-500/10 p-1.5 rounded-lg border border-indigo-500/20">
               <Terminal className="h-5 w-5 text-indigo-400" />
             </div>
-            <span className="font-bold text-lg tracking-tight">
+            <span className="hidden font-bold text-lg tracking-tight md:inline">
               ASAP Protocol
             </span>
           </Link>
@@ -57,7 +58,7 @@ export function HeaderContent({ session }: HeaderContentProps) {
 
         {/* Center Nav — hidden on dashboard routes (Sidebar provides nav) */}
         {!isDashboardRoute && (
-          <nav className="hidden items-center gap-6 md:flex">
+          <nav className="hidden items-center gap-8 md:flex">
             <Link
               href="/browse"
               className="text-sm font-medium text-zinc-400 transition-colors hover:text-white"

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  "rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
+  "rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:min-h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
   {
     variants: {
       variant: {

--- a/apps/web/src/lib/protocol-versions.ts
+++ b/apps/web/src/lib/protocol-versions.ts
@@ -1,0 +1,10 @@
+/**
+ * ASAP protocol versions used for Lite Registry demos (rotation by agent index).
+ * Keep in sync with PROTOCOL_VERSIONS in scripts/diversify_registry_asap_versions.py.
+ */
+export const PROTOCOL_VERSION_CYCLE = ['1.0.0', '1.1.0', '2.0.0', '2.1.0', '2.2.1'] as const;
+
+export function asapVersionForFixtureIndex(index: number): string {
+  const cycle = PROTOCOL_VERSION_CYCLE;
+  return cycle[index % cycle.length]!;
+}

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -53,6 +53,16 @@ describe('proxy (middleware)', () => {
             const res = (await proxy(req, middlewareContext)) as Response;
             expect(res.status).toBe(200);
         });
+
+        it('allows localhost with a different port when NODE_ENV is development', async () => {
+            vi.stubEnv('NODE_ENV', 'development');
+            const { default: proxy } = await import('@/proxy');
+            const req = createRequest('/api/health-check', { origin: 'http://localhost:3001' });
+            const res = (await proxy(req, middlewareContext)) as Response;
+            expect(res.status).toBe(200);
+            expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3001');
+            vi.unstubAllEnvs();
+        });
     });
 
     describe('/api/fixtures excluded from strict CORS (server-side fetch)', () => {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,6 +1,29 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 
+/**
+ * Origin allowed for CORS on /api (except auth + fixtures).
+ * Production: only NEXT_PUBLIC_APP_URL.
+ * Development: that URL or any http(s) Origin on localhost / 127.0.0.1 (any port) so `next dev`
+ * on :3001 still works when NEXT_PUBLIC_APP_URL defaults to :3000.
+ */
+function corsReflectOrigin(requestOrigin: string | null): string | null {
+  const configured = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  if (!requestOrigin) return null;
+  if (requestOrigin === configured) return requestOrigin;
+  if (process.env.NODE_ENV === 'development') {
+    try {
+      const url = new URL(requestOrigin);
+      if (url.hostname === 'localhost' || url.hostname === '127.0.0.1') {
+        return requestOrigin;
+      }
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
   const { pathname } = req.nextUrl;
@@ -10,14 +33,14 @@ export default auth((req) => {
   // Skip for /api/fixtures so server-side fetch (e.g. REGISTRY_URL in E2E) can reach it.
   if (pathname.startsWith('/api/') && !pathname.startsWith('/api/auth') && !pathname.startsWith('/api/fixtures')) {
     const origin = req.headers.get('origin');
-    const allowedOrigin = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const reflect = corsReflectOrigin(origin);
 
-    if (!origin || origin !== allowedOrigin) {
+    if (!reflect) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     const response = NextResponse.next();
-    response.headers.set('Access-Control-Allow-Origin', allowedOrigin);
+    response.headers.set('Access-Control-Allow-Origin', reflect);
     response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
     response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
     response.headers.set('Access-Control-Max-Age', '86400');

--- a/docs/adapters/openapi.md
+++ b/docs/adapters/openapi.md
@@ -1,0 +1,184 @@
+# OpenAPI adapter (Python)
+
+The `asap.adapters.openapi` package derives ASAP **skills**, JSON Schemas, and a **`task.request` handler** from an **OpenAPI 3.0 or 3.1** document, then proxies each invocation to the upstream HTTP API described by the spec.
+
+**Requires** the optional extra:
+
+```bash
+uv add 'asap-protocol[openapi]'
+# or
+pip install 'asap-protocol[openapi]'
+```
+
+This pulls in `openapi-pydantic` for validation and parsing.
+
+## Architecture
+
+```text
+OpenAPI document (URL or local .json)
+        │
+        ▼
+  load_spec()  ──► openapi-pydantic root model (3.0 / 3.1)
+        │
+        ▼
+  map_openapi_to_capabilities()
+        │  operationId → skill id; parameters + JSON body → input schema;
+        │  200/201 application/json → output schema; OA-010 execution kind
+        ▼
+  OpenAPIUpstreamHandler  ◄── httpx.AsyncClient (spec fetch + upstream calls)
+        │
+        ▼
+  create_openapi_task_handler()  ──► HandlerRegistry["task.request"]
+        │
+        ▼
+  OpenAPIAdapterBundle.manifest + .registry  ──► create_app()
+```
+
+- **One async entrypoint**: `create_from_openapi` builds an `OpenAPIAdapterBundle` with a ready-to-use `Manifest`, `HandlerRegistry`, and metadata (`require_webauthn_for`, `upstream_base_url`).
+- **Upstream base URL**: Taken from `servers[0].url` when it is absolute (`https://…`). If the spec uses a **relative** server URL (e.g. `/api/v3`), the adapter resolves it with `urllib.parse.urljoin` against the document URL used to load the spec. Loading from a **local file only** with a relative server requires `upstream_base_url=`.
+- **Execution modes (OA-010)**: The mapper classifies each operation as `sync`, `streaming` (response advertises `text/event-stream`), or `async_polling` (`202` + `Location`). The manifest’s `Capability.streaming` flag is set if any operation is streaming; the current **`task.request` path** still performs a single HTTP round-trip and returns JSON (or wrapped non-object JSON). Treat streaming/async polling as **metadata for future wiring**, not full ASAP streaming handlers yet.
+- **Identity & capability grants**: `create_app` still provisions identity and capability HTTP routes. Use [`FreshSessionConfig`](../security/self-authorization-prevention.md) and `bundle.require_webauthn_for` (from `approval_strength`) for approval/WebAuthn policy; registering `CapabilityDefinition` rows in `app.state.capability_registry` is separate from OpenAPI mapping.
+
+## Quick usage
+
+Always pass a shared **`httpx.AsyncClient`** (timeout, proxies, mock transports, MTLS as you configure it):
+
+```python
+import asyncio
+import httpx
+
+from asap.adapters.openapi import create_from_openapi
+from asap.transport.server import create_app
+
+
+async def main() -> None:
+    async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as http:
+        bundle = await create_from_openapi(
+            spec_url="https://api.example.com/openapi.json",
+            http_client=http,
+            default_capabilities=["GET", "HEAD"],
+            upstream_base_url="https://api.example.com",  # optional override
+            manifest_id="urn:asap:agent:my-openapi-bridge",
+            asap_endpoint="https://my-host.example/asap",
+        )
+
+    app = create_app(bundle.manifest, bundle.registry)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### Approval strength (OA-008) and registration
+
+Map HTTP methods or `operationId` values to `session` vs `webauthn`, then feed the derived list into `FreshSessionConfig`:
+
+```python
+from asap.auth.self_auth import FreshSessionConfig
+from asap.transport.server import create_app
+
+bundle = await create_from_openapi(
+    spec_url="https://api.example.com/openapi.json",
+    http_client=http,
+    approval_strength={"GET": "session", "POST": "webauthn", "DELETE": "webauthn"},
+)
+
+app = create_app(
+    bundle.manifest,
+    bundle.registry,
+    identity_fresh_session_config=FreshSessionConfig(
+        require_webauthn_for=bundle.require_webauthn_for,
+    ),
+)
+```
+
+Details: [Self-authorization prevention](../security/self-authorization-prevention.md).
+
+### Upstream auth (OA-009)
+
+Pass a callable `(session) -> dict[str, str]` to inject headers (for example `Authorization`); operation-defined header parameters still merge and may override callback keys:
+
+```python
+def resolve_headers(session: object | None) -> dict[str, str]:
+    _ = session
+    return {"Authorization": "Bearer <token>"}
+
+
+bundle = await create_from_openapi(
+    spec_url="https://api.example.com/openapi.json",
+    http_client=http,
+    resolve_headers=resolve_headers,
+)
+```
+
+## Configuration reference
+
+| Parameter | Description |
+|:----------|:-------------|
+| `spec_url` | HTTP(S) URL of the OpenAPI document (exactly one of `spec_url` or `spec_path`). |
+| `spec_path` | Local path to a UTF-8 **JSON** document (`.json`). YAML is not supported yet. |
+| `http_client` | `httpx.AsyncClient` used to fetch the spec (if URL) and for all upstream API calls. |
+| `upstream_base_url` | Overrides inferred base URL from `servers`. |
+| `default_capabilities` | `"all"`, a single method string (`"GET"`), a sequence of methods, or a callable `(OpenAPIOperationContext) -> bool`. See `map_openapi_to_capabilities`. |
+| `approval_strength` | Optional `dict[str, str]` mapping HTTP verbs and/or `operationId` to `session` or `webauthn`; populates `bundle.require_webauthn_for` for WebAuthn-gated capability names. |
+| `resolve_headers` | Optional callback for extra request headers to the upstream. |
+| `manifest_id` | ASAP manifest id (default `urn:asap:agent:openapi-adapter`). |
+| `manifest_name` | Overrides manifest name (default: `info.title`). |
+| `asap_endpoint` | Value stored on `Manifest.endpoints.asap` (advertised to clients). |
+
+**Bundle fields**
+
+| Field | Meaning |
+|:------|:--------|
+| `manifest` | `Manifest` with skills mirroring the selected operations. |
+| `registry` | `HandlerRegistry` with `task.request` → OpenAPI proxy handler. |
+| `capabilities` | List of `OpenAPICapability` (HTTP method, path template, `operation_id`, execution kind, etc.). |
+| `require_webauthn_for` | Capability names requiring WebAuthn when `approval_strength` is set. |
+| `upstream_base_url` | Resolved base URL used by the handler. |
+
+## Runnable example and compliance
+
+The repo includes `examples/openapi_petstore/`: bundled PetStore-shaped fragment, **Compliance Harness v2** in-process, and a call to `findPetsByStatus`. By default the upstream is **mocked** for reliability; use `--live` for the public PetStore URL (network; remote service may error).
+
+```bash
+uv sync --extra openapi
+uv run python examples/openapi_petstore/main.py
+```
+
+See also [Compliance testing](../guides/compliance-testing.md) and [CI compliance gate](../ci-compliance.md).
+
+## Common pitfalls
+
+### Authentication and secrets
+
+- The adapter does not read OpenAPI `securitySchemes` automatically. Use **`resolve_headers`** (Bearer, API keys, custom headers) or a dedicated gateway in front of the upstream.
+- Never embed tokens in source; load from environment or a secret store and build headers at runtime.
+
+### Relative `servers` and local specs
+
+If the spec only declares `servers: [{ url: "/api/v3" }]` and you load from disk, the adapter cannot infer an absolute origin. Pass **`upstream_base_url`** explicitly.
+
+### Polymorphism and complex schemas
+
+- Input/output mapping focuses on `application/json` and inlines internal `#/components/schemas/` refs where possible. **`oneOf` / `anyOf`** at the top level of request or response bodies may not round-trip cleanly into strict JSON Schema validation everywhere; review generated `Skill` schemas before exposing them to untrusted callers.
+- Non-JSON success bodies are returned as a small wrapper dict (e.g. `_text`, `_json`) depending on `Content-Type`.
+
+### Large specifications
+
+- Every operation can become a **skill**; large APIs (hundreds of paths) produce large manifests and handler indexes. Use **`default_capabilities`** (e.g. only `GET`) or a **callable filter** to trim surface area. Consider a curated spec or a gateway that exposes a subset.
+
+### Public demo APIs
+
+Third-party OpenAPI hosts may return **4xx/5xx** or change without notice. Prefer contract tests with **mocked `httpx`** transports for CI; use live URLs for manual exploration only.
+
+### Streaming (SSE) vs ASAP streaming
+
+Upstream **`text/event-stream`** is detected for metadata, but the default **`task.request`** handler does not bridge SSE into ASAP `TaskStream` envelopes. Document behavior if you expose streaming operations; a dedicated streaming handler may be required for full parity.
+
+## Related documentation
+
+- [Transport](../transport.md) — HTTP JSON-RPC, `create_app`
+- [Security](../security.md) — auth schemes at the ASAP layer
+- [Self-authorization prevention](../security/self-authorization-prevention.md) — `FreshSessionConfig`, WebAuthn
+- [Error handling](../error-handling.md) — `FatalError`, `RecoverableError` from upstream proxying
+- [PRD v2.3 OpenAPI adapter](https://github.com/adriannoes/asap-protocol/blob/main/product/prd/prd-v2.3-scale.md) — OA-* requirements (source of truth for scope)

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,7 @@ See [CLI reference](cli.md) (all commands, exit codes, `compliance-check`, `audi
 
 ## Documentation
 
+- [OpenAPI adapter](adapters/openapi.md) — derive ASAP skills and an upstream proxy from OpenAPI 3.x (`asap.adapters.openapi`)
 - [CLI reference](cli.md) — all `asap` commands, including `compliance-check`, `audit export`, and exit codes
 - [Audit log](audit.md) — hash chain model, export formats, tamper checks
 - [API Reference](api-reference.md)
@@ -110,3 +111,9 @@ See [CLI reference](cli.md) (all commands, exit codes, `compliance-check`, `audi
 | **Discovery** | Well-known manifest, Lite Registry, health endpoint | [Transport](transport.md), `asap.discovery` |
 | **State Storage** | SQLite backend, env-based backend selection | [State Management](state-management.md), [Best Practices: Failover](best-practices/agent-failover-migration.md), examples: `storage_backends`, `state_migration` |
 | **Health** | `GET /.well-known/asap/health` for liveness | [Transport](transport.md), `asap.discovery.health` |
+
+## Contact
+
+**General inquiries** about the protocol or project: [info@asap-protocol.com](mailto:info@asap-protocol.com).
+
+For vulnerability reports, use **[SECURITY.md](../SECURITY.md)** (GitHub Private Vulnerability Reporting), not email. Technical questions work well via [GitHub Discussions](https://github.com/adriannoes/asap-protocol/discussions) or [Issues](https://github.com/adriannoes/asap-protocol/issues).

--- a/engineering/code-review/v2.3.0/pr-132-openapi-adapter.md
+++ b/engineering/code-review/v2.3.0/pr-132-openapi-adapter.md
@@ -1,0 +1,250 @@
+# Code Review: PR #132 — `feat(openapi): OpenAPI 3.x adapter`
+
+> **Reviewer**: Antigravity (Senior Staff Engineer)
+> **PR**: [#132](https://github.com/adriannoes/asap-protocol/pull/132)
+> **Branch**: `feat/openapi-adapter-python` → `main`
+> **Sprint**: [S1 — OpenAPI Adapter](../../../engineering/tasks/v2.3.0/sprint-S1-openapi-adapter.md)
+> **Date**: 2026-05-01
+> **Re-review**: 2026-05-01 (post-fixes)
+
+---
+
+## ✅ Review Status: APPROVED
+
+All Required Fixes (RF-1 through RF-3) and Improvements (IMP-1 through IMP-6) have been verified locally. **82/82 tests passing** in 0.36s.
+
+---
+
+## 1. Executive Summary
+
+| Category | Status | Summary |
+| :--- | :--- | :--- |
+| **Tech Stack** | ✅ | Correct dependencies, Pydantic v2, optional extras — all per tech-stack-decisions.md |
+| **Architecture** | ✅ | Clean adapter module boundary, handler registry pattern, no monolith expansion |
+| **Security** | ✅ | Async I/O fixed; `resolve_headers` validated; upstream error body leakage mitigated |
+| **Tests** | ✅ | 82 tests across 5 test files; comprehensive unit + integration + E2E coverage |
+| **Observability** | ✅ | Structured logging across all 4 adapter modules |
+
+---
+
+## 2. Required Fixes — Re-verification
+
+### RF-1: Synchronous File I/O in Async Path ✅ FIXED
+
+**File:** [spec_loader.py](file:///Users/adrianno/GitHub/asap-protocol/src/asap/adapters/openapi/spec_loader.py#L61-L83)
+
+**Implementation:** `_load_json_from_path()` is now `async def` and delegates all filesystem operations (`is_file()`, `read_text()`, `json.loads()`) to a nested `_sync_load()` function called via `asyncio.to_thread()`. This was the zero-dependency approach recommended in the review.
+
+```python
+async def _load_json_from_path(path: Path) -> dict[str, Any]:
+    """Read a local spec without blocking the event loop (filesystem + decode in worker thread)."""
+    def _sync_load() -> dict[str, Any]:
+        ...
+    try:
+        return await asyncio.to_thread(_sync_load)
+    except OpenAPISpecError as exc:
+        logger.error("OpenAPI spec load from path failed path=%s: %s", path, exc)
+        raise
+```
+
+**Verdict:** Clean implementation. Error handling preserves the original `OpenAPISpecError` chain while adding a log point.
+
+---
+
+### RF-2: Missing Structured Logging ✅ FIXED
+
+**Files:** All 4 adapter modules now have `logger = logging.getLogger(__name__)`:
+
+| Module | Logger | Key log points |
+| :--- | :--- | :--- |
+| [spec_loader.py](file:///Users/adrianno/GitHub/asap-protocol/src/asap/adapters/openapi/spec_loader.py#L22) | ✅ L22 | HTTP fetch errors (ERROR), version/parse errors (ERROR), load start (DEBUG), load complete (INFO) |
+| [handler.py](file:///Users/adrianno/GitHub/asap-protocol/src/asap/adapters/openapi/handler.py#L28) | ✅ L28 | Upstream connection errors (WARNING), 5xx (WARNING), 4xx (ERROR) |
+| [factory.py](file:///Users/adrianno/GitHub/asap-protocol/src/asap/adapters/openapi/factory.py#L30) | ✅ L30 | Capabilities mapped count (INFO) |
+| [capability_mapper.py](file:///Users/adrianno/GitHub/asap-protocol/src/asap/adapters/openapi/capability_mapper.py#L14) | ✅ L14 | `$ref` depth limit hit (DEBUG), capabilities produced count (DEBUG) |
+
+**Verdict:** Appropriate log levels — operators will see WARNINGs for transient upstream issues and ERRORs for client errors, without DEBUG noise in production.
+
+---
+
+### RF-3: Missing `create_from_openapi` Re-export ✅ FIXED
+
+**File:** [src/asap/\_\_init\_\_.py](file:///Users/adrianno/GitHub/asap-protocol/src/asap/__init__.py)
+
+```python
+def __getattr__(name: str) -> Any:
+    if name == "create_from_openapi":
+        from asap.adapters.openapi import create_from_openapi as exported
+        return exported
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+```
+
+**Test:** [test_factory.py::test_asap_package_lazy_exports_create_from_openapi](file:///Users/adrianno/GitHub/asap-protocol/tests/adapters/openapi/test_factory.py#L210-L214) — verifies `asap.create_from_openapi is create_from_openapi`.
+
+**Verdict:** Lazy `__getattr__` avoids importing `openapi-pydantic` for users without the `[openapi]` extra. Exactly as recommended.
+
+---
+
+## 3. Improvements — Re-verification
+
+### IMP-1: Silent `**kwargs` Swallowing ✅ FIXED
+
+**File:** [factory.py](file:///Users/adrianno/GitHub/asap-protocol/src/asap/adapters/openapi/factory.py#L169-L178)
+
+Now filters kwargs against `_KNOWN_CREATE_FROM_OPENAPI_KEYS` frozenset and emits `UserWarning` for unrecognized keys:
+
+```python
+remainder = dict(kwargs)
+for _key in _KNOWN_CREATE_FROM_OPENAPI_KEYS:
+    remainder.pop(_key, None)
+if remainder:
+    warnings.warn(
+        "create_from_openapi ignored unexpected keyword arguments: "
+        + ", ".join(sorted(remainder)),
+        UserWarning,
+        stacklevel=2,
+    )
+```
+
+**Test:** [test_factory.py::test_kwargs_unknown_keys_emit_warning](file:///Users/adrianno/GitHub/asap-protocol/tests/adapters/openapi/test_factory.py#L188-L207) — uses `pytest.warns(UserWarning, ...)`.
+
+---
+
+### IMP-2: Test Fixture Cleanup Pattern ✅ FIXED
+
+**File:** [conftest.py](file:///Users/adrianno/GitHub/asap-protocol/tests/adapters/openapi/conftest.py)
+
+Introduced shared `tmp_openapi_spec()` context manager using `pytest`'s `tmp_path` fixture. All test files (`test_handler.py`, `test_capability_mapper.py`) refactored to use `with tmp_openapi_spec(tmp_path, raw, name) as path:` instead of manual `_write_tmp` + `try/finally/unlink`.
+
+**Verdict:** Clean DRY pattern. Old `_FIXTURES` directory no longer gets polluted with temp files.
+
+---
+
+### IMP-3: Excessive `cast()` Usage Comment ✅ FIXED
+
+**File:** [capability_mapper.py](file:///Users/adrianno/GitHub/asap-protocol/src/asap/adapters/openapi/capability_mapper.py#L16-L18)
+
+Added explanatory comment at module level:
+
+```python
+# ``cast(...)`` usages below compensate for incomplete / structural typing from
+# openapi-pydantic stubs: paths, responses, headers, and parameters are modeled
+# as generic objects at compile time though runtime layout matches OpenAPI 3.x.
+```
+
+**Verdict:** Documents the technical debt clearly for future contributors.
+
+---
+
+### IMP-4: `$ref` Recursion Depth Guard ✅ FIXED
+
+**File:** [capability_mapper.py](file:///Users/adrianno/GitHub/asap-protocol/src/asap/adapters/openapi/capability_mapper.py#L128-L149)
+
+`expand_refs()` now takes a `depth: int = 0` parameter with a limit of 50:
+
+```python
+def expand_refs(self, node: Any, seen: frozenset[str], depth: int = 0) -> Any:
+    if depth > 50:
+        logger.debug("OpenAPI schema $ref expansion stopped at depth %s ...", depth)
+        return node
+    next_depth = depth + 1
+    ...
+```
+
+**Test:** `test_expand_refs_depth_returns_early_without_error_on_deep_trees` — PASSED ✅
+
+**Verdict:** Graceful degradation for deeply nested schemas (e.g., Stripe's API spec) without crashing with `RecursionError`.
+
+---
+
+### IMP-5: `session=None` in Task Handler ✅ DOCUMENTED
+
+**File:** [handler.py](file:///Users/adrianno/GitHub/asap-protocol/src/asap/adapters/openapi/handler.py#L472-L478)
+
+Documented as a known limitation with a clear future-work pointer:
+
+```python
+def create_openapi_task_handler(upstream: OpenAPIUpstreamHandler) -> AsyncHandler:
+    """Build an async ``task.request`` handler that proxies to *upstream*.
+
+    The nested ``openapi_task_request_handler`` always passes ``session=None`` into
+    :meth:`OpenAPIUpstreamHandler.execute` today. OA-009 header resolution from Host-held
+    context likely needs envelope- or TaskRequest-level session wiring in a future change.
+    """
+```
+
+**Verdict:** Acceptable — documenting the limitation is the right call for v2.3.0; wiring session extraction from envelope context can be a v2.3.x follow-up.
+
+---
+
+### IMP-6: Path Parameter Value Validation ✅ FIXED
+
+**File:** [handler.py](file:///Users/adrianno/GitHub/asap-protocol/src/asap/adapters/openapi/handler.py#L281-L299)
+
+`_fill_path_template()` now validates path parameter values after checking for missing ones:
+
+```python
+invalid_names = [
+    n for n in names_order
+    if path_params[n] is None
+    or (isinstance(path_params[n], str) and cast(str, path_params[n]).strip() == "")
+]
+if invalid_names:
+    raise OpenAPIPathParameterError(path_template=path_template, invalid=invalid_names)
+```
+
+`OpenAPIPathParameterError` was also extended to support both `missing=` and `invalid=` modes with mutually exclusive constructor validation.
+
+**Tests (3 new):**
+- `test_execute_empty_path_parameter_string_raises` — ✅
+- `test_execute_whitespace_only_path_parameter_raises` — ✅
+- `test_execute_none_path_parameter_raises` — ✅
+
+---
+
+## 4. Security Fix — Re-verification
+
+### §5.3: Upstream Error Body Leakage ✅ FIXED
+
+**File:** [handler.py](file:///Users/adrianno/GitHub/asap-protocol/src/asap/adapters/openapi/handler.py#L407-L446)
+
+| HTTP Status | Before | After |
+| :--- | :--- | :--- |
+| **5xx** | `body_snippet` = first 500 chars exposed to caller | `body_snippet` **removed** from details dict; logged server-side only |
+| **4xx** | `body_snippet` = first 500 chars | Truncated to **200 chars** (`_UPSTREAM_CLIENT_ERROR_BODY_MAX_LEN`) |
+
+Constants and inline comments explain the rationale:
+
+```python
+# Bound upstream HTTP error payloads copied into FatalError/RecoverableError details to
+# reduce accidental leakage of large or sensitive bodies (prefer server logs for triage).
+_UPSTREAM_CLIENT_ERROR_BODY_MAX_LEN = 200
+```
+
+**Tests:**
+- `test_execute_upstream_502_is_recoverable` — now asserts `"body_snippet" not in exc_info.value.details` ✅
+- `test_execute_upstream_404_is_fatal` — now asserts `len(snippet) <= 200` ✅
+
+---
+
+## 5. Test Run Results
+
+```
+tests/adapters/openapi/ — 82 passed in 0.36s
+```
+
+| Test File | Count | Status |
+| :--- | :--- | :--- |
+| `test_approval.py` | 4 | ✅ All passed |
+| `test_capability_mapper.py` | 22 | ✅ All passed |
+| `test_factory.py` | 10 | ✅ All passed |
+| `test_handler.py` | 26 | ✅ All passed |
+| `test_spec_loader.py` | 20 | ✅ All passed |
+
+---
+
+## 6. Final Verdict
+
+**✅ APPROVED — Ready to merge.**
+
+All 3 Required Fixes, 6 Improvements, and the security mitigation have been verified in the local codebase with passing tests. The code is clean, well-documented, and architecturally sound. Push the local changes to the branch and merge when CI is green.

--- a/engineering/tasks/v2.3.0/sprint-S1-openapi-adapter.md
+++ b/engineering/tasks/v2.3.0/sprint-S1-openapi-adapter.md
@@ -9,18 +9,28 @@
 
 ### New Files
 - `src/asap/adapters/__init__.py` — adapters namespace
-- `src/asap/adapters/openapi/__init__.py` — public API: `create_from_openapi`, `OpenAPIAdapterConfig`
+- `src/asap/adapters/openapi/__init__.py` — public API: `create_from_openapi`, `OpenAPIAdapterBundle`, `PETSTORE_OPENAPI_URL`
+- `src/asap/adapters/openapi/factory.py` — load spec + manifest + registry wiring (OA-001)
+- `tests/adapters/__init__.py` — test package for adapters
+- `tests/adapters/openapi/__init__.py` — test package for OpenAPI adapter
+- `tests/adapters/openapi/integration/__init__.py` — integration/E2E test package
 - `src/asap/adapters/openapi/spec_loader.py` — fetch + parse via `openapi-pydantic`
-- `src/asap/adapters/openapi/capability_mapper.py` — operationId → capability name; schemas → input/output JSON Schema
-- `src/asap/adapters/openapi/handler.py` — Execution handler proxying to upstream HTTP API
-- `src/asap/adapters/openapi/approval.py` — `approval_strength` per HTTP method/operation
-- `tests/adapters/openapi/test_capability_mapper.py`
-- `tests/adapters/openapi/test_handler.py`
+- `src/asap/adapters/openapi/capability_mapper.py` — skills + schemas; `default_capabilities` (OA-007); `OpenAPIExecutionKind` (OA-010)
+- `src/asap/adapters/openapi/handler.py` — upstream proxy, `resolve_headers(session)` → merged headers (OA-009)
+- `src/asap/adapters/openapi/approval.py` — `approval_strength` map → `FreshSessionConfig.require_webauthn_for` (OA-008)
+- `tests/fixtures/openapi/minimal-3.0.3.json` — minimal OpenAPI 3.0.3 fixture for spec loader tests
+- `tests/fixtures/openapi/minimal-3.1.0.json` — minimal OpenAPI 3.1.0 fixture for spec loader tests
+- `tests/adapters/openapi/test_spec_loader.py` — unit tests for `spec_loader.load_spec`
+- `tests/adapters/openapi/test_capability_mapper.py` — mapping, `default_capabilities`, execution-kind detection
+- `tests/adapters/openapi/test_handler.py` — mocked httpx + `resolve_headers` merge and RecoverableError cases
 - `tests/adapters/openapi/integration/test_e2e_petstore.py` — E2E with PetStore OpenAPI spec
-- `examples/openapi_petstore/` — runnable example onboarding the public PetStore spec
+- `tests/adapters/openapi/test_approval.py` — unit tests for approval strength normalization and WebAuthn capability list
+- `tests/adapters/openapi/integration/test_approval_strength_register.py` — register + `DELETE`/`webauthn` + `agent_controls_browser` (real WebAuthn extra)
+- `examples/openapi_petstore/` — `README.md`, `main.py`, `openapi-fragment.json` (bundled PetStore-shaped spec + Compliance Harness v2; mock upstream by default; `--live` for public spec)
 
 ### Modified Files
-- `pyproject.toml` — Add `openapi-pydantic>=0.5` dependency (optional extra `[openapi]`)
+- `pyproject.toml` — Add `openapi-pydantic>=0.5` dependency (optional extra `[openapi]`); `examples/**` ruff `T201` allowlist for demo scripts
+- `uv.lock` — Resolved versions for `openapi-pydantic` when the `[openapi]` extra is selected
 - `src/asap/__init__.py` — Re-export `create_from_openapi` for convenience
 - `docs/adapters/openapi.md` — Adapter usage guide
 
@@ -28,62 +38,62 @@
 
 ### 1.0 Scaffolding & Dependencies (TDD-first)
 
-- [ ] 1.1 Add `openapi-pydantic` optional extra
+- [x] 1.1 Add `openapi-pydantic` optional extra
   - **File**: `pyproject.toml`
   - **What**: `[project.optional-dependencies] openapi = ["openapi-pydantic>=0.5"]`
   - **Verify**: `uv sync --extra openapi`
 
-- [ ] 1.2 Write failing E2E test (TDD)
+- [x] 1.2 Write failing E2E test (TDD)
   - **File**: `tests/adapters/openapi/integration/test_e2e_petstore.py`
   - **What**: Load `https://petstore3.swagger.io/api/v3/openapi.json` (or fixture), call `create_from_openapi(spec_url=...)`, register against test ASAP server, invoke `findPetsByStatus` capability, assert response shape
   - **Verify**: Red
 
 ### 2.0 Spec Loading & Capability Mapping
 
-- [ ] 2.1 Spec loader
+- [x] 2.1 Spec loader
   - **File**: `src/asap/adapters/openapi/spec_loader.py`
   - **What**: `async def load_spec(url_or_path) -> OpenAPI` using `openapi-pydantic`. Support both URL (httpx) and local file. Validate version 3.x.
   - **Verify**: Unit tests with fixture specs
 
-- [ ] 2.2 Capability mapper (OA-002, OA-003, OA-004, OA-005)
+- [x] 2.2 Capability mapper (OA-002, OA-003, OA-004, OA-005)
   - **File**: `src/asap/adapters/openapi/capability_mapper.py`
   - **What**: For each operation: `operationId` → capability name; `summary`/`description` → description; merge `parameters` + `requestBody.content[application/json].schema` → input JSON Schema; `responses["200"].content[application/json].schema` (fallback `"201"`) → output JSON Schema
   - **Verify**: Unit tests covering: GET with path/query params, POST with JSON body, response with `$ref`, missing operationId fallback to `<method>_<path>`
 
-- [ ] 2.3 `default_capabilities` filter (OA-007)
+- [x] 2.3 `default_capabilities` filter (OA-007)
   - **What**: Accept `"GET"`, `["GET", "HEAD"]`, `"all"`, or callable `(operation) -> bool`. Apply at capability selection time.
   - **Verify**: Three test cases per filter type
 
 ### 3.0 Execution Handler
 
-- [ ] 3.1 Handler skeleton (OA-001, OA-006)
+- [x] 3.1 Handler skeleton (OA-001, OA-006)
   - **File**: `src/asap/adapters/openapi/handler.py`
   - **What**: `async def execute(capability_name, args, session) -> dict`. Map args back to path params (template substitution), query params, headers, request body. Use `httpx.AsyncClient` for upstream call.
   - **Verify**: Unit tests with mocked httpx
 
-- [ ] 3.2 `resolve_headers` callback (OA-009)
+- [x] 3.2 `resolve_headers` callback (OA-009)
   - **What**: Accept callable `(session) -> dict[str, str]`. Inject into upstream request headers (e.g., `Authorization: Bearer <user-token>`).
   - **Verify**: Test that headers are merged correctly; unauthorized callback raises `RecoverableError`
 
-- [ ] 3.3 Response type auto-detection (OA-010)
+- [x] 3.3 Response type auto-detection (OA-010)
   - **What**: Inspect `responses[].content[]` keys. `text/event-stream` → register as streaming handler; `202` (`Accepted`) with `Location` → register as async with polling; default → sync.
   - **Verify**: Three test scenarios
 
 ### 4.0 Approval Strength Mapping
 
-- [ ] 4.1 `approval_strength` configuration (OA-008)
+- [x] 4.1 `approval_strength` configuration (OA-008)
   - **File**: `src/asap/adapters/openapi/approval.py`
   - **What**: Accept dict by HTTP method `{"GET": "session", "POST": "webauthn", "DELETE": "webauthn"}` OR by operationId. Wire into capability registration so write operations require fresh-session/WebAuthn (per v2.2.1).
   - **Verify**: Unit tests; integration test that `DELETE` requires WebAuthn assertion when `agent_controls_browser=True`
 
 ### 5.0 Reference Example & Docs
 
-- [ ] 5.1 PetStore example
+- [x] 5.1 PetStore example
   - **File**: `examples/openapi_petstore/`
   - **What**: README + `main.py` invoking `create_from_openapi` against PetStore spec, registering capabilities, running an agent that calls `findPetsByStatus`. Include Compliance Harness v2 check.
   - **Verify**: `uv run python examples/openapi_petstore/main.py` succeeds end-to-end
 
-- [ ] 5.2 Documentation
+- [x] 5.2 Documentation
   - **File**: `docs/adapters/openapi.md`
   - **What**: Architecture overview, usage examples, configuration reference, common pitfalls (auth, polymorphism, large specs)
   - **Verify**: Reviewed by another contributor; cross-linked from `docs/index.md`

--- a/engineering/tasks/v2.3.0/tasks-v2.3.0-adoption-multiplier.md
+++ b/engineering/tasks/v2.3.0/tasks-v2.3.0-adoption-multiplier.md
@@ -1,6 +1,6 @@
 # Tasks: v2.3.0 Adoption Multiplier — Sprint Index
 
-**Status: 🟡 PLANNED** — Rescoped 2026-04-17 from "Scale & Registry" after v2.2.0 audit confirmed 120/500 agents (trigger unmet).
+**Status: 🟢 IN PROGRESS** — Rescoped 2026-04-17 from "Scale & Registry" after v2.2.0 audit confirmed 120/500 agents (trigger unmet). **S1 (OpenAPI adapter)** is **complete in-repo** (2026-05-01); S2–S5 and PyPI/npm release remain.
 
 Based on [PRD v2.3 Adoption Multiplier](../../../product/prd/prd-v2.3-scale.md). Each sprint maps to a PR sequence.
 
@@ -16,7 +16,7 @@ Based on [PRD v2.3 Adoption Multiplier](../../../product/prd/prd-v2.3-scale.md).
 
 | Sprint | Focus | PRD Sections | Priority | Status |
 |--------|-------|--------------|----------|--------|
-| **S1** | [OpenAPI Adapter (Python)](./sprint-S1-openapi-adapter.md) | §4.1 (OA-001..011) | P0 | 🟡 |
+| **S1** | [OpenAPI Adapter (Python)](./sprint-S1-openapi-adapter.md) | §4.1 (OA-001..011) | P0 | 🟢 **Done (repo)** — PyPI with `2.3.0` via **S5** |
 | **S2** | [TypeScript Client SDK](./sprint-S2-typescript-sdk.md) | §4.2 (TS-001..011) | P0 | 🟡 |
 | **S3** | [Auto-Registration](./sprint-S3-auto-registration.md) | §4.3 (AUTO-001..007) | P0 | 🟡 |
 | **S4** | [Capability Escalation + ASAP Challenge](./sprint-S4-escalation-challenge.md) | §4.4 (ESC-001..004), §4.5 (CHAL-001..004) | P1/P2 | 🟡 |
@@ -27,28 +27,29 @@ Based on [PRD v2.3 Adoption Multiplier](../../../product/prd/prd-v2.3-scale.md).
 ```
 S1 (OpenAPI Adapter ─ Python) ──► S4 (Escalation + Challenge) ──► S5 (Release)
                                               ▲
-S2 (TypeScript SDK) ─────────────────────────┤
+S2 (TypeScript SDK) ──────────────────────────┤
                                               │
-S3 (Auto-Registration) ──────────────────────┘
+S3 (Auto-Registration) ───────────────────────┘
 ```
 
 S1, S2, and S3 are independent and can run in parallel with three contributors. S4 depends on S1 (escalation flow used by OpenAPI-derived agents) and on S2 (escalation client method needed in TS SDK). S5 depends on S1–S4.
 
 ## Definition of Done (v2.3.0)
 
-- [ ] **OpenAPI Adapter**: Python package `asap.adapters.openapi` published; reference example onboards a public OpenAPI spec end-to-end
+- [x] **OpenAPI Adapter (repo)**: `asap.adapters.openapi` implemented (`create_from_openapi`, PetStore example `examples/openapi_petstore/`, docs `docs/adapters/openapi.md`) — see [sprint-S1-openapi-adapter.md](./sprint-S1-openapi-adapter.md). *Acceptance: sprint checklist complete; release packaging tracked separately.*
+- [ ] **OpenAPI Adapter (release)**: `asap-protocol==2.3.0` on **PyPI** includes the `[openapi]` extra and adapter surface (closes when S5 ships)
 - [ ] **TypeScript SDK**: `@asap-protocol/client@2.3.0` published to npm with Vercel AI / OpenAI / Anthropic adapters
 - [ ] **Auto-Registration**: `POST /registry/agents` endpoint live; bot-driven PR flow merging into `registry.json` automatically when Compliance Harness v2 passes
 - [ ] **Capability Escalation**: `POST /asap/agent/request-capability` operational with approval flow integration
 - [ ] **ASAP Challenge**: `WWW-Authenticate: ASAP discovery=...` middleware shipped; client recognizes scheme
-- [ ] Test coverage ≥90% for new modules (Python and TS)
+- [ ] Test coverage ≥90% for new modules (Python and TS) — *OpenAPI package: bring `src/asap/adapters/openapi/` to ≥90% before release or document exception; see [sprint-S1-openapi-adapter.md](./sprint-S1-openapi-adapter.md) acceptance block.*
 - [ ] `uv run mypy src/` and `uv run ruff check .` pass
 - [ ] TS SDK passes `pnpm test`, `pnpm lint`, `pnpm typecheck`
 - [ ] E2E test: spec URL → onboarded agent → invocable capability with constraints
 - [ ] `apps/web` landing page, feature cards, and docs links updated to announce the backend/protocol improvements
 - [ ] Public docs route users from the homepage to GitHub documentation for OpenAPI, TypeScript SDK, and adapter examples
 - [ ] CHANGELOG.md updated under `[2.3.0]`
-- [ ] `asap-protocol==2.3.0` published to PyPI
+- [ ] `asap-protocol==2.3.0` published to PyPI *(full package; confirms **OpenAPI Adapter (release)** above)*
 - [ ] `@asap-protocol/client@2.3.0` published to npm
 - [ ] Tag `v2.3.0` on `main` + GitHub Release notes
 - [ ] Docker `ghcr.io/adriannoes/asap-protocol:v2.3.0` and `:latest` rebuilt

--- a/examples/openapi_petstore/README.md
+++ b/examples/openapi_petstore/README.md
@@ -1,0 +1,36 @@
+# OpenAPI PetStore reference example
+
+Runnable demo: builds an ASAP app from a **PetStore-shaped** OpenAPI fragment (bundled under `openapi-fragment.json`), runs **Compliance Harness v2** (expects score **1.0**), and invokes `findPetsByStatus` in-process. By default the upstream API is **mocked** so the script works offline and is not affected when the public PetStore service misbehaves.
+
+## Prerequisites
+
+- Python 3.13+
+- `uv`
+
+Install the OpenAPI extra:
+
+```bash
+uv sync --extra openapi
+```
+
+## Run (default: bundled fragment + mock upstream)
+
+From the repository root:
+
+```bash
+uv run python examples/openapi_petstore/main.py
+```
+
+## Live public PetStore spec (optional)
+
+To load the real OpenAPI document from the network and call the live host (requires connectivity; the remote API may return errors):
+
+```bash
+uv run python examples/openapi_petstore/main.py --live
+```
+
+Equivalent: `ASAP_PETSTORE_LIVE=1`.
+
+## Notes
+
+- **Identity / approval**: This example does not configure `FreshSessionConfig` or `approval_strength` on the app; see `src/asap/adapters/openapi/approval.py` for OA-008 wiring in production.

--- a/examples/openapi_petstore/main.py
+++ b/examples/openapi_petstore/main.py
@@ -1,0 +1,133 @@
+"""PetStore OpenAPI → ASAP adapter demo (Compliance Harness v2 + findPetsByStatus)."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+from httpx import ASGITransport
+
+from asap.adapters.openapi import PETSTORE_OPENAPI_URL, OpenAPIAdapterBundle, create_from_openapi
+from asap.economics.audit import InMemoryAuditStore
+from asap.models.enums import TaskStatus
+from asap.models.envelope import Envelope
+from asap.models.payloads import TaskRequest, TaskResponse
+from asap.testing.compliance import run_compliance_harness_v2
+from asap.transport.client import ASAPClient
+from asap.transport.rate_limit import create_test_limiter
+from asap.transport.server import create_app
+
+_FRAGMENT = Path(__file__).resolve().parent / "openapi-fragment.json"
+
+
+def _pets_preview(result: dict[str, Any] | None) -> str:
+    if result is None:
+        return "(no result)"
+    for key in ("value", "data", "body", "items", "_json"):
+        v = result.get(key)
+        if isinstance(v, list):
+            return f"{len(v)} item(s) via {key!r}"
+    for _k, v in result.items():
+        if isinstance(v, list):
+            return f"{len(v)} item(s) in list field"
+    return str(result)[:200]
+
+
+def _mock_upstream(request: httpx.Request) -> httpx.Response:
+    if request.method == "GET" and "findByStatus" in request.url.path:
+        return httpx.Response(
+            200,
+            json=[{"id": 1, "name": "DemoPet", "status": "available"}],
+        )
+    return httpx.Response(404, text=f"unexpected request: {request.method} {request.url}")
+
+
+async def _run(*, live_petstore: bool) -> None:
+    timeout = 60.0
+    if live_petstore:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as http:
+            bundle = await create_from_openapi(
+                spec_url=PETSTORE_OPENAPI_URL,
+                http_client=http,
+                default_capabilities="GET",
+                manifest_id="urn:asap:agent:openapi-petstore-example",
+                asap_endpoint="http://127.0.0.1:8000/asap",
+            )
+            await _harness_and_call(bundle)
+        return
+
+    transport = httpx.MockTransport(_mock_upstream)
+    async with httpx.AsyncClient(transport=transport, timeout=timeout) as http:
+        bundle = await create_from_openapi(
+            spec_path=_FRAGMENT,
+            http_client=http,
+            default_capabilities="GET",
+            manifest_id="urn:asap:agent:openapi-petstore-example",
+            asap_endpoint="http://127.0.0.1:8000/asap",
+        )
+        await _harness_and_call(bundle)
+
+
+async def _harness_and_call(bundle: OpenAPIAdapterBundle) -> None:
+    audit = InMemoryAuditStore()
+    app = create_app(
+        bundle.manifest,
+        bundle.registry,
+        audit_store=audit,
+        rate_limit="999999/minute",
+    )
+    app.state.limiter = create_test_limiter()
+
+    report = await run_compliance_harness_v2(app)
+    print(report.summary)
+    if report.score < 1.0:
+        failed = [c for c in report.checks if not c.passed]
+        detail = [(c.name, c.message) for c in failed]
+        msg = f"Compliance Harness v2 score {report.score}: {detail}"
+        raise SystemExit(msg)
+
+    inproc = ASGITransport(app=app)
+    envelope = Envelope(
+        asap_version="0.1",
+        sender="urn:asap:agent:petstore-example-client",
+        recipient=bundle.manifest.id,
+        payload_type="task.request",
+        payload=TaskRequest(
+            conversation_id="conv-petstore-example",
+            skill_id="findPetsByStatus",
+            input={"status": "available"},
+        ).model_dump(),
+    )
+    async with ASAPClient(
+        "http://testserver",
+        transport=inproc,
+        require_https=False,
+    ) as client:
+        response = await client.send(envelope)
+
+    if response.payload_type != "task.response":
+        raise SystemExit(f"unexpected payload_type: {response.payload_type!r}")
+    task_response = TaskResponse.model_validate(response.payload_dict)
+    if task_response.status != TaskStatus.COMPLETED:
+        raise SystemExit(f"task not completed: {task_response.status}")
+    print("findPetsByStatus:", _pets_preview(task_response.result))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="OpenAPI PetStore ASAP demo")
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Load spec from petstore3.swagger.io (real network; remote API may error)",
+    )
+    args = parser.parse_args()
+    live = args.live or os.environ.get("ASAP_PETSTORE_LIVE") == "1"
+    asyncio.run(_run(live_petstore=live))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/openapi_petstore/openapi-fragment.json
+++ b/examples/openapi_petstore/openapi-fragment.json
@@ -1,0 +1,50 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "PetStore fragment (demo)",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://petstore.mock/api/v3"
+    }
+  ],
+  "paths": {
+    "/pet/findByStatus": {
+      "get": {
+        "operationId": "findPetsByStatus",
+        "summary": "Find pets by status",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["available", "pending", "sold"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer", "format": "int64" },
+                      "name": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/product/decision-records/05-product-strategy.md
+++ b/product/decision-records/05-product-strategy.md
@@ -388,7 +388,7 @@ The ASAP Protocol ecosystem now spans two deployed applications:
 
 | Application | Vercel Project | Current URL |
 |-------------|---------------|-------------|
-| ASAP Protocol (Web App) | `asap-protocol` | `asap-protocol.vercel.app` |
+| ASAP Protocol (Web App) | `asap-protocol` | `https://asap-protocol.com` (canonical; `asap-protocol.vercel.app` remains as Vercel host) |
 | Agent Builder (agentic-orchestration) | `v0-agent-kit` | `open-agentic-flow.vercel.app` |
 
 These are separate Next.js apps on separate Vercel deployments. The cross-platform integration (see `prd-cross-platform-integration-asap.md` and `prd-cross-platform-integration-agentic.md`) introduces bidirectional navigation and shared authentication between them.
@@ -431,19 +431,19 @@ The question: should we acquire a custom domain now, or defer?
 
 ### Expert Assessment
 
-Acquiring a domain is important for branding and SSO but is not a blocker for the integration. The integration is designed with environment variables for all cross-app URLs, making domain migration a configuration change (not a code change). Deferring the domain purchase is the pragmatic choice: it avoids premature optimization and allows the team to validate the integration UX before investing in branding.
+Acquiring a domain is important for branding and SSO but is not a blocker for the integration. The integration is designed with environment variables for all cross-app URLs, making domain migration a configuration change (not a code change). The ASAP Protocol marketplace now uses **`https://asap-protocol.com`** as the canonical production URL; a paired custom domain for Agent Builder (`open-agentic-flow.vercel.app` today) may follow later under the same env-var-first pattern.
 
 ### Decision
 
 > [!IMPORTANT]
-> **ADR-26**: The cross-platform integration proceeds with **Vercel subdomains** (`asap-protocol.vercel.app` and `open-agentic-flow.vercel.app`). Custom domain acquisition is **deferred** to a future milestone.
+> **ADR-26**: Cross-platform URLs use environment variables (`NEXT_PUBLIC_*`). The ASAP Protocol marketplace **production** URL is **`https://asap-protocol.com`** (canonical). The Agent Builder remains on **`open-agentic-flow.vercel.app`** until a paired custom domain is acquired; **`asap-protocol.vercel.app`** remains available as the Vercel deployment hostname (typically redirecting to the custom domain).
 >
-> **Rationale**: The integration uses environment variables for all cross-app URLs, ensuring zero-code-change migration when a domain is purchased. SSO works via shared GitHub OAuth App (1-click sign-in). The current priority is validating the integration UX, not branding.
+> **Rationale**: The integration uses environment variables for all cross-app URLs, enabling domain changes without hardcoding. SSO works via shared GitHub OAuth App (1-click sign-in); OAuth callback URLs MUST include **`https://asap-protocol.com/api/auth/callback/github`** alongside any legacy `.vercel.app` entries while redirects are phased out.
 >
 > **Constraints**:
 > - All cross-app URLs MUST use environment variables (never hardcoded).
-> - The shared GitHub OAuth App MUST have both callback URLs registered.
-> - When a domain is acquired, follow the Migration Checklist above.
+> - The shared GitHub OAuth App MUST register production callback URLs (including **`https://asap-protocol.com/api/auth/callback/github`**) plus any transitional `.vercel.app` URLs as needed.
+> - For further domain changes (e.g., Agent Builder), follow the Migration Checklist above.
 >
 > **Recommended Domain TLDs** (for future reference): `.dev`, `.app`, `.io`, `.protocol`
 >

--- a/product/prd/prd-cross-platform-integration-agentic.md
+++ b/product/prd/prd-cross-platform-integration-agentic.md
@@ -26,7 +26,7 @@ The Agent Builder is a visual drag-and-drop platform for creating, configuring, 
 
 | Application | Vercel Project | Production URL | Auth Stack |
 |-------------|---------------|----------------|------------|
-| ASAP Protocol | `asap-protocol` | `asap-protocol.vercel.app` | NextAuth v5 + GitHub OAuth |
+| ASAP Protocol | `asap-protocol` | `https://asap-protocol.com` | NextAuth v5 + GitHub OAuth |
 | Agent Builder | `v0-agent-kit` | `open-agentic-flow.vercel.app` | NextAuth v5 + GitHub OAuth + Supabase (optional) |
 
 ### 1.3 Current State (What Exists Today)
@@ -263,7 +263,7 @@ callbacks: {
 
 | Variable | Default Value | Purpose |
 |----------|--------------|---------|
-| `NEXT_PUBLIC_ASAP_PROTOCOL_URL` | `https://asap-protocol.vercel.app` | Back-navigation links |
+| `NEXT_PUBLIC_ASAP_PROTOCOL_URL` | `https://asap-protocol.com` | Back-navigation links |
 | `NEXT_PUBLIC_REGISTRY_URL` | `https://raw.githubusercontent.com/adriannoes/asap-protocol/main/registry.json` | Registry data source |
 | `NEXT_PUBLIC_REVOKED_URL` | `https://raw.githubusercontent.com/adriannoes/asap-protocol/main/revoked_agents.json` | Revoked agents list |
 | `AUTH_GITHUB_ID` | (shared with ASAP Protocol) | SSO |
@@ -503,7 +503,7 @@ This repo (agentic-orchestration) MUST be implemented and deployed **before** as
 #### Step 0: GitHub OAuth App (both repos — config only)
 1. Go to `github.com/settings/developers` → select (or create) the OAuth App.
 2. Add **both** callback URLs:
-   - `https://asap-protocol.vercel.app/api/auth/callback/github`
+   - `https://asap-protocol.com/api/auth/callback/github`
    - `https://open-agentic-flow.vercel.app/api/auth/callback/github`
 3. Copy the Client ID and Client Secret.
 4. In Vercel dashboard, set `AUTH_GITHUB_ID` and `AUTH_GITHUB_SECRET` on **both** projects with the same values.

--- a/product/prd/prd-cross-platform-integration-asap.md
+++ b/product/prd/prd-cross-platform-integration-asap.md
@@ -26,7 +26,7 @@ The ASAP Protocol and Agent Builder are deployed as separate Next.js application
 
 | Application | Vercel Project | Production URL | Auth Stack |
 |-------------|---------------|----------------|------------|
-| ASAP Protocol | `asap-protocol` | `asap-protocol.vercel.app` | NextAuth v5 + GitHub OAuth |
+| ASAP Protocol | `asap-protocol` | `https://asap-protocol.com` | NextAuth v5 + GitHub OAuth |
 | Agent Builder | `v0-agent-kit` | `open-agentic-flow.vercel.app` | NextAuth v5 + GitHub OAuth + Supabase (optional) |
 
 Both apps share the **same auth provider** (GitHub OAuth via NextAuth v5), which is the foundation for the SSO strategy.
@@ -134,7 +134,7 @@ Both applications MUST use the **same GitHub OAuth App** credentials:
 - Same `AUTH_GITHUB_ID` (Client ID)
 - Same `AUTH_GITHUB_SECRET` (Client Secret)
 - The GitHub OAuth App must have **both** callback URLs registered:
-  - `https://asap-protocol.vercel.app/api/auth/callback/github`
+  - `https://asap-protocol.com/api/auth/callback/github`
   - `https://open-agentic-flow.vercel.app/api/auth/callback/github`
 
 **Vercel Configuration**:
@@ -322,7 +322,7 @@ The agentic-orchestration MUST be implemented and deployed **before** asap-proto
 #### Step 0: GitHub OAuth App (both repos — config only)
 1. Go to `github.com/settings/developers` → select (or create) the OAuth App.
 2. Add **both** callback URLs:
-   - `https://asap-protocol.vercel.app/api/auth/callback/github`
+   - `https://asap-protocol.com/api/auth/callback/github`
    - `https://open-agentic-flow.vercel.app/api/auth/callback/github`
 3. Copy the Client ID and Client Secret.
 4. In Vercel dashboard, set `AUTH_GITHUB_ID` and `AUTH_GITHUB_SECRET` on **both** projects with the same values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,10 @@ pydanticai = [
 openclaw = [
     "openclaw-sdk>=2.0",
 ]
+# OpenAPI 3.x spec parsing for asap.adapters.openapi (Sprint S1).
+openapi = [
+    "openapi-pydantic>=0.5",
+]
 
 [project.urls]
 Homepage = "https://github.com/adriannoes/asap-protocol"
@@ -185,6 +189,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "scripts/**" = ["T201"]
 "src/asap/examples/**" = ["T201", "ASYNC210"]
+"examples/**" = ["T201"]
 "benchmarks/**" = ["T201"]
 "tests/**" = ["B008"]
 "src/asap/transport/usage_api.py" = ["B008"]

--- a/registry.json
+++ b/registry.json
@@ -22,7 +22,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -74,7 +74,7 @@
         "other",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -99,7 +99,7 @@
         "search",
         "research"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -124,7 +124,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -149,7 +149,7 @@
         "data",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -202,7 +202,7 @@
         "qa",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -227,7 +227,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "Custom",
@@ -252,7 +252,7 @@
         "code-review",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -278,7 +278,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -331,7 +331,7 @@
         "research",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -355,7 +355,7 @@
         "analyze",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -380,7 +380,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -406,7 +406,7 @@
         "productivity",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -458,7 +458,7 @@
         "documentation",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -484,7 +484,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -508,7 +508,7 @@
         "summarize",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -534,7 +534,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -587,7 +587,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -611,7 +611,7 @@
         "synthesize",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -637,7 +637,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -662,7 +662,7 @@
         "coding",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -715,7 +715,7 @@
         "code-review",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -740,7 +740,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "Custom",
@@ -764,7 +764,7 @@
         "translate",
         "other"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -791,7 +791,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -843,7 +843,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -868,7 +868,7 @@
         "planning",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -893,7 +893,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -918,7 +918,7 @@
         "productivity",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -971,7 +971,7 @@
         "summarize",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -996,7 +996,7 @@
         "other",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -1021,7 +1021,7 @@
         "search",
         "research"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1047,7 +1047,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1100,7 +1100,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1124,7 +1124,7 @@
         "qa",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -1149,7 +1149,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1175,7 +1175,7 @@
         "coding",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1227,7 +1227,7 @@
         "translate",
         "other"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1253,7 +1253,7 @@
         "research",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "Custom",
@@ -1277,7 +1277,7 @@
         "analyze",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1303,7 +1303,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1356,7 +1356,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1380,7 +1380,7 @@
         "documentation",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -1406,7 +1406,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1431,7 +1431,7 @@
         "productivity",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1484,7 +1484,7 @@
         "search",
         "research"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1509,7 +1509,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -1533,7 +1533,7 @@
         "synthesize",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1560,7 +1560,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1612,7 +1612,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1637,7 +1637,7 @@
         "code-review",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -1662,7 +1662,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1687,7 +1687,7 @@
         "other",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1740,7 +1740,7 @@
         "analyze",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1765,7 +1765,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "Custom",
@@ -1790,7 +1790,7 @@
         "planning",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1816,7 +1816,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1869,7 +1869,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -1893,7 +1893,7 @@
         "summarize",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -1918,7 +1918,7 @@
         "other",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -1944,7 +1944,7 @@
         "research",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -1996,7 +1996,7 @@
         "synthesize",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2022,7 +2022,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -2046,7 +2046,7 @@
         "qa",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2072,7 +2072,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2125,7 +2125,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2149,7 +2149,7 @@
         "translate",
         "other"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -2175,7 +2175,7 @@
         "research",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2200,7 +2200,7 @@
         "data",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2253,7 +2253,7 @@
         "planning",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2278,7 +2278,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "Custom",
@@ -2302,7 +2302,7 @@
         "documentation",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2329,7 +2329,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2381,7 +2381,7 @@
         "other",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2406,7 +2406,7 @@
         "search",
         "research"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -2431,7 +2431,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2456,7 +2456,7 @@
         "data",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2509,7 +2509,7 @@
         "qa",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2534,7 +2534,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -2559,7 +2559,7 @@
         "code-review",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2585,7 +2585,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2638,7 +2638,7 @@
         "research",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2662,7 +2662,7 @@
         "analyze",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -2687,7 +2687,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2713,7 +2713,7 @@
         "productivity",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2765,7 +2765,7 @@
         "documentation",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2791,7 +2791,7 @@
         "coding",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "Custom",
@@ -2815,7 +2815,7 @@
         "summarize",
         "productivity"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2841,7 +2841,7 @@
         "enterprise",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -2894,7 +2894,7 @@
         "data",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": "https://github.com/asap-protocol/examples",
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -2918,7 +2918,7 @@
         "synthesize",
         "data"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -2944,7 +2944,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",
@@ -2969,7 +2969,7 @@
         "coding",
         "verified"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "1.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "CrewAI",
@@ -3022,7 +3022,7 @@
         "code-review",
         "coding"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.0.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "AutoGen",
@@ -3047,7 +3047,7 @@
         "productivity",
         "enterprise"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.1.0",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "Custom",
@@ -3071,7 +3071,7 @@
         "translate",
         "other"
       ],
-      "asap_version": "1.1.0",
+      "asap_version": "2.2.1",
       "repository_url": null,
       "documentation_url": null,
       "built_with": "PydanticAI",

--- a/scripts/diversify_registry_asap_versions.py
+++ b/scripts/diversify_registry_asap_versions.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Assign rotated asap_version to each Lite Registry agent for realistic ecosystem demos.
+
+Reads registry.json (wrapped `{agents: [...]}` or bare array), sets asap_version per
+agent index using PROTOCOL_VERSIONS cycle, writes repo root registry.json and
+apps/web/public/registry.json identically.
+
+Keep PROTOCOL_VERSIONS in sync with apps/web/src/lib/protocol-versions.ts.
+
+Usage (repo root): uv run python scripts/diversify_registry_asap_versions.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import cast
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PROTOCOL_VERSIONS: tuple[str, ...] = ("1.0.0", "1.1.0", "2.0.0", "2.1.0", "2.2.1")
+
+
+def _agents_payload(data: object) -> tuple[list[dict[str, object]], bool]:
+    """Return (agents_list, was_wrapped_dict)."""
+    if isinstance(data, list):
+        return cast("list[dict[str, object]]", data), False
+    if isinstance(data, dict) and "agents" in data:
+        inner = data["agents"]
+        if isinstance(inner, list):
+            return cast("list[dict[str, object]]", inner), True
+    raise ValueError("registry JSON must be an array or an object with key 'agents'")
+
+
+def diversify_agents(agents: list[dict[str, object]]) -> None:
+    n = len(PROTOCOL_VERSIONS)
+    for i, agent in enumerate(agents):
+        agent["asap_version"] = PROTOCOL_VERSIONS[i % n]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print summary only; do not write files.",
+    )
+    args = parser.parse_args()
+
+    registry_path = _REPO_ROOT / "registry.json"
+    web_public_path = _REPO_ROOT / "apps" / "web" / "public" / "registry.json"
+
+    if not registry_path.is_file():
+        print(f"Missing {registry_path}", file=sys.stderr)
+        return 1
+
+    raw = json.loads(registry_path.read_text(encoding="utf-8"))
+    agents, wrapped = _agents_payload(raw)
+    diversify_agents(agents)
+
+    out_main = registry_path
+    out_web = web_public_path
+
+    if args.dry_run:
+        sample = [(a.get("id"), a.get("asap_version")) for a in agents[:8]]
+        print(f"Would write {len(agents)} agents; sample: {sample}")
+        return 0
+
+    payload: dict[str, object] | list[dict[str, object]]
+    if wrapped and isinstance(raw, dict):
+        raw["agents"] = agents
+        payload = cast("dict[str, object]", raw)
+    else:
+        payload = agents
+
+    text = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+    out_main.write_text(text, encoding="utf-8")
+    out_web.parent.mkdir(parents=True, exist_ok=True)
+    out_web.write_text(text, encoding="utf-8")
+    print(f"Wrote {len(agents)} agents to {out_main} and {out_web}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seed_registry.py
+++ b/scripts/seed_registry.py
@@ -36,6 +36,9 @@ SKILLS_POOL = [
 ]
 FRAMEWORKS = ["CrewAI", "LangChain", "AutoGen", "Custom", "PydanticAI"]
 
+# Rotated per agent index; keep in sync with scripts/diversify_registry_asap_versions.py
+PROTOCOL_VERSIONS = ("1.0.0", "1.1.0", "2.0.0", "2.1.0", "2.2.1")
+
 # New realistic name components
 NAME_ADJECTIVES = [
     "Global",
@@ -119,7 +122,7 @@ def build_seed_agents(count: int) -> list[RegistryEntry]:
             skills=skills,
             category=category,
             tags=tags,
-            asap_version="1.1.0",
+            asap_version=PROTOCOL_VERSIONS[i % len(PROTOCOL_VERSIONS)],
             repository_url="https://github.com/asap-protocol/examples" if i % 4 == 0 else None,
             documentation_url=None,
             built_with=FRAMEWORKS[i % len(FRAMEWORKS)],

--- a/src/asap/__init__.py
+++ b/src/asap/__init__.py
@@ -4,6 +4,19 @@ A streamlined, scalable, asynchronous protocol for agent-to-agent communication
 and task coordination.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 __version__ = "2.2.1"
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "create_from_openapi"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "create_from_openapi":
+        from asap.adapters.openapi import create_from_openapi as exported
+
+        return exported
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/src/asap/adapters/__init__.py
+++ b/src/asap/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""ASAP protocol adapters (third-party wire formats → ASAP capabilities)."""

--- a/src/asap/adapters/openapi/__init__.py
+++ b/src/asap/adapters/openapi/__init__.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+
 from asap.adapters.openapi.factory import (
     PETSTORE_OPENAPI_URL,
     OpenAPIAdapterBundle,
     create_from_openapi,
 )
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "PETSTORE_OPENAPI_URL",

--- a/src/asap/adapters/openapi/__init__.py
+++ b/src/asap/adapters/openapi/__init__.py
@@ -1,0 +1,15 @@
+"""OpenAPI 3.x → ASAP adapter (Sprint S1)."""
+
+from __future__ import annotations
+
+from asap.adapters.openapi.factory import (
+    PETSTORE_OPENAPI_URL,
+    OpenAPIAdapterBundle,
+    create_from_openapi,
+)
+
+__all__ = [
+    "PETSTORE_OPENAPI_URL",
+    "OpenAPIAdapterBundle",
+    "create_from_openapi",
+]

--- a/src/asap/adapters/openapi/approval.py
+++ b/src/asap/adapters/openapi/approval.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from typing import Literal, cast
 
 from asap.adapters.openapi.capability_mapper import OpenAPICapability
+
+logger = logging.getLogger(__name__)
 
 ApprovalStrength = Literal["session", "webauthn"]
 
@@ -92,6 +95,7 @@ def collect_webauthn_required_capability_names(
             if name not in seen:
                 seen.add(name)
                 ordered.append(name)
+    logger.debug("collect_webauthn_required_capability_names: %s name(s)", len(ordered))
     return ordered
 
 

--- a/src/asap/adapters/openapi/approval.py
+++ b/src/asap/adapters/openapi/approval.py
@@ -1,0 +1,103 @@
+"""Map OpenAPI operations to ASAP approval strength (OA-008, v2.2.1 self-auth)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Literal, cast
+
+from asap.adapters.openapi.capability_mapper import OpenAPICapability
+
+ApprovalStrength = Literal["session", "webauthn"]
+
+_HTTP_VERBS_FROZEN: frozenset[str] = frozenset(
+    ("GET", "PUT", "POST", "DELETE", "OPTIONS", "HEAD", "PATCH", "TRACE"),
+)
+_VALID_STRENGTH: frozenset[str] = frozenset(("session", "webauthn"))
+
+
+def normalize_approval_strength_map(
+    mapping: Mapping[str, str],
+) -> dict[str, ApprovalStrength]:
+    """Normalize user map keys (HTTP verbs uppercased) and validate strength values.
+
+    Args:
+        mapping: Keys are HTTP methods (any case) or OpenAPI ``operationId`` strings
+            (case-sensitive). Values must be ``\"session\"`` or ``\"webauthn\"``.
+
+    Returns:
+        A normalized dict suitable for :func:`resolve_approval_strength`.
+
+    Raises:
+        ValueError: If any strength value is invalid.
+    """
+    out: dict[str, ApprovalStrength] = {}
+    for raw_key, raw_val in mapping.items():
+        if not isinstance(raw_key, str) or not raw_key.strip():
+            continue
+        key = raw_key.strip()
+        norm_key = key.upper() if key.strip().upper() in _HTTP_VERBS_FROZEN else key.strip()
+        if not isinstance(raw_val, str) or not raw_val.strip():
+            msg = f"approval_strength value for {raw_key!r} must be a non-empty string"
+            raise ValueError(msg)
+        val = raw_val.strip().lower()
+        if val not in _VALID_STRENGTH:
+            msg = (
+                f"Invalid approval_strength {raw_val!r} for key {raw_key!r}; "
+                "expected 'session' or 'webauthn'"
+            )
+            raise ValueError(msg)
+        out[norm_key] = cast("ApprovalStrength", val)
+    return out
+
+
+def resolve_approval_strength(
+    *,
+    http_method: str,
+    operation_id: str | None,
+    mapping: Mapping[str, ApprovalStrength],
+) -> ApprovalStrength | None:
+    """Resolve strength for one operation.
+
+    Precedence:
+        1. Exact ``operationId`` key in *mapping* when *operation_id* is set.
+        2. HTTP method (case-insensitive, compared as uppercase).
+    """
+    if operation_id is not None and operation_id in mapping:
+        return mapping[operation_id]
+    verb = http_method.strip().upper()
+    return mapping.get(verb)
+
+
+def collect_webauthn_required_capability_names(
+    capabilities: Sequence[OpenAPICapability],
+    approval_strength: Mapping[str, str],
+) -> list[str]:
+    """Capability names that must appear in ``FreshSessionConfig.require_webauthn_for``.
+
+    Args:
+        capabilities: Mapped OpenAPI operations from :func:`~.capability_mapper.map_openapi_to_capabilities`.
+        approval_strength: Raw mapping (normalized by :func:`normalize_approval_strength_map`).
+    """
+    normalized = normalize_approval_strength_map(approval_strength)
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for cap in capabilities:
+        strength = resolve_approval_strength(
+            http_method=cap.http_method,
+            operation_id=cap.operation_id,
+            mapping=normalized,
+        )
+        if strength == "webauthn":
+            name = cap.skill.id
+            if name not in seen:
+                seen.add(name)
+                ordered.append(name)
+    return ordered
+
+
+__all__ = [
+    "ApprovalStrength",
+    "collect_webauthn_required_capability_names",
+    "normalize_approval_strength_map",
+    "resolve_approval_strength",
+]

--- a/src/asap/adapters/openapi/capability_mapper.py
+++ b/src/asap/adapters/openapi/capability_mapper.py
@@ -1,0 +1,484 @@
+"""Map OpenAPI 3.x operations to ASAP :class:`~asap.models.entities.Skill` definitions."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from enum import Enum, StrEnum
+from typing import Any, Literal, Protocol, TypeAlias, cast
+
+from asap.adapters.openapi.spec_loader import OpenAPIDocument
+from asap.models.entities import Skill
+
+_HTTP_METHODS: tuple[str, ...] = (
+    "get",
+    "put",
+    "post",
+    "delete",
+    "options",
+    "head",
+    "patch",
+    "trace",
+)
+
+
+class OpenAPIExecutionKind(StrEnum):
+    """How upstream responses should be executed (OA-010)."""
+
+    SYNC = "sync"
+    STREAMING = "streaming"
+    ASYNC_POLLING = "async_polling"
+
+
+class _SupportsRef(Protocol):
+    ref: str
+
+
+def _is_reference(obj: object) -> bool:
+    """Detect Reference models across openapi-pydantic v3.0 / v3.1 types."""
+    return type(obj).__name__ == "Reference" and hasattr(obj, "ref")
+
+
+def _ref_fragment(ref: str, prefix: str) -> str | None:
+    if not ref.startswith(prefix):
+        return None
+    return ref.removeprefix(prefix)
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAPICapability:
+    """One ASAP skill derived from an OpenAPI operation plus HTTP routing metadata."""
+
+    skill: Skill
+    http_method: str
+    """Lowercase HTTP verb (e.g. ``get``, ``post``)."""
+    path_template: str
+    """OpenAPI path template (e.g. ``/pets/{petId}``)."""
+    execution_kind: OpenAPIExecutionKind
+    """Derived from response media types and status codes (``202`` + ``Location``, SSE)."""
+    operation_id: str | None = None
+    """Raw ``operationId`` from the spec when present; used for approval-strength lookup."""
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAPIOperationContext:
+    """OpenAPI operation identity exposed to :func:`map_openapi_to_capabilities` filters."""
+
+    http_method: str
+    """Lowercase HTTP verb (e.g. ``get``, ``head``)."""
+    path_template: str
+    capability_name: str
+    """Resolved ASAP capability id (``operationId`` or method/path fallback)."""
+    operation_id: str | None
+    """Raw ``operationId`` from the spec, if present and non-empty."""
+    openapi_operation: object
+    """Underlying *openapi-pydantic* operation model for advanced filtering."""
+
+
+DefaultCapabilitiesFilter: TypeAlias = (
+    Literal["all"] | str | Sequence[str] | Callable[[OpenAPIOperationContext], bool]
+)
+
+
+def _predicate_from_default_capabilities(
+    spec: DefaultCapabilitiesFilter,
+) -> Callable[[OpenAPIOperationContext], bool]:
+    """Turn *spec* into a predicate applied while scanning operations."""
+    if spec == "all":
+        return lambda _ctx: True
+    if callable(spec):
+        return spec
+    if isinstance(spec, str):
+        verb = spec.strip().lower()
+        return lambda ctx: ctx.http_method == verb
+    if isinstance(spec, Sequence) and not isinstance(spec, (str, bytes)):
+        verbs = {str(m).strip().lower() for m in spec}
+        return lambda ctx: ctx.http_method in verbs
+    raise TypeError(
+        "default_capabilities must be 'all', an HTTP method string, a sequence of methods, "
+        f"or a callable; got {type(spec)!r}.",
+    )
+
+
+class _SchemaResolver:
+    """Resolve ``#/components/schemas/*`` references into inlined JSON Schema dicts."""
+
+    def __init__(self, raw_by_name: dict[str, dict[str, Any]]) -> None:
+        self._raw_by_name = raw_by_name
+
+    @classmethod
+    def from_components(cls, components: object | None) -> _SchemaResolver:
+        if components is None:
+            return cls({})
+        schemas = getattr(components, "schemas", None)
+        if not schemas:
+            return cls({})
+        raw: dict[str, dict[str, Any]] = {}
+        for name, schema_obj in cast(dict[str, Any], schemas).items():
+            raw[name] = schema_obj.model_dump(mode="json", by_alias=True, exclude_none=True)
+        return cls(raw)
+
+    def expand_refs(self, node: Any, seen: frozenset[str]) -> Any:
+        """Inline internal component schema refs; leave unknown or cyclic ``$ref`` as-is."""
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str):
+                name = _ref_fragment(ref, "#/components/schemas/")
+                if name is not None and name in self._raw_by_name:
+                    if name in seen:
+                        return {"$ref": ref}
+                    base = self._raw_by_name[name]
+                    return self.expand_refs(base, seen | {name})
+            return {k: self.expand_refs(v, seen) for k, v in node.items()}
+        if isinstance(node, list):
+            return [self.expand_refs(item, seen) for item in node]
+        return node
+
+    def materialize(self, schema_or_ref: object | None) -> dict[str, Any] | None:
+        if schema_or_ref is None:
+            return None
+        if _is_reference(schema_or_ref):
+            ref = cast(_SupportsRef, schema_or_ref).ref
+            name = _ref_fragment(ref, "#/components/schemas/")
+            if name is None or name not in self._raw_by_name:
+                return {"$ref": ref}
+            return cast(
+                dict[str, Any],
+                self.expand_refs(self._raw_by_name[name], frozenset({name})),
+            )
+        model_dump = getattr(schema_or_ref, "model_dump", None)
+        if callable(model_dump):
+            dumped = model_dump(mode="json", by_alias=True, exclude_none=True)
+            return cast(dict[str, Any], self.expand_refs(dumped, frozenset()))
+        return None
+
+
+def _resolve_parameter(
+    param_or_ref: object,
+    components: object | None,
+) -> object | None:
+    if not _is_reference(param_or_ref):
+        return param_or_ref
+    ref = cast(_SupportsRef, param_or_ref).ref
+    key = _ref_fragment(ref, "#/components/parameters/")
+    if key is None or components is None:
+        return None
+    bag = getattr(components, "parameters", None)
+    if not bag or key not in bag:
+        return None
+    target = bag[key]
+    if _is_reference(target):
+        return _resolve_parameter(target, components)
+    return cast(object | None, target)
+
+
+def _param_location_str(loc_raw: Any) -> str:
+    return cast(str, loc_raw.value) if isinstance(loc_raw, Enum) else str(loc_raw)
+
+
+def _merge_parameters(
+    path_item: object,
+    operation: object,
+    components: object | None,
+) -> list[object]:
+    merged: dict[tuple[str, str], object] = {}
+    for entry in getattr(path_item, "parameters", None) or []:
+        resolved = _resolve_parameter(entry, components)
+        if resolved is not None and hasattr(resolved, "name") and hasattr(resolved, "param_in"):
+            r = cast(Any, resolved)
+            name = cast(str, r.name)
+            loc_val = _param_location_str(r.param_in)
+            merged[(name, loc_val)] = resolved
+    for entry in getattr(operation, "parameters", None) or []:
+        resolved = _resolve_parameter(entry, components)
+        if resolved is not None and hasattr(resolved, "name") and hasattr(resolved, "param_in"):
+            r = cast(Any, resolved)
+            name = cast(str, r.name)
+            loc_val = _param_location_str(r.param_in)
+            merged[(name, loc_val)] = resolved
+    return list(merged.values())
+
+
+def _resolve_request_body(obj: object | None, components: object | None) -> object | None:
+    if obj is None:
+        return None
+    if not _is_reference(obj):
+        return obj
+    ref = cast(_SupportsRef, obj).ref
+    key = _ref_fragment(ref, "#/components/requestBodies/")
+    if key is None or components is None:
+        return None
+    bag = getattr(components, "requestBodies", None)
+    if not bag or key not in bag:
+        return None
+    body = bag[key]
+    return _resolve_request_body(body, components)
+
+
+def _resolve_response(obj: object | None, components: object | None) -> object | None:
+    if obj is None:
+        return None
+    if not _is_reference(obj):
+        return obj
+    ref = cast(_SupportsRef, obj).ref
+    key = _ref_fragment(ref, "#/components/responses/")
+    if key is None or components is None:
+        return None
+    bag = getattr(components, "responses", None)
+    if not bag or key not in bag:
+        return None
+    target = bag[key]
+    return _resolve_response(target, components)
+
+
+def _responses_include_event_stream(operation: object, components: object | None) -> bool:
+    responses = getattr(operation, "responses", None)
+    if not responses:
+        return False
+    for _, ref_or_resp in cast(dict[str, Any], responses).items():
+        resp = _resolve_response(ref_or_resp, components)
+        if resp is None:
+            continue
+        content = getattr(resp, "content", None)
+        if not content:
+            continue
+        for media_type in content:
+            if isinstance(media_type, str) and media_type.lower() == "text/event-stream":
+                return True
+    return False
+
+
+def _responses_202_include_location(operation: object, components: object | None) -> bool:
+    responses = getattr(operation, "responses", None)
+    if not responses or "202" not in responses:
+        return False
+    resp = _resolve_response(cast(dict[str, Any], responses)["202"], components)
+    if resp is None:
+        return False
+    headers = getattr(resp, "headers", None)
+    if not headers:
+        return False
+    for name in cast(dict[str, Any], headers):
+        if isinstance(name, str) and name.lower() == "location":
+            return True
+    return False
+
+
+def detect_openapi_execution_kind(
+    operation: object, components: object | None
+) -> OpenAPIExecutionKind:
+    """Classify an operation for async/sync/streaming registration (OA-010)."""
+    if _responses_include_event_stream(operation, components):
+        return OpenAPIExecutionKind.STREAMING
+    if _responses_202_include_location(operation, components):
+        return OpenAPIExecutionKind.ASYNC_POLLING
+    return OpenAPIExecutionKind.SYNC
+
+
+def _json_media_schema(media: object | None, resolver: _SchemaResolver) -> dict[str, Any] | None:
+    if media is None:
+        return None
+    schema_obj = getattr(media, "media_type_schema", None)
+    return resolver.materialize(schema_obj)
+
+
+def _body_json_schema(
+    request_body: object | None, resolver: _SchemaResolver
+) -> dict[str, Any] | None:
+    if request_body is None:
+        return None
+    content = getattr(request_body, "content", None)
+    if not content:
+        return None
+    media = content.get("application/json")
+    if media is None:
+        return None
+    return _json_media_schema(media, resolver)
+
+
+def _success_response_schema(
+    operation: object,
+    components: object | None,
+    resolver: _SchemaResolver,
+) -> dict[str, Any] | None:
+    responses = getattr(operation, "responses", None)
+    if not responses:
+        return None
+    for code in ("200", "201"):
+        if code not in responses:
+            continue
+        resp = _resolve_response(responses[code], components)
+        if resp is None:
+            continue
+        content = getattr(resp, "content", None)
+        if not content:
+            continue
+        media = content.get("application/json")
+        if media is None:
+            continue
+        return _json_media_schema(media, resolver)
+    return None
+
+
+def _parameter_properties(
+    parameters: list[object],
+    resolver: _SchemaResolver,
+) -> tuple[dict[str, Any], list[str]]:
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for model in parameters:
+        m = cast(Any, model)
+        name = cast(str, m.name)
+        schema_obj = m.param_schema
+        if schema_obj is None:
+            content = m.content
+            if content:
+                mt = content.get("application/json")
+                if mt is not None:
+                    schema_obj = mt.media_type_schema
+        base = resolver.materialize(schema_obj) if schema_obj is not None else {"type": "string"}
+        if base is None:
+            base = {"type": "string"}
+        loc = m.param_in
+        loc_val = _param_location_str(loc)
+        prop_schema: dict[str, Any] = {
+            **base,
+            "x-openapi-param-in": loc_val,
+        }
+        desc = m.description
+        if isinstance(desc, str) and desc and "description" not in prop_schema:
+            prop_schema["description"] = desc
+        properties[name] = prop_schema
+        if m.required and name not in required:
+            required.append(name)
+    return properties, required
+
+
+def _build_input_schema(
+    parameters: list[object],
+    body_schema: dict[str, Any] | None,
+    resolver: _SchemaResolver,
+) -> dict[str, Any] | None:
+    param_props, param_req = _parameter_properties(parameters, resolver)
+    parts: list[dict[str, Any]] = []
+    if param_props:
+        obj: dict[str, Any] = {"type": "object", "properties": dict(param_props)}
+        if param_req:
+            obj["required"] = list(param_req)
+        parts.append(obj)
+    if body_schema:
+        parts.append(body_schema)
+    if not parts:
+        return None
+    if len(parts) == 1:
+        return parts[0]
+    return {"allOf": parts}
+
+
+def _fallback_capability_name(method: str, path_template: str) -> str:
+    trimmed = path_template.strip("/")
+    part = (
+        "rootpath" if not trimmed else trimmed.replace("/", "_").replace("{", "").replace("}", "")
+    )
+    return f"{method.lower()}_{part}"
+
+
+def _operation_description(operation: object, path_item: object, fallback: str) -> str:
+    for attr in ("summary", "description"):
+        val = getattr(operation, attr, None)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    for attr in ("summary", "description"):
+        val = getattr(path_item, attr, None)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return fallback
+
+
+def map_openapi_to_capabilities(
+    doc: OpenAPIDocument,
+    *,
+    default_capabilities: DefaultCapabilitiesFilter = "all",
+) -> list[OpenAPICapability]:
+    """Derive ASAP skills (and HTTP metadata) from operations in *doc*.
+
+    Each :class:`OpenAPICapability` includes :attr:`OpenAPICapability.execution_kind`
+    (OA-010): ``streaming`` if any response advertises ``text/event-stream``,
+    else ``async_polling`` if a ``202`` response declares a ``Location`` header,
+    else ``sync``.
+
+    Args:
+        doc: Parsed OpenAPI 3.0 / 3.1 root model.
+        default_capabilities: Which HTTP operations to include. The literal
+            ``all`` keeps every verb. A single string (e.g. ``GET``) or a
+            sequence of method names matches case-insensitively against the
+            lowercase verb used internally. A callable receives
+            :class:`OpenAPIOperationContext` for each operation and must return
+            ``True`` to include it.
+    """
+    paths_raw = getattr(doc, "paths", None)
+    if not paths_raw:
+        return []
+
+    resolver = _SchemaResolver.from_components(getattr(doc, "components", None))
+    components = getattr(doc, "components", None)
+    predicate = _predicate_from_default_capabilities(default_capabilities)
+
+    capabilities: list[OpenAPICapability] = []
+    for path_template, path_item in cast(dict[str, Any], paths_raw).items():
+        for method in _HTTP_METHODS:
+            operation = getattr(path_item, method, None)
+            if operation is None:
+                continue
+
+            op_id = getattr(operation, "operationId", None)
+            op_id_str = op_id.strip() if isinstance(op_id, str) and op_id.strip() else None
+            cap_name = op_id_str if op_id_str else _fallback_capability_name(method, path_template)
+
+            ctx = OpenAPIOperationContext(
+                http_method=method,
+                path_template=path_template,
+                capability_name=cap_name,
+                operation_id=op_id_str,
+                openapi_operation=operation,
+            )
+            if not predicate(ctx):
+                continue
+
+            params = _merge_parameters(path_item, operation, components)
+            rb = _resolve_request_body(getattr(operation, "requestBody", None), components)
+            body_json = _body_json_schema(rb, resolver)
+
+            input_schema = _build_input_schema(params, body_json, resolver)
+            output_schema = _success_response_schema(operation, components, resolver)
+
+            description = _operation_description(operation, path_item, cap_name)
+            execution_kind = detect_openapi_execution_kind(operation, components)
+
+            skill = Skill(
+                id=cap_name,
+                description=description,
+                input_schema=input_schema,
+                output_schema=output_schema,
+            )
+            capabilities.append(
+                OpenAPICapability(
+                    skill=skill,
+                    http_method=method,
+                    path_template=path_template,
+                    execution_kind=execution_kind,
+                    operation_id=op_id_str,
+                ),
+            )
+
+    return capabilities
+
+
+__all__ = [
+    "DefaultCapabilitiesFilter",
+    "OpenAPICapability",
+    "OpenAPIExecutionKind",
+    "OpenAPIOperationContext",
+    "detect_openapi_execution_kind",
+    "map_openapi_to_capabilities",
+]

--- a/src/asap/adapters/openapi/capability_mapper.py
+++ b/src/asap/adapters/openapi/capability_mapper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from enum import Enum, StrEnum
@@ -9,6 +10,12 @@ from typing import Any, Literal, Protocol, TypeAlias, cast
 
 from asap.adapters.openapi.spec_loader import OpenAPIDocument
 from asap.models.entities import Skill
+
+logger = logging.getLogger(__name__)
+
+# ``cast(...)`` usages below compensate for incomplete / structural typing from
+# openapi-pydantic stubs: paths, responses, headers, and parameters are modeled
+# as generic objects at compile time though runtime layout matches OpenAPI 3.x.
 
 _HTTP_METHODS: tuple[str, ...] = (
     "get",
@@ -118,8 +125,15 @@ class _SchemaResolver:
             raw[name] = schema_obj.model_dump(mode="json", by_alias=True, exclude_none=True)
         return cls(raw)
 
-    def expand_refs(self, node: Any, seen: frozenset[str]) -> Any:
+    def expand_refs(self, node: Any, seen: frozenset[str], depth: int = 0) -> Any:
         """Inline internal component schema refs; leave unknown or cyclic ``$ref`` as-is."""
+        if depth > 50:
+            logger.debug(
+                "OpenAPI schema $ref expansion stopped at depth %s (limit 50); node left as-is.",
+                depth,
+            )
+            return node
+        next_depth = depth + 1
         if isinstance(node, dict):
             ref = node.get("$ref")
             if isinstance(ref, str):
@@ -128,10 +142,10 @@ class _SchemaResolver:
                     if name in seen:
                         return {"$ref": ref}
                     base = self._raw_by_name[name]
-                    return self.expand_refs(base, seen | {name})
-            return {k: self.expand_refs(v, seen) for k, v in node.items()}
+                    return self.expand_refs(base, seen | {name}, next_depth)
+            return {k: self.expand_refs(v, seen, next_depth) for k, v in node.items()}
         if isinstance(node, list):
-            return [self.expand_refs(item, seen) for item in node]
+            return [self.expand_refs(item, seen, next_depth) for item in node]
         return node
 
     def materialize(self, schema_or_ref: object | None) -> dict[str, Any] | None:
@@ -144,12 +158,12 @@ class _SchemaResolver:
                 return {"$ref": ref}
             return cast(
                 dict[str, Any],
-                self.expand_refs(self._raw_by_name[name], frozenset({name})),
+                self.expand_refs(self._raw_by_name[name], frozenset({name}), 0),
             )
         model_dump = getattr(schema_or_ref, "model_dump", None)
         if callable(model_dump):
             dumped = model_dump(mode="json", by_alias=True, exclude_none=True)
-            return cast(dict[str, Any], self.expand_refs(dumped, frozenset()))
+            return cast(dict[str, Any], self.expand_refs(dumped, frozenset(), 0))
         return None
 
 
@@ -471,6 +485,7 @@ def map_openapi_to_capabilities(
                 ),
             )
 
+    logger.debug("map_openapi_to_capabilities produced %s capability(ies)", len(capabilities))
     return capabilities
 
 

--- a/src/asap/adapters/openapi/factory.py
+++ b/src/asap/adapters/openapi/factory.py
@@ -1,0 +1,198 @@
+"""Assemble manifest + handler registry from a loaded OpenAPI document (OA-001)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin
+
+import httpx
+
+from asap.adapters.openapi.approval import collect_webauthn_required_capability_names
+from asap.adapters.openapi.capability_mapper import (
+    DefaultCapabilitiesFilter,
+    OpenAPIExecutionKind,
+    OpenAPICapability,
+    map_openapi_to_capabilities,
+)
+from asap.adapters.openapi.handler import (
+    OpenAPIUpstreamHandler,
+    ResolveHeaders,
+    create_openapi_task_handler,
+)
+from asap.adapters.openapi.spec_loader import OpenAPISpecError, OpenAPIDocument, load_spec
+from asap.models.entities import Capability, Endpoint, Manifest, Skill
+from asap.transport.handlers import HandlerRegistry
+
+PETSTORE_OPENAPI_URL = "https://petstore3.swagger.io/api/v3/openapi.json"
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAPIAdapterBundle:
+    """Result of :func:`create_from_openapi` — ready for :func:`asap.transport.server.create_app`."""
+
+    manifest: Manifest
+    registry: HandlerRegistry
+    capabilities: list[OpenAPICapability]
+    require_webauthn_for: list[str]
+    upstream_base_url: str
+
+
+def _infer_upstream_base_url(
+    doc: OpenAPIDocument,
+    override: str | None,
+    *,
+    resolution_base: str | None,
+) -> str:
+    if override is not None and override.strip():
+        return override.strip().rstrip("/")
+    servers = getattr(doc, "servers", None)
+    if not servers:
+        msg = "OpenAPI document has no `servers`; pass upstream_base_url= to create_from_openapi."
+        raise OpenAPISpecError(msg)
+    first = servers[0]
+    raw_url = getattr(first, "url", None)
+    if not isinstance(raw_url, str) or not raw_url.strip():
+        msg = "OpenAPI `servers[0].url` is missing or empty."
+        raise OpenAPISpecError(msg)
+    candidate = raw_url.strip()
+    if candidate.startswith(("http://", "https://")):
+        return candidate.rstrip("/")
+    if resolution_base is None or not resolution_base.strip():
+        msg = (
+            f"Relative OpenAPI server URL {raw_url!r} requires upstream_base_url= "
+            "when the spec is loaded from a local path."
+        )
+        raise OpenAPISpecError(msg)
+    joined = urljoin(resolution_base.strip(), candidate)
+    return joined.rstrip("/")
+
+
+def _build_manifest(
+    *,
+    doc: OpenAPIDocument,
+    caps: list[OpenAPICapability],
+    manifest_id: str,
+    manifest_name: str,
+    asap_endpoint: str,
+) -> Manifest:
+    title = getattr(getattr(doc, "info", None), "title", None)
+    ver = getattr(getattr(doc, "info", None), "version", None)
+    name = (
+        manifest_name.strip()
+        if manifest_name.strip()
+        else (title.strip() if isinstance(title, str) and title.strip() else "OpenAPI Adapter")
+    )
+    version = ver.strip() if isinstance(ver, str) and ver.strip() else "1.0.0"
+    skills = [
+        Skill(
+            id=c.skill.id,
+            description=c.skill.description,
+            input_schema=c.skill.input_schema,
+            output_schema=c.skill.output_schema,
+        )
+        for c in caps
+    ]
+    return Manifest(
+        id=manifest_id.strip(),
+        name=name,
+        version=version,
+        description=f"ASAP adapter for OpenAPI spec {name!r}",
+        capabilities=Capability(
+            asap_version="0.1",
+            skills=skills,
+            streaming=any(c.execution_kind == OpenAPIExecutionKind.STREAMING for c in caps),
+            state_persistence=False,
+        ),
+        endpoints=Endpoint(asap=asap_endpoint.strip()),
+    )
+
+
+async def create_from_openapi(
+    *,
+    spec_url: str | None = None,
+    spec_path: str | Path | None = None,
+    http_client: httpx.AsyncClient,
+    upstream_base_url: str | None = None,
+    default_capabilities: DefaultCapabilitiesFilter = "all",
+    approval_strength: dict[str, str] | None = None,
+    resolve_headers: ResolveHeaders | None = None,
+    manifest_id: str = "urn:asap:agent:openapi-adapter",
+    manifest_name: str = "",
+    asap_endpoint: str = "http://localhost:8000/asap",
+    **kwargs: Any,
+) -> OpenAPIAdapterBundle:
+    """Load OpenAPI 3.x, map operations to skills, and wire an upstream proxy handler.
+
+    Args:
+        spec_url: HTTPS (or HTTP) URL of the OpenAPI JSON/YAML document.
+        spec_path: Local path to a document (alternative to ``spec_url``).
+        http_client: Shared ``httpx`` client used for spec fetch (if URL) and upstream calls.
+        upstream_base_url: Base URL for API calls; defaults to the first OpenAPI ``servers``.
+        default_capabilities: Filter forwarded to :func:`map_openapi_to_capabilities`.
+        approval_strength: Optional OA-008 mapping; use
+            :attr:`OpenAPIAdapterBundle.require_webauthn_for` with
+            :class:`asap.auth.self_auth.FreshSessionConfig`.
+        resolve_headers: Optional `(session) -> headers` for upstream auth (OA-009).
+        manifest_id: ``Manifest.id`` (also Host JWT ``aud`` when using identity routes).
+        manifest_name: Override manifest display name (default: ``info.title``).
+        asap_endpoint: Advertised ``/asap`` URL in the manifest.
+        **kwargs: Reserved for forward compatibility (ignored).
+
+    Returns:
+        Bundle containing manifest, handler registry, and metadata.
+
+    Raises:
+        OpenAPISpecError: Invalid document, unsupported server URL, etc.
+        ValueError: Duplicate capability ids in the spec.
+    """
+    _ = kwargs
+    if (spec_url is None) == (spec_path is None):
+        msg = "Exactly one of spec_url or spec_path must be set."
+        raise OpenAPISpecError(msg)
+    if spec_url is not None:
+        doc = await load_spec(spec_url, http_client=http_client)
+        resolution_base = spec_url
+    else:
+        if spec_path is None:
+            msg = "spec_path is required when spec_url is omitted."
+            raise OpenAPISpecError(msg)
+        doc = await load_spec(spec_path)
+        resolution_base = None
+    caps = map_openapi_to_capabilities(doc, default_capabilities=default_capabilities)
+    base = _infer_upstream_base_url(doc, upstream_base_url, resolution_base=resolution_base)
+    require_wa = (
+        collect_webauthn_required_capability_names(caps, approval_strength)
+        if approval_strength
+        else []
+    )
+    manifest = _build_manifest(
+        doc=doc,
+        caps=caps,
+        manifest_id=manifest_id,
+        manifest_name=manifest_name,
+        asap_endpoint=asap_endpoint,
+    )
+    upstream = OpenAPIUpstreamHandler.from_capabilities(
+        base_url=base,
+        capabilities=caps,
+        http_client=http_client,
+        resolve_headers=resolve_headers,
+    )
+    registry = HandlerRegistry()
+    registry.register("task.request", create_openapi_task_handler(upstream))
+    return OpenAPIAdapterBundle(
+        manifest=manifest,
+        registry=registry,
+        capabilities=list(caps),
+        require_webauthn_for=require_wa,
+        upstream_base_url=base,
+    )
+
+
+__all__ = [
+    "OpenAPIAdapterBundle",
+    "PETSTORE_OPENAPI_URL",
+    "create_from_openapi",
+]

--- a/src/asap/adapters/openapi/factory.py
+++ b/src/asap/adapters/openapi/factory.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -25,7 +27,24 @@ from asap.adapters.openapi.spec_loader import OpenAPISpecError, OpenAPIDocument,
 from asap.models.entities import Capability, Endpoint, Manifest, Skill
 from asap.transport.handlers import HandlerRegistry
 
+logger = logging.getLogger(__name__)
+
 PETSTORE_OPENAPI_URL = "https://petstore3.swagger.io/api/v3/openapi.json"
+
+_KNOWN_CREATE_FROM_OPENAPI_KEYS: frozenset[str] = frozenset(
+    (
+        "spec_url",
+        "spec_path",
+        "http_client",
+        "upstream_base_url",
+        "default_capabilities",
+        "approval_strength",
+        "resolve_headers",
+        "manifest_id",
+        "manifest_name",
+        "asap_endpoint",
+    ),
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -138,7 +157,7 @@ async def create_from_openapi(
         manifest_id: ``Manifest.id`` (also Host JWT ``aud`` when using identity routes).
         manifest_name: Override manifest display name (default: ``info.title``).
         asap_endpoint: Advertised ``/asap`` URL in the manifest.
-        **kwargs: Reserved for forward compatibility (ignored).
+        **kwargs: Reserved; unknown keys emit :class:`UserWarning` to surface typos.
 
     Returns:
         Bundle containing manifest, handler registry, and metadata.
@@ -147,7 +166,16 @@ async def create_from_openapi(
         OpenAPISpecError: Invalid document, unsupported server URL, etc.
         ValueError: Duplicate capability ids in the spec.
     """
-    _ = kwargs
+    remainder = dict(kwargs)
+    for _key in _KNOWN_CREATE_FROM_OPENAPI_KEYS:
+        remainder.pop(_key, None)
+    if remainder:
+        warnings.warn(
+            "create_from_openapi ignored unexpected keyword arguments: "
+            + ", ".join(sorted(remainder)),
+            UserWarning,
+            stacklevel=2,
+        )
     if (spec_url is None) == (spec_path is None):
         msg = "Exactly one of spec_url or spec_path must be set."
         raise OpenAPISpecError(msg)
@@ -161,6 +189,11 @@ async def create_from_openapi(
         doc = await load_spec(spec_path)
         resolution_base = None
     caps = map_openapi_to_capabilities(doc, default_capabilities=default_capabilities)
+    logger.info(
+        "OpenAPI capabilities mapped count=%s manifest_id=%s",
+        len(caps),
+        manifest_id,
+    )
     base = _infer_upstream_base_url(doc, upstream_base_url, resolution_base=resolution_base)
     require_wa = (
         collect_webauthn_required_capability_names(caps, approval_strength)

--- a/src/asap/adapters/openapi/handler.py
+++ b/src/asap/adapters/openapi/handler.py
@@ -1,0 +1,440 @@
+"""Execute OpenAPI-derived capabilities by proxying to an upstream HTTP API (OA-001, OA-006)."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any, TypeAlias
+from urllib.parse import quote
+
+import httpx
+
+from asap.adapters.openapi.capability_mapper import OpenAPICapability
+from asap.errors import (
+    FatalError,
+    RPC_CONNECTION_ERROR,
+    RPC_HANDLER_NOT_FOUND,
+    RPC_REMOTE_GENERIC,
+    RecoverableError,
+)
+from asap.models.entities import Manifest
+from asap.models.enums import TaskStatus
+from asap.models.envelope import Envelope
+from asap.models.ids import generate_id
+from asap.models.payloads import TaskRequest, TaskResponse
+from asap.transport.handlers import AsyncHandler
+
+_UNKNOWN_CAPABILITY = "asap:adapters/openapi/unknown_capability"
+_INVOCATION = "asap:adapters/openapi/invocation"
+_PATH_PARAMS = "asap:adapters/openapi/path_parameters"
+_UPSTREAM = "asap:adapters/openapi/upstream_connection"
+_UPSTREAM_5XX = "asap:adapters/openapi/upstream_server_error"
+_UPSTREAM_4XX = "asap:adapters/openapi/upstream_client_error"
+_RESOLVE_HEADERS = "asap:adapters/openapi/resolve_headers"
+
+ResolveHeaders: TypeAlias = Callable[[object | None], dict[str, str]]
+
+
+class UnknownOpenAPICapabilityError(FatalError):
+    """No operation was registered under the given capability name."""
+
+    def __init__(self, capability_name: str) -> None:
+        super().__init__(
+            _UNKNOWN_CAPABILITY,
+            f"Unknown OpenAPI capability {capability_name!r}.",
+            {"capability_name": capability_name},
+            rpc_code=RPC_HANDLER_NOT_FOUND,
+        )
+        self.capability_name = capability_name
+
+
+class OpenAPIInvocationError(FatalError):
+    """Caller arguments do not match the derived input schema."""
+
+    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
+        super().__init__(
+            _INVOCATION,
+            message,
+            details,
+            rpc_code=RPC_REMOTE_GENERIC,
+        )
+
+
+class OpenAPIPathParameterError(FatalError):
+    """Path template could not be fully substituted from *args*."""
+
+    def __init__(self, *, path_template: str, missing: list[str]) -> None:
+        super().__init__(
+            _PATH_PARAMS,
+            f"Missing path parameter(s) for template {path_template!r}: {', '.join(missing)}.",
+            {"path_template": path_template, "missing": missing},
+            rpc_code=RPC_REMOTE_GENERIC,
+        )
+        self.path_template = path_template
+        self.missing = missing
+
+
+def index_capabilities(caps: Iterable[OpenAPICapability]) -> dict[str, OpenAPICapability]:
+    """Index capabilities by skill id, detecting duplicates early."""
+    out: dict[str, OpenAPICapability] = {}
+    for item in caps:
+        skill_id = item.skill.id
+        if skill_id in out:
+            msg = f"Duplicate OpenAPI capability id {skill_id!r}."
+            raise ValueError(msg)
+        out[skill_id] = item
+    return out
+
+
+def _param_props_from_object(obj: dict[str, Any], param_in: dict[str, str]) -> None:
+    if obj.get("type") != "object" or "properties" not in obj:
+        return
+    for name, sub in obj["properties"].items():
+        if isinstance(sub, dict):
+            loc = sub.get("x-openapi-param-in")
+            if isinstance(loc, str):
+                param_in[name] = loc
+
+
+def _collect_body_property_keys(part: dict[str, Any], sink: set[str]) -> None:
+    if part.get("type") == "object" and "properties" in part:
+        sink.update(part["properties"])
+        return
+    if "allOf" in part:
+        for child in part["allOf"]:
+            if isinstance(child, dict):
+                _collect_body_property_keys(child, sink)
+
+
+def _parse_input_schema_routing(
+    input_schema: dict[str, Any] | None,
+) -> tuple[dict[str, str], set[str]]:
+    """Map parameter names to OpenAPI ``in`` and collect JSON body property names."""
+    if input_schema is None:
+        return {}, set()
+
+    param_in: dict[str, str] = {}
+    body_keys: set[str] = set()
+    if "allOf" in input_schema:
+        parts = input_schema["allOf"]
+        if parts and isinstance(parts[0], dict):
+            _param_props_from_object(parts[0], param_in)
+        for part in parts[1:]:
+            if isinstance(part, dict):
+                _collect_body_property_keys(part, body_keys)
+        return param_in, body_keys
+
+    if input_schema.get("type") == "object" and "properties" in input_schema:
+        for name, sub in input_schema["properties"].items():
+            if not isinstance(sub, dict):
+                continue
+            loc = sub.get("x-openapi-param-in")
+            if isinstance(loc, str):
+                param_in[name] = loc
+            else:
+                body_keys.add(name)
+        return param_in, body_keys
+
+    return {}, set()
+
+
+def _split_arguments_for_request(
+    input_schema: dict[str, Any] | None,
+    args: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, str], dict[str, Any] | None]:
+    param_in, body_keys = _parse_input_schema_routing(input_schema)
+    allowed = set(param_in) | set(body_keys)
+    if input_schema is None and args:
+        raise OpenAPIInvocationError(
+            "Unexpected arguments for capability with no input schema.",
+            details={"unexpected": sorted(args)},
+        )
+    extras = set(args) - allowed
+    if extras:
+        raise OpenAPIInvocationError(
+            f"Unexpected argument name(s): {', '.join(sorted(extras))}.",
+            details={"unexpected": sorted(extras), "allowed": sorted(allowed)},
+        )
+
+    path_vals: dict[str, Any] = {}
+    query: dict[str, Any] = {}
+    headers: dict[str, str] = {}
+    cookie_pairs: list[str] = []
+    body: dict[str, Any] = {}
+
+    for key, val in args.items():
+        if key in param_in:
+            loc = param_in[key]
+            if loc == "path":
+                path_vals[key] = val
+            elif loc == "query":
+                query[key] = val
+            elif loc == "header":
+                headers[key] = str(val)
+            elif loc == "cookie":
+                cookie_pairs.append(f"{key}={val}")
+            else:
+                raise OpenAPIInvocationError(
+                    f"Unsupported OpenAPI parameter location {loc!r} for {key!r}.",
+                    details={"name": key, "in": loc},
+                )
+        else:
+            body[key] = val
+
+    if cookie_pairs:
+        headers["Cookie"] = "; ".join(cookie_pairs)
+
+    wants_json = bool(body_keys)
+    json_body: dict[str, Any] | None = body if wants_json else None
+
+    return path_vals, query, headers, json_body
+
+
+def _merge_request_headers(
+    resolve_first: Mapping[str, str] | None,
+    operation: Mapping[str, str],
+) -> dict[str, str] | None:
+    """Merge *resolve_first* with OpenAPI header parameters *operation*.
+
+    *operation* wins on duplicate keys so per-invocation header args can override
+    injected defaults (e.g. tracing) when needed.
+    """
+    if not resolve_first and not operation:
+        return None
+    merged: dict[str, str] = {}
+    if resolve_first:
+        merged.update(dict(resolve_first))
+    merged.update(operation)
+    return merged
+
+
+def _headers_from_resolve_callback(
+    fn: ResolveHeaders,
+    session: object | None,
+) -> dict[str, str]:
+    """Run *fn* and validate a ``dict[str, str]`` for upstream injection."""
+    try:
+        raw = fn(session)
+    except Exception as exc:
+        raise RecoverableError(
+            _RESOLVE_HEADERS,
+            f"resolve_headers callback failed: {exc!s}.",
+            {
+                "error_type": type(exc).__name__,
+            },
+            rpc_code=RPC_REMOTE_GENERIC,
+        ) from exc
+    if not isinstance(raw, dict):
+        raise RecoverableError(
+            _RESOLVE_HEADERS,
+            "resolve_headers must return dict[str, str].",
+            {"got_type": type(raw).__name__},
+            rpc_code=RPC_REMOTE_GENERIC,
+        )
+    out: dict[str, str] = {}
+    for key, val in raw.items():
+        if not isinstance(key, str) or not isinstance(val, str):
+            raise RecoverableError(
+                _RESOLVE_HEADERS,
+                "resolve_headers dict must use only str keys and str values.",
+                {
+                    "key_type": type(key).__name__,
+                    "value_type": type(val).__name__,
+                },
+                rpc_code=RPC_REMOTE_GENERIC,
+            )
+        out[key] = val
+    return out
+
+
+def _fill_path_template(path_template: str, path_params: Mapping[str, Any]) -> str:
+    names = re.findall(r"\{([^}]+)\}", path_template)
+    missing = [n for n in names if n not in path_params]
+    if missing:
+        raise OpenAPIPathParameterError(path_template=path_template, missing=missing)
+    out = path_template
+    for name, raw in path_params.items():
+        out = out.replace("{" + name + "}", quote(str(raw), safe=""))
+    return out
+
+
+class OpenAPIUpstreamHandler:
+    """Proxy ASAP capability calls to an upstream service described by OpenAPI."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        capabilities: dict[str, OpenAPICapability],
+        http_client: httpx.AsyncClient,
+        resolve_headers: ResolveHeaders | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._capabilities = capabilities
+        self._http_client = http_client
+        self._resolve_headers = resolve_headers
+
+    @classmethod
+    def from_capabilities(
+        cls,
+        *,
+        base_url: str,
+        capabilities: Iterable[OpenAPICapability],
+        http_client: httpx.AsyncClient,
+        resolve_headers: ResolveHeaders | None = None,
+    ) -> OpenAPIUpstreamHandler:
+        """Build a handler from a list of :class:`OpenAPICapability` records."""
+        return cls(
+            base_url=base_url,
+            capabilities=index_capabilities(capabilities),
+            http_client=http_client,
+            resolve_headers=resolve_headers,
+        )
+
+    async def execute(
+        self,
+        capability_name: str,
+        args: Mapping[str, Any],
+        session: object | None = None,
+    ) -> dict[str, Any]:
+        """Invoke *capability_name* on the upstream API with *args*.
+
+        Args:
+            capability_name: ``operationId`` (or path/method fallback id) from the spec.
+            args: Keys must match the mapped input schema (path/query/header/cookie + JSON body).
+            session: Passed to :attr:`resolve_headers` when configured (OA-009), for example
+                Host-held OAuth context used to build ``Authorization``.
+
+        Returns:
+            Parsed JSON object for ``application/json`` responses; an empty dict for HTTP 204.
+
+        Raises:
+            UnknownOpenAPICapabilityError: *capability_name* is not registered.
+            OpenAPIInvocationError: *args* are inconsistent with the input schema.
+            OpenAPIPathParameterError: Path placeholders remain after substitution.
+            RecoverableError: Network failure, HTTP 5xx from upstream, or *resolve_headers* failure.
+            FatalError: HTTP 4xx from upstream.
+        """
+        cap = self._capabilities.get(capability_name)
+        if cap is None:
+            raise UnknownOpenAPICapabilityError(capability_name)
+
+        schema = cap.skill.input_schema
+        schema_dict = schema if isinstance(schema, dict) else None
+        path_vals, query, headers, json_body = _split_arguments_for_request(schema_dict, args)
+        resolved_path = _fill_path_template(cap.path_template, path_vals)
+        if not resolved_path.startswith("/"):
+            resolved_path = "/" + resolved_path
+        url = f"{self._base_url}{resolved_path}"
+
+        resolved_auth: dict[str, str] | None = None
+        if self._resolve_headers is not None:
+            resolved_auth = _headers_from_resolve_callback(self._resolve_headers, session)
+        merged_headers = _merge_request_headers(resolved_auth, headers)
+
+        try:
+            response = await self._http_client.request(
+                cap.http_method.upper(),
+                url,
+                params=query or None,
+                headers=merged_headers,
+                json=json_body,
+            )
+        except httpx.RequestError as exc:
+            raise RecoverableError(
+                _UPSTREAM,
+                f"Upstream request failed: {exc!s}.",
+                {"capability_name": capability_name, "url": url},
+                rpc_code=RPC_CONNECTION_ERROR,
+            ) from exc
+
+        if response.status_code == 204:
+            return {}
+
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            snippet = exc.response.text[:500]
+            details = {
+                "capability_name": capability_name,
+                "url": str(exc.request.url),
+                "status_code": status,
+                "body_snippet": snippet,
+            }
+            if status >= 500:
+                raise RecoverableError(
+                    _UPSTREAM_5XX,
+                    f"Upstream HTTP {status}.",
+                    details,
+                    rpc_code=RPC_REMOTE_GENERIC,
+                ) from exc
+            raise FatalError(
+                _UPSTREAM_4XX,
+                f"Upstream HTTP {status}.",
+                details,
+                rpc_code=RPC_REMOTE_GENERIC,
+            ) from exc
+
+        content_type = response.headers.get("content-type", "")
+        if "application/json" in content_type.lower():
+            data = response.json()
+            if isinstance(data, dict):
+                return data
+            return {"_json": data}
+
+        return {
+            "_text": response.text,
+            "_status_code": response.status_code,
+            "content_type": content_type,
+        }
+
+
+async def execute(
+    handler: OpenAPIUpstreamHandler,
+    capability_name: str,
+    args: Mapping[str, Any],
+    session: object | None = None,
+) -> dict[str, Any]:
+    """Invoke :meth:`OpenAPIUpstreamHandler.execute` on *handler* (module-level wrapper)."""
+    return await handler.execute(capability_name, args, session=session)
+
+
+def create_openapi_task_handler(upstream: OpenAPIUpstreamHandler) -> AsyncHandler:
+    """Build an async ``task.request`` handler that proxies to *upstream*."""
+
+    async def openapi_task_request_handler(envelope: Envelope, manifest: Manifest) -> Envelope:
+        task_request = TaskRequest.model_validate(envelope.payload_dict)
+        result = await upstream.execute(
+            task_request.skill_id,
+            task_request.input,
+            session=None,
+        )
+        response_payload = TaskResponse(
+            task_id=f"task_{generate_id()}",
+            status=TaskStatus.COMPLETED,
+            result=result,
+        )
+        return Envelope(
+            asap_version=envelope.asap_version,
+            sender=manifest.id,
+            recipient=envelope.sender,
+            payload_type="task.response",
+            payload=response_payload.model_dump(),
+            correlation_id=envelope.id,
+            trace_id=envelope.trace_id,
+        )
+
+    return openapi_task_request_handler
+
+
+__all__ = [
+    "OpenAPIInvocationError",
+    "OpenAPIPathParameterError",
+    "OpenAPIUpstreamHandler",
+    "ResolveHeaders",
+    "UnknownOpenAPICapabilityError",
+    "create_openapi_task_handler",
+    "execute",
+    "index_capabilities",
+]

--- a/src/asap/adapters/openapi/handler.py
+++ b/src/asap/adapters/openapi/handler.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Callable, Iterable, Mapping
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, cast
 from urllib.parse import quote
 
 import httpx
@@ -24,6 +25,8 @@ from asap.models.ids import generate_id
 from asap.models.payloads import TaskRequest, TaskResponse
 from asap.transport.handlers import AsyncHandler
 
+logger = logging.getLogger(__name__)
+
 _UNKNOWN_CAPABILITY = "asap:adapters/openapi/unknown_capability"
 _INVOCATION = "asap:adapters/openapi/invocation"
 _PATH_PARAMS = "asap:adapters/openapi/path_parameters"
@@ -31,6 +34,10 @@ _UPSTREAM = "asap:adapters/openapi/upstream_connection"
 _UPSTREAM_5XX = "asap:adapters/openapi/upstream_server_error"
 _UPSTREAM_4XX = "asap:adapters/openapi/upstream_client_error"
 _RESOLVE_HEADERS = "asap:adapters/openapi/resolve_headers"
+
+# Bound upstream HTTP error payloads copied into FatalError/RecoverableError details to
+# reduce accidental leakage of large or sensitive bodies (prefer server logs for triage).
+_UPSTREAM_CLIENT_ERROR_BODY_MAX_LEN = 200
 
 ResolveHeaders: TypeAlias = Callable[[object | None], dict[str, str]]
 
@@ -63,15 +70,39 @@ class OpenAPIInvocationError(FatalError):
 class OpenAPIPathParameterError(FatalError):
     """Path template could not be fully substituted from *args*."""
 
-    def __init__(self, *, path_template: str, missing: list[str]) -> None:
+    def __init__(
+        self,
+        *,
+        path_template: str,
+        missing: list[str] | None = None,
+        invalid: list[str] | None = None,
+    ) -> None:
+        miss = list(missing) if missing else []
+        inv = list(invalid) if invalid else []
+        if bool(miss) == bool(inv):
+            raise ValueError(
+                "OpenAPIPathParameterError requires exactly one of missing= or invalid=."
+            )
+        if miss:
+            message = (
+                f"Missing path parameter(s) for template {path_template!r}: {', '.join(miss)}."
+            )
+            details: dict[str, Any] = {"path_template": path_template, "missing": miss}
+        else:
+            message = (
+                f"Invalid path parameter value(s) for template {path_template!r}: "
+                f"{', '.join(inv)} (must not be None, empty, or whitespace-only)."
+            )
+            details = {"path_template": path_template, "invalid": inv}
         super().__init__(
             _PATH_PARAMS,
-            f"Missing path parameter(s) for template {path_template!r}: {', '.join(missing)}.",
-            {"path_template": path_template, "missing": missing},
+            message,
+            details,
             rpc_code=RPC_REMOTE_GENERIC,
         )
         self.path_template = path_template
-        self.missing = missing
+        self.missing = miss
+        self.invalid = inv
 
 
 def index_capabilities(caps: Iterable[OpenAPICapability]) -> dict[str, OpenAPICapability]:
@@ -248,12 +279,22 @@ def _headers_from_resolve_callback(
 
 
 def _fill_path_template(path_template: str, path_params: Mapping[str, Any]) -> str:
-    names = re.findall(r"\{([^}]+)\}", path_template)
-    missing = [n for n in names if n not in path_params]
+    raw_names = re.findall(r"\{([^}]+)\}", path_template)
+    names_order = list(dict.fromkeys(raw_names))
+    missing = [n for n in names_order if n not in path_params]
     if missing:
         raise OpenAPIPathParameterError(path_template=path_template, missing=missing)
+    invalid_names = [
+        n
+        for n in names_order
+        if path_params[n] is None
+        or (isinstance(path_params[n], str) and cast(str, path_params[n]).strip() == "")
+    ]
+    if invalid_names:
+        raise OpenAPIPathParameterError(path_template=path_template, invalid=invalid_names)
     out = path_template
-    for name, raw in path_params.items():
+    for name in names_order:
+        raw = path_params[name]
         out = out.replace("{" + name + "}", quote(str(raw), safe=""))
     return out
 
@@ -311,7 +352,8 @@ class OpenAPIUpstreamHandler:
         Raises:
             UnknownOpenAPICapabilityError: *capability_name* is not registered.
             OpenAPIInvocationError: *args* are inconsistent with the input schema.
-            OpenAPIPathParameterError: Path placeholders remain after substitution.
+            OpenAPIPathParameterError: Path placeholders unchanged, missing arguments,
+                or path values that are ``None`` / empty / whitespace-only strings.
             RecoverableError: Network failure, HTTP 5xx from upstream, or *resolve_headers* failure.
             FatalError: HTTP 4xx from upstream.
         """
@@ -341,6 +383,12 @@ class OpenAPIUpstreamHandler:
                 json=json_body,
             )
         except httpx.RequestError as exc:
+            logger.warning(
+                "OpenAPI upstream request failed capability_name=%r url=%r error=%s",
+                capability_name,
+                url,
+                exc,
+            )
             raise RecoverableError(
                 _UPSTREAM,
                 f"Upstream request failed: {exc!s}.",
@@ -355,20 +403,41 @@ class OpenAPIUpstreamHandler:
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
             status = exc.response.status_code
-            snippet = exc.response.text[:500]
-            details = {
-                "capability_name": capability_name,
-                "url": str(exc.request.url),
-                "status_code": status,
-                "body_snippet": snippet,
-            }
+            req_url = str(exc.request.url)
+            # Client-facing details: omit upstream body snippets for 5xx (internal errors /
+            # possible sensitive stack hints); truncate 4xx bodies to mitigate leakage while
+            # retaining some operator context.
             if status >= 500:
+                details: dict[str, Any] = {
+                    "capability_name": capability_name,
+                    "url": req_url,
+                    "status_code": status,
+                }
+                logger.warning(
+                    "OpenAPI upstream server error capability_name=%r url=%r status=%s",
+                    capability_name,
+                    req_url,
+                    status,
+                )
                 raise RecoverableError(
                     _UPSTREAM_5XX,
                     f"Upstream HTTP {status}.",
                     details,
                     rpc_code=RPC_REMOTE_GENERIC,
                 ) from exc
+            snippet = exc.response.text[:_UPSTREAM_CLIENT_ERROR_BODY_MAX_LEN]
+            details = {
+                "capability_name": capability_name,
+                "url": req_url,
+                "status_code": status,
+                "body_snippet": snippet,
+            }
+            logger.error(
+                "OpenAPI upstream client error capability_name=%r url=%r status=%s",
+                capability_name,
+                req_url,
+                status,
+            )
             raise FatalError(
                 _UPSTREAM_4XX,
                 f"Upstream HTTP {status}.",
@@ -401,9 +470,15 @@ async def execute(
 
 
 def create_openapi_task_handler(upstream: OpenAPIUpstreamHandler) -> AsyncHandler:
-    """Build an async ``task.request`` handler that proxies to *upstream*."""
+    """Build an async ``task.request`` handler that proxies to *upstream*.
+
+    The nested ``openapi_task_request_handler`` always passes ``session=None`` into
+    :meth:`OpenAPIUpstreamHandler.execute` today. OA-009 header resolution from Host-held
+    context likely needs envelope- or TaskRequest-level session wiring in a future change.
+    """
 
     async def openapi_task_request_handler(envelope: Envelope, manifest: Manifest) -> Envelope:
+        """Translate ``task.request`` envelopes through *upstream* (``session`` is always ``None``)."""
         task_request = TaskRequest.model_validate(envelope.payload_dict)
         result = await upstream.execute(
             task_request.skill_id,

--- a/src/asap/adapters/openapi/spec_loader.py
+++ b/src/asap/adapters/openapi/spec_loader.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -16,6 +18,8 @@ from pydantic import ValidationError
 OpenAPIDocument = OpenAPI_3_0 | OpenAPI_3_1
 
 _DEFAULT_HTTP_TIMEOUT = 30.0
+
+logger = logging.getLogger(__name__)
 
 
 class OpenAPISpecError(ValueError):
@@ -32,43 +36,65 @@ async def _load_json_from_url(url: str, client: httpx.AsyncClient) -> dict[str, 
         response = await client.get(url)
         response.raise_for_status()
     except httpx.HTTPStatusError as exc:
+        logger.error(
+            "OpenAPI spec HTTP fetch failed url=%r status=%s",
+            url,
+            exc.response.status_code,
+        )
         raise OpenAPISpecError(
             f"Failed to fetch OpenAPI document from {url!r} (HTTP {exc.response.status_code}).",
         ) from exc
     except httpx.HTTPError as exc:
+        logger.error("OpenAPI spec HTTP error url=%r", url)
         raise OpenAPISpecError(f"HTTP error while fetching OpenAPI document from {url!r}.") from exc
     try:
         data = response.json()
     except json.JSONDecodeError as exc:
+        logger.error("OpenAPI URL did not return JSON url=%r", url)
         raise OpenAPISpecError(f"OpenAPI URL did not return JSON: {url!r}.") from exc
     if not isinstance(data, dict):
+        logger.error("OpenAPI URL root is not a JSON object url=%r", url)
         raise OpenAPISpecError(f"OpenAPI root must be a JSON object: {url!r}.")
     return data
 
 
-def _load_json_from_path(path: Path) -> dict[str, Any]:
-    if not path.is_file():
-        raise OpenAPISpecError(f"OpenAPI spec file not found: {path}")
+async def _load_json_from_path(path: Path) -> dict[str, Any]:
+    """Read a local spec without blocking the event loop (filesystem + decode in worker thread)."""
+
+    def _sync_load() -> dict[str, Any]:
+        if not path.is_file():
+            raise OpenAPISpecError(f"OpenAPI spec file not found: {path}")
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise OpenAPISpecError(f"Cannot read OpenAPI spec file: {path}") from exc
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise OpenAPISpecError(f"OpenAPI spec file is not valid JSON: {path}") from exc
+        if not isinstance(data, dict):
+            raise OpenAPISpecError(f"OpenAPI root must be a JSON object: {path}")
+        return data
+
     try:
-        raw = path.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise OpenAPISpecError(f"Cannot read OpenAPI spec file: {path}") from exc
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise OpenAPISpecError(f"OpenAPI spec file is not valid JSON: {path}") from exc
-    if not isinstance(data, dict):
-        raise OpenAPISpecError(f"OpenAPI root must be a JSON object: {path}")
-    return data
+        return await asyncio.to_thread(_sync_load)
+    except OpenAPISpecError as exc:
+        logger.error("OpenAPI spec load from path failed path=%s: %s", path, exc)
+        raise
 
 
 def _ensure_openapi_version_3_x(data: dict[str, Any]) -> None:
     version = data.get("openapi")
     if version is None:
+        logger.error("OpenAPI document missing required 'openapi' field")
         raise OpenAPISpecError("Missing required 'openapi' field (expected OpenAPI 3.x).")
     if not isinstance(version, str):
+        logger.error(
+            "OpenAPI 'openapi' version field must be a string, got %s", type(version).__name__
+        )
         raise OpenAPISpecError("'openapi' version field must be a string.")
     if not version.startswith("3."):
+        logger.error("Unsupported OpenAPI version %r (only 3.x supported)", version)
         raise OpenAPISpecError(
             f"Unsupported OpenAPI version {version!r}; only 3.x is supported.",
         )
@@ -78,6 +104,7 @@ def _parse_openapi_document(data: dict[str, Any]) -> OpenAPIDocument:
     try:
         parsed: OpenAPIDocument = parse_obj(data)
     except ValidationError as exc:
+        logger.error("Invalid OpenAPI document: %s", exc)
         raise OpenAPISpecError(f"Invalid OpenAPI document: {exc}") from exc
     return parsed
 
@@ -102,8 +129,10 @@ async def load_spec(
     Raises:
         OpenAPISpecError: Missing file, non-JSON payload, non-3.x version, or schema errors.
     """
+    source = str(url_or_path) if isinstance(url_or_path, Path) else url_or_path
+    logger.debug("Loading OpenAPI spec from %r", source)
     if isinstance(url_or_path, Path):
-        data = _load_json_from_path(url_or_path)
+        data = await _load_json_from_path(url_or_path)
     elif isinstance(url_or_path, str) and _is_http_url(url_or_path):
         if http_client is None:
             async with httpx.AsyncClient(
@@ -114,10 +143,12 @@ async def load_spec(
         else:
             data = await _load_json_from_url(url_or_path, http_client)
     else:
-        data = _load_json_from_path(Path(url_or_path))
+        data = await _load_json_from_path(Path(url_or_path))
 
     _ensure_openapi_version_3_x(data)
-    return _parse_openapi_document(data)
+    doc = _parse_openapi_document(data)
+    logger.info("Loaded OpenAPI spec source=%r openapi=%r", source, data.get("openapi"))
+    return doc
 
 
 __all__ = ["OpenAPIDocument", "OpenAPISpecError", "load_spec"]

--- a/src/asap/adapters/openapi/spec_loader.py
+++ b/src/asap/adapters/openapi/spec_loader.py
@@ -1,0 +1,123 @@
+"""Load OpenAPI 3.x documents from URLs or local JSON files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from openapi_pydantic import parse_obj
+from openapi_pydantic.v3.v3_0.open_api import OpenAPI as OpenAPI_3_0
+from openapi_pydantic.v3.v3_1.open_api import OpenAPI as OpenAPI_3_1
+from pydantic import ValidationError
+
+OpenAPIDocument = OpenAPI_3_0 | OpenAPI_3_1
+
+_DEFAULT_HTTP_TIMEOUT = 30.0
+
+
+class OpenAPISpecError(ValueError):
+    """The document is missing, not valid OpenAPI 3.x, or could not be loaded."""
+
+
+def _is_http_url(value: str) -> bool:
+    parsed = urlparse(value)
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+
+
+async def _load_json_from_url(url: str, client: httpx.AsyncClient) -> dict[str, Any]:
+    try:
+        response = await client.get(url)
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise OpenAPISpecError(
+            f"Failed to fetch OpenAPI document from {url!r} (HTTP {exc.response.status_code}).",
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise OpenAPISpecError(f"HTTP error while fetching OpenAPI document from {url!r}.") from exc
+    try:
+        data = response.json()
+    except json.JSONDecodeError as exc:
+        raise OpenAPISpecError(f"OpenAPI URL did not return JSON: {url!r}.") from exc
+    if not isinstance(data, dict):
+        raise OpenAPISpecError(f"OpenAPI root must be a JSON object: {url!r}.")
+    return data
+
+
+def _load_json_from_path(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise OpenAPISpecError(f"OpenAPI spec file not found: {path}")
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise OpenAPISpecError(f"Cannot read OpenAPI spec file: {path}") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise OpenAPISpecError(f"OpenAPI spec file is not valid JSON: {path}") from exc
+    if not isinstance(data, dict):
+        raise OpenAPISpecError(f"OpenAPI root must be a JSON object: {path}")
+    return data
+
+
+def _ensure_openapi_version_3_x(data: dict[str, Any]) -> None:
+    version = data.get("openapi")
+    if version is None:
+        raise OpenAPISpecError("Missing required 'openapi' field (expected OpenAPI 3.x).")
+    if not isinstance(version, str):
+        raise OpenAPISpecError("'openapi' version field must be a string.")
+    if not version.startswith("3."):
+        raise OpenAPISpecError(
+            f"Unsupported OpenAPI version {version!r}; only 3.x is supported.",
+        )
+
+
+def _parse_openapi_document(data: dict[str, Any]) -> OpenAPIDocument:
+    try:
+        parsed: OpenAPIDocument = parse_obj(data)
+    except ValidationError as exc:
+        raise OpenAPISpecError(f"Invalid OpenAPI document: {exc}") from exc
+    return parsed
+
+
+async def load_spec(
+    url_or_path: str | Path,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> OpenAPIDocument:
+    """Fetch or read an OpenAPI 3.x document and validate it with ``openapi-pydantic``.
+
+    Local files must be UTF-8 JSON (``.json``). YAML is not supported yet.
+
+    Args:
+        url_or_path: ``https://`` / ``http://`` URL or filesystem path string / :class:`~pathlib.Path`.
+        http_client: Optional shared client for URL loads (e.g. tests with
+            :class:`httpx.MockTransport`). When ``None``, a temporary client is used.
+
+    Returns:
+        Parsed OpenAPI 3.0 or 3.1 root model.
+
+    Raises:
+        OpenAPISpecError: Missing file, non-JSON payload, non-3.x version, or schema errors.
+    """
+    if isinstance(url_or_path, Path):
+        data = _load_json_from_path(url_or_path)
+    elif isinstance(url_or_path, str) and _is_http_url(url_or_path):
+        if http_client is None:
+            async with httpx.AsyncClient(
+                follow_redirects=True,
+                timeout=_DEFAULT_HTTP_TIMEOUT,
+            ) as client:
+                data = await _load_json_from_url(url_or_path, client)
+        else:
+            data = await _load_json_from_url(url_or_path, http_client)
+    else:
+        data = _load_json_from_path(Path(url_or_path))
+
+    _ensure_openapi_version_3_x(data)
+    return _parse_openapi_document(data)
+
+
+__all__ = ["OpenAPIDocument", "OpenAPISpecError", "load_spec"]

--- a/tests/adapters/__init__.py
+++ b/tests/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ASAP adapters."""

--- a/tests/adapters/openapi/__init__.py
+++ b/tests/adapters/openapi/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the OpenAPI adapter."""

--- a/tests/adapters/openapi/conftest.py
+++ b/tests/adapters/openapi/conftest.py
@@ -1,0 +1,19 @@
+"""Shared fixtures and helpers for OpenAPI adapter tests."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+
+@contextmanager
+def tmp_openapi_spec(
+    tmp_path: Path, data: dict[str, Any], name: str
+) -> Generator[Path, None, None]:
+    """Write *data* as JSON under *tmp_path* and yield the file path (pytest cleans *tmp_path*)."""
+    path = tmp_path / f"{name}.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    yield path

--- a/tests/adapters/openapi/integration/__init__.py
+++ b/tests/adapters/openapi/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration/E2E tests for the OpenAPI adapter."""

--- a/tests/adapters/openapi/integration/test_approval_strength_register.py
+++ b/tests/adapters/openapi/integration/test_approval_strength_register.py
@@ -1,0 +1,127 @@
+"""Integration: OpenAPI-derived DELETE capability + approval strength + WebAuthn gate."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi.testclient import TestClient
+from openapi_pydantic import parse_obj
+
+from asap.adapters.openapi.approval import collect_webauthn_required_capability_names
+from asap.adapters.openapi.capability_mapper import map_openapi_to_capabilities
+from asap.auth.agent_jwt import create_host_jwt
+from asap.auth.capabilities import CapabilityDefinition, CapabilityRegistry
+from asap.auth.identity import InMemoryAgentStore, InMemoryHostStore
+from asap.auth.self_auth import FreshSessionConfig, reset_default_webauthn_verifier_cache
+from asap.models.entities import Manifest
+from asap.transport.server import create_app
+from tests.crypto.jwk_helpers import ed25519_public_jwk
+from tests.transport.conftest import NoRateLimitTestBase
+
+if TYPE_CHECKING:
+    from asap.transport.rate_limit import ASAPRateLimiter
+
+_HOST_JWT_AUDIENCE = "urn:asap:agent:test-server"
+
+
+def _openapi_with_delete() -> dict[str, object]:
+    return {
+        "openapi": "3.0.3",
+        "info": {"title": "Delete API", "version": "1.0.0"},
+        "paths": {
+            "/widgets/{widgetId}": {
+                "delete": {
+                    "operationId": "removeWidget",
+                    "summary": "Remove a widget",
+                    "parameters": [
+                        {
+                            "name": "widgetId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        },
+                    ],
+                    "responses": {"204": {"description": "deleted"}},
+                },
+            },
+        },
+    }
+
+
+class TestOpenAPIApprovalStrengthRegister(NoRateLimitTestBase):
+    """Register path respects WebAuthn policy derived from OpenAPI HTTP method mapping."""
+
+    def test_delete_capability_triggers_403_webauthn_when_agent_controls_browser(
+        self,
+        sample_manifest: Manifest,
+        isolated_rate_limiter: ASAPRateLimiter | None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """DELETE mapped to webauthn + browser flag + real verifier → 403 without assertion."""
+        if importlib.util.find_spec("webauthn") is None:
+            pytest.skip("webauthn extra not installed in this environment")
+
+        monkeypatch.setenv("ASAP_WEBAUTHN_RP_ID", "localhost")
+        monkeypatch.setenv("ASAP_WEBAUTHN_ORIGIN", "http://127.0.0.1")
+        reset_default_webauthn_verifier_cache()
+
+        doc = parse_obj(_openapi_with_delete())
+        caps = map_openapi_to_capabilities(doc)
+        webauthn_caps = collect_webauthn_required_capability_names(
+            caps,
+            {"DELETE": "webauthn"},
+        )
+        assert "removeWidget" in webauthn_caps
+
+        agent_store = InMemoryAgentStore()
+        host_store = InMemoryHostStore(agent_store=agent_store)
+        cap_registry = CapabilityRegistry()
+        for cap in caps:
+            cap_registry.register(
+                CapabilityDefinition(
+                    name=cap.skill.id,
+                    description=cap.skill.description,
+                    input_schema=cap.skill.input_schema,
+                    output_schema=cap.skill.output_schema,
+                ),
+            )
+
+        app = create_app(
+            sample_manifest,
+            rate_limit="999999/minute",
+            identity_host_store=host_store,
+            identity_agent_store=agent_store,
+            identity_rate_limit="999999/minute",
+            identity_jwt_audience=_HOST_JWT_AUDIENCE,
+            identity_fresh_session_config=FreshSessionConfig(
+                window_seconds=300,
+                require_webauthn_for=webauthn_caps,
+            ),
+        )
+        if isolated_rate_limiter is not None:
+            app.state.limiter = isolated_rate_limiter
+        app.state.capability_registry = cap_registry
+
+        host_sk = Ed25519PrivateKey.generate()
+        agent_sk = Ed25519PrivateKey.generate()
+        agent_jwk = ed25519_public_jwk(agent_sk)
+        token = create_host_jwt(
+            host_sk,
+            aud=_HOST_JWT_AUDIENCE,
+            agent_public_key=agent_jwk,
+            ttl_seconds=120,
+        )
+        client = TestClient(app)
+        response = client.post(
+            "/asap/agent/register",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "capabilities": ["removeWidget"],
+                "agent_controls_browser": True,
+            },
+        )
+        assert response.status_code == 403
+        assert response.json() == {"detail": "webauthn_required"}

--- a/tests/adapters/openapi/integration/test_e2e_petstore.py
+++ b/tests/adapters/openapi/integration/test_e2e_petstore.py
@@ -1,0 +1,99 @@
+"""E2E: PetStore-shaped OpenAPI fragment → ASAP agent (mocked upstream)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from asap.adapters.openapi import create_from_openapi
+from asap.economics.audit import InMemoryAuditStore
+from asap.models.enums import TaskStatus
+from asap.models.envelope import Envelope
+from asap.models.payloads import TaskRequest, TaskResponse
+from asap.transport.client import ASAPClient
+from asap.transport.rate_limit import create_test_limiter
+from asap.transport.server import create_app
+
+from tests.transport.conftest import NoRateLimitTestBase
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_PETSTORE_FRAGMENT = _REPO_ROOT / "examples" / "openapi_petstore" / "openapi-fragment.json"
+
+
+def _pets_list_from_task_result(result: dict[str, Any] | None) -> list[Any]:
+    assert result is not None, "TaskResponse.result must be present for findPetsByStatus"
+    for key in ("value", "data", "body", "items", "response", "json", "_json"):
+        payload = result.get(key)
+        if isinstance(payload, list):
+            return payload
+    for _nested_key, val in result.items():
+        if isinstance(val, list):
+            return val
+    raise AssertionError(
+        f"Expected a list of pets in TaskResponse.result, got keys {sorted(result.keys())}",
+    )
+
+
+def _mock_petstore(request: httpx.Request) -> httpx.Response:
+    if request.method == "GET" and "findByStatus" in request.url.path:
+        return httpx.Response(
+            200,
+            json=[{"id": 42, "name": "MockPet", "status": "available"}],
+        )
+    return httpx.Response(404, text=f"unexpected: {request.method} {request.url}")
+
+
+class TestPetstoreOpenAPIAdapterE2E(NoRateLimitTestBase):
+    """E2E: PetStore-shaped fragment with mocked upstream."""
+
+    @pytest.mark.asyncio
+    async def test_find_pets_by_status_calls_upstream_and_returns_pet_list(self) -> None:
+        assert _PETSTORE_FRAGMENT.is_file(), f"missing fixture: {_PETSTORE_FRAGMENT}"
+        transport = httpx.MockTransport(_mock_petstore)
+        async with httpx.AsyncClient(transport=transport, timeout=30.0) as http:
+            built = await create_from_openapi(
+                spec_path=_PETSTORE_FRAGMENT,
+                http_client=http,
+                default_capabilities="GET",
+                manifest_id="urn:asap:agent:petstore-e2e",
+                asap_endpoint="http://test/asap",
+            )
+            audit = InMemoryAuditStore()
+            app = create_app(
+                built.manifest,
+                built.registry,
+                audit_store=audit,
+                rate_limit="999999/minute",
+            )
+            app.state.limiter = create_test_limiter()
+            asgi = httpx.ASGITransport(app=app)
+
+            envelope = Envelope(
+                asap_version="0.1",
+                sender="urn:asap:agent:petstore-test-client",
+                recipient=built.manifest.id,
+                payload_type="task.request",
+                payload=TaskRequest(
+                    conversation_id="conv-petstore-e2e",
+                    skill_id="findPetsByStatus",
+                    input={"status": "available"},
+                ).model_dump(),
+            )
+
+            async with ASAPClient(
+                "http://testserver",
+                transport=asgi,
+                require_https=False,
+            ) as client:
+                response = await client.send(envelope)
+
+        assert response.payload_type == "task.response"
+        task_response = TaskResponse.model_validate(response.payload_dict)
+        assert task_response.status == TaskStatus.COMPLETED
+        pets = _pets_list_from_task_result(task_response.result)
+        assert len(pets) >= 1
+        assert isinstance(pets[0], dict)
+        assert "id" in pets[0]

--- a/tests/adapters/openapi/test_approval.py
+++ b/tests/adapters/openapi/test_approval.py
@@ -1,0 +1,149 @@
+"""Unit tests for OpenAPI adapter approval strength (OA-008)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from asap.adapters.openapi.approval import (
+    collect_webauthn_required_capability_names,
+    normalize_approval_strength_map,
+    resolve_approval_strength,
+)
+from asap.adapters.openapi.capability_mapper import (
+    OpenAPIExecutionKind,
+    OpenAPICapability,
+    map_openapi_to_capabilities,
+)
+from asap.adapters.openapi.spec_loader import load_spec
+from asap.models.entities import Skill
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "openapi"
+
+
+def _write_tmp(data: dict[str, Any], name: str) -> Path:
+    path = _FIXTURES / f"_tmp_{name}.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def test_normalize_approval_strength_map_uppercases_verbs() -> None:
+    m = normalize_approval_strength_map({"get": "session", "POST": "webauthn"})
+    assert m == {"GET": "session", "POST": "webauthn"}
+
+
+def test_normalize_approval_strength_map_preserves_operation_id_case() -> None:
+    m = normalize_approval_strength_map({"deletePet": "webauthn"})
+    assert m == {"deletePet": "webauthn"}
+
+
+def test_normalize_approval_strength_map_rejects_invalid_value() -> None:
+    with pytest.raises(ValueError, match="Invalid approval_strength"):
+        normalize_approval_strength_map({"GET": "none"})
+
+
+def test_normalize_approval_strength_map_rejects_empty_string_value() -> None:
+    with pytest.raises(ValueError, match="non-empty string"):
+        normalize_approval_strength_map({"GET": "   "})
+
+
+def test_normalize_approval_strength_map_skips_whitespace_only_keys() -> None:
+    out = normalize_approval_strength_map({"  \t": "session", "post": "webauthn"})
+    assert out == {"POST": "webauthn"}
+
+
+@pytest.mark.asyncio
+async def test_collect_webauthn_uses_http_method_mapping() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/items": {
+                "get": {
+                    "operationId": "listItems",
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+            "/items/{id}": {
+                "delete": {
+                    "operationId": "removeItem",
+                    "responses": {"204": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "approval_methods")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        names = collect_webauthn_required_capability_names(
+            caps,
+            {"GET": "session", "DELETE": "webauthn"},
+        )
+        assert "removeItem" in names
+        assert "listItems" not in names
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_operation_id_overrides_method_strength() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/items/{id}": {
+                "delete": {
+                    "operationId": "softDelete",
+                    "responses": {"204": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "approval_op_override")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        mapping = normalize_approval_strength_map(
+            {"DELETE": "webauthn", "softDelete": "session"},
+        )
+        assert (
+            resolve_approval_strength(
+                http_method="delete",
+                operation_id=caps[0].operation_id,
+                mapping=mapping,
+            )
+            == "session"
+        )
+        names = collect_webauthn_required_capability_names(
+            caps,
+            {"DELETE": "webauthn", "softDelete": "session"},
+        )
+        assert names == []
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_collect_webauthn_deduplicates_same_skill_id() -> None:
+    skill = Skill(id="sharedId", description="x")
+    caps = [
+        OpenAPICapability(
+            skill=skill,
+            http_method="delete",
+            path_template="/a",
+            execution_kind=OpenAPIExecutionKind.SYNC,
+            operation_id="delA",
+        ),
+        OpenAPICapability(
+            skill=skill,
+            http_method="delete",
+            path_template="/b",
+            execution_kind=OpenAPIExecutionKind.SYNC,
+            operation_id="delB",
+        ),
+    ]
+    names = collect_webauthn_required_capability_names(caps, {"DELETE": "webauthn"})
+    assert names == ["sharedId"]

--- a/tests/adapters/openapi/test_capability_mapper.py
+++ b/tests/adapters/openapi/test_capability_mapper.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
@@ -11,21 +10,18 @@ import pytest
 from asap.adapters.openapi.capability_mapper import (
     OpenAPIExecutionKind,
     OpenAPIOperationContext,
+    _SchemaResolver,
     map_openapi_to_capabilities,
 )
 from asap.adapters.openapi.spec_loader import load_spec
 
+from tests.adapters.openapi.conftest import tmp_openapi_spec
+
 _FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "openapi"
 
 
-def _write_tmp(data: dict[str, Any], name: str) -> Path:
-    path = _FIXTURES / f"_tmp_{name}.json"
-    path.write_text(json.dumps(data), encoding="utf-8")
-    return path
-
-
 @pytest.mark.asyncio
-async def test_get_maps_path_and_query_parameters() -> None:
+async def test_get_maps_path_and_query_parameters(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -65,8 +61,7 @@ async def test_get_maps_path_and_query_parameters() -> None:
             },
         },
     }
-    path = _write_tmp(raw, "get_path_query")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "get_path_query") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         assert len(caps) == 1
@@ -87,12 +82,10 @@ async def test_get_maps_path_and_query_parameters() -> None:
         out = c0.skill.output_schema
         assert out is not None
         assert out["properties"]["id"]["type"] == "integer"
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_post_merges_json_body_with_allof() -> None:
+async def test_post_merges_json_body_with_allof(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -135,8 +128,7 @@ async def test_post_merges_json_body_with_allof() -> None:
             },
         },
     }
-    path = _write_tmp(raw, "post_body")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "post_body") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         assert len(caps) == 1
@@ -148,12 +140,10 @@ async def test_post_merges_json_body_with_allof() -> None:
         assert param_obj["properties"]["dryRun"]["x-openapi-param-in"] == "query"
         assert body_obj["properties"]["name"]["type"] == "string"
         assert body_obj["required"] == ["name"]
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_response_resolves_component_schema_ref() -> None:
+async def test_response_resolves_component_schema_ref(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -186,20 +176,17 @@ async def test_response_resolves_component_schema_ref() -> None:
             },
         },
     }
-    path = _write_tmp(raw, "ref_response")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "ref_response") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         out = caps[0].skill.output_schema
         assert out is not None
         assert "$ref" not in out
         assert out["properties"]["name"]["type"] == "string"
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_missing_operation_id_uses_method_and_path_fallback() -> None:
+async def test_missing_operation_id_uses_method_and_path_fallback(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -212,19 +199,16 @@ async def test_missing_operation_id_uses_method_and_path_fallback() -> None:
             },
         },
     }
-    path = _write_tmp(raw, "no_op_id")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "no_op_id") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         assert len(caps) == 1
         assert caps[0].skill.id == "get_pets_petId"
         assert caps[0].operation_id is None
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_parameter_reference_from_components() -> None:
+async def test_parameter_reference_from_components(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -248,15 +232,12 @@ async def test_parameter_reference_from_components() -> None:
             },
         },
     }
-    path = _write_tmp(raw, "param_ref")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "param_ref") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         inp = caps[0].skill.input_schema
         assert inp is not None
         assert inp["properties"]["petId"]["type"] == "string"
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
@@ -300,56 +281,43 @@ _MULTI_OP_RAW: dict[str, Any] = {
 
 
 @pytest.mark.asyncio
-async def test_default_capabilities_single_method_keeps_get_operations() -> None:
-    path = _write_tmp(_MULTI_OP_RAW, "filter_get")
-    try:
+async def test_default_capabilities_single_method_keeps_get_operations(tmp_path: Path) -> None:
+    with tmp_openapi_spec(tmp_path, _MULTI_OP_RAW, "filter_get") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc, default_capabilities="GET")
         ids = {c.skill.id for c in caps}
         assert ids == {"listItems", "getItem"}
         assert all(c.http_method == "get" for c in caps)
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_default_capabilities_single_method_post_case_insensitive() -> None:
-    path = _write_tmp(_MULTI_OP_RAW, "filter_post")
-    try:
+async def test_default_capabilities_single_method_post_case_insensitive(tmp_path: Path) -> None:
+    with tmp_openapi_spec(tmp_path, _MULTI_OP_RAW, "filter_post") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc, default_capabilities="post")
         assert [c.skill.id for c in caps] == ["createItem"]
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_default_capabilities_single_method_no_match_returns_empty() -> None:
-    path = _write_tmp(_MULTI_OP_RAW, "filter_patch")
-    try:
+async def test_default_capabilities_single_method_no_match_returns_empty(tmp_path: Path) -> None:
+    with tmp_openapi_spec(tmp_path, _MULTI_OP_RAW, "filter_patch") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc, default_capabilities="patch")
         assert caps == []
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_default_capabilities_sequence_get_and_head() -> None:
-    path = _write_tmp(_MULTI_OP_RAW, "filter_get_head")
-    try:
+async def test_default_capabilities_sequence_get_and_head(tmp_path: Path) -> None:
+    with tmp_openapi_spec(tmp_path, _MULTI_OP_RAW, "filter_get_head") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc, default_capabilities=["GET", "HEAD"])
         ids = {c.skill.id for c in caps}
         assert ids == {"listItems", "listItemsHead", "getItem"}
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_default_capabilities_sequence_excludes_unlisted_verbs() -> None:
-    path = _write_tmp(_MULTI_OP_RAW, "filter_no_delete")
-    try:
+async def test_default_capabilities_sequence_excludes_unlisted_verbs(tmp_path: Path) -> None:
+    with tmp_openapi_spec(tmp_path, _MULTI_OP_RAW, "filter_no_delete") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(
             doc,
@@ -358,14 +326,11 @@ async def test_default_capabilities_sequence_excludes_unlisted_verbs() -> None:
         ids = {c.skill.id for c in caps}
         assert "deleteItem" not in ids
         assert "createItem" in ids
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_default_capabilities_sequence_is_case_insensitive() -> None:
-    path = _write_tmp(_MULTI_OP_RAW, "filter_mixed_case")
-    try:
+async def test_default_capabilities_sequence_is_case_insensitive(tmp_path: Path) -> None:
+    with tmp_openapi_spec(tmp_path, _MULTI_OP_RAW, "filter_mixed_case") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(
             doc,
@@ -373,14 +338,11 @@ async def test_default_capabilities_sequence_is_case_insensitive() -> None:
         )
         ids = {c.skill.id for c in caps}
         assert ids == {"listItems", "listItemsHead", "getItem"}
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_default_capabilities_all_includes_every_operation() -> None:
-    path = _write_tmp(_MULTI_OP_RAW, "filter_all")
-    try:
+async def test_default_capabilities_all_includes_every_operation(tmp_path: Path) -> None:
+    with tmp_openapi_spec(tmp_path, _MULTI_OP_RAW, "filter_all") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc, default_capabilities="all")
         assert len(caps) == 5
@@ -391,21 +353,16 @@ async def test_default_capabilities_all_includes_every_operation() -> None:
             "getItem",
             "deleteItem",
         }
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_default_capabilities_default_equals_explicit_all() -> None:
-    path = _write_tmp(_MULTI_OP_RAW, "filter_default_all")
-    try:
+async def test_default_capabilities_default_equals_explicit_all(tmp_path: Path) -> None:
+    with tmp_openapi_spec(tmp_path, _MULTI_OP_RAW, "filter_default_all") as path:
         doc = await load_spec(path)
         assert map_openapi_to_capabilities(doc) == map_openapi_to_capabilities(
             doc,
             default_capabilities="all",
         )
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
@@ -415,9 +372,8 @@ async def test_default_capabilities_all_on_empty_paths() -> None:
 
 
 @pytest.mark.asyncio
-async def test_default_capabilities_callable_filters_by_operation_id() -> None:
-    path = _write_tmp(_MULTI_OP_RAW, "filter_callable_id")
-    try:
+async def test_default_capabilities_callable_filters_by_operation_id(tmp_path: Path) -> None:
+    with tmp_openapi_spec(tmp_path, _MULTI_OP_RAW, "filter_callable_id") as path:
         doc = await load_spec(path)
 
         def _pred(ctx: OpenAPIOperationContext) -> bool:
@@ -426,14 +382,11 @@ async def test_default_capabilities_callable_filters_by_operation_id() -> None:
         caps = map_openapi_to_capabilities(doc, default_capabilities=_pred)
         ids = {c.skill.id for c in caps}
         assert ids == {"listItems", "listItemsHead"}
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_default_capabilities_callable_filters_by_path_and_method() -> None:
-    path = _write_tmp(_MULTI_OP_RAW, "filter_callable_path")
-    try:
+async def test_default_capabilities_callable_filters_by_path_and_method(tmp_path: Path) -> None:
+    with tmp_openapi_spec(tmp_path, _MULTI_OP_RAW, "filter_callable_path") as path:
         doc = await load_spec(path)
 
         def _pred(ctx: OpenAPIOperationContext) -> bool:
@@ -441,23 +394,18 @@ async def test_default_capabilities_callable_filters_by_path_and_method() -> Non
 
         caps = map_openapi_to_capabilities(doc, default_capabilities=_pred)
         assert [c.skill.id for c in caps] == ["getItem"]
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_default_capabilities_callable_rejects_everything() -> None:
-    path = _write_tmp(_MULTI_OP_RAW, "filter_callable_empty")
-    try:
+async def test_default_capabilities_callable_rejects_everything(tmp_path: Path) -> None:
+    with tmp_openapi_spec(tmp_path, _MULTI_OP_RAW, "filter_callable_empty") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc, default_capabilities=lambda _ctx: False)
         assert caps == []
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_execution_kind_streaming_when_text_event_stream_response() -> None:
+async def test_execution_kind_streaming_when_text_event_stream_response(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -477,18 +425,15 @@ async def test_execution_kind_streaming_when_text_event_stream_response() -> Non
             },
         },
     }
-    path = _write_tmp(raw, "exec_sse")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "exec_sse") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         assert len(caps) == 1
         assert caps[0].execution_kind == OpenAPIExecutionKind.STREAMING
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_execution_kind_async_polling_when_202_and_location_header() -> None:
+async def test_execution_kind_async_polling_when_202_and_location_header(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -508,18 +453,15 @@ async def test_execution_kind_async_polling_when_202_and_location_header() -> No
             },
         },
     }
-    path = _write_tmp(raw, "exec_202")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "exec_202") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         assert len(caps) == 1
         assert caps[0].execution_kind == OpenAPIExecutionKind.ASYNC_POLLING
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_execution_kind_sync_for_typical_json_ok_response() -> None:
+async def test_execution_kind_sync_for_typical_json_ok_response(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -541,18 +483,15 @@ async def test_execution_kind_sync_for_typical_json_ok_response() -> None:
             },
         },
     }
-    path = _write_tmp(raw, "exec_sync")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "exec_sync") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         assert len(caps) == 1
         assert caps[0].execution_kind == OpenAPIExecutionKind.SYNC
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_default_capabilities_invalid_type_raises_type_error() -> None:
+async def test_default_capabilities_invalid_type_raises_type_error(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -560,10 +499,22 @@ async def test_default_capabilities_invalid_type_raises_type_error() -> None:
             "/z": {"get": {"operationId": "z", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "bad_filter_type")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "bad_filter_type") as path:
         doc = await load_spec(path)
         with pytest.raises(TypeError, match="default_capabilities"):
             map_openapi_to_capabilities(doc, default_capabilities=object())
-    finally:
-        path.unlink(missing_ok=True)
+
+
+def test_expand_refs_depth_returns_early_without_error_on_deep_trees() -> None:
+    """Regression: pathological schema-shape dicts cannot recurse deeper than depth 51."""
+    resolver = _SchemaResolver({})
+    root: dict[str, Any] = {"top": 1}
+    cur = root
+    for _ in range(52):
+        nxt: dict[str, Any] = {}
+        cur["child"] = nxt
+        cur = nxt
+    cur["leaf"] = 2
+    result = resolver.expand_refs(root, frozenset())
+    assert result["top"] == 1
+    assert isinstance(result["child"], dict)

--- a/tests/adapters/openapi/test_capability_mapper.py
+++ b/tests/adapters/openapi/test_capability_mapper.py
@@ -1,0 +1,569 @@
+"""Unit tests for OpenAPI → ASAP capability mapping."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from asap.adapters.openapi.capability_mapper import (
+    OpenAPIExecutionKind,
+    OpenAPIOperationContext,
+    map_openapi_to_capabilities,
+)
+from asap.adapters.openapi.spec_loader import load_spec
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "openapi"
+
+
+def _write_tmp(data: dict[str, Any], name: str) -> Path:
+    path = _FIXTURES / f"_tmp_{name}.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+@pytest.mark.asyncio
+async def test_get_maps_path_and_query_parameters() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/pets/{petId}": {
+                "get": {
+                    "operationId": "getPet",
+                    "summary": "Get a pet",
+                    "parameters": [
+                        {
+                            "name": "petId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        },
+                        {
+                            "name": "verbose",
+                            "in": "query",
+                            "required": False,
+                            "schema": {"type": "boolean"},
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "ok",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {"id": {"type": "integer"}},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "get_path_query")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        assert len(caps) == 1
+        c0 = caps[0]
+        assert c0.skill.id == "getPet"
+        assert c0.operation_id == "getPet"
+        assert c0.http_method == "get"
+        assert c0.path_template == "/pets/{petId}"
+        assert c0.execution_kind == OpenAPIExecutionKind.SYNC
+        assert c0.skill.description == "Get a pet"
+        inp = c0.skill.input_schema
+        assert inp is not None
+        props = inp["properties"]
+        assert props["petId"]["type"] == "string"
+        assert props["petId"]["x-openapi-param-in"] == "path"
+        assert props["verbose"]["x-openapi-param-in"] == "query"
+        assert inp["required"] == ["petId"]
+        out = c0.skill.output_schema
+        assert out is not None
+        assert out["properties"]["id"]["type"] == "integer"
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_post_merges_json_body_with_allof() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/pets": {
+                "post": {
+                    "operationId": "createPet",
+                    "parameters": [
+                        {
+                            "name": "dryRun",
+                            "in": "query",
+                            "schema": {"type": "boolean"},
+                        },
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {"name": {"type": "string"}},
+                                    "required": ["name"],
+                                },
+                            },
+                        },
+                    },
+                    "responses": {
+                        "201": {
+                            "description": "created",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {"id": {"type": "integer"}},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "post_body")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        assert len(caps) == 1
+        inp = caps[0].skill.input_schema
+        assert inp is not None
+        assert "allOf" in inp
+        assert len(inp["allOf"]) == 2
+        param_obj, body_obj = inp["allOf"]
+        assert param_obj["properties"]["dryRun"]["x-openapi-param-in"] == "query"
+        assert body_obj["properties"]["name"]["type"] == "string"
+        assert body_obj["required"] == ["name"]
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_response_resolves_component_schema_ref() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "components": {
+            "schemas": {
+                "Pet": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "name": {"type": "string"},
+                    },
+                },
+            },
+        },
+        "paths": {
+            "/pets": {
+                "get": {
+                    "operationId": "listPets",
+                    "responses": {
+                        "200": {
+                            "description": "ok",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Pet"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "ref_response")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        out = caps[0].skill.output_schema
+        assert out is not None
+        assert "$ref" not in out
+        assert out["properties"]["name"]["type"] == "string"
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_missing_operation_id_uses_method_and_path_fallback() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/pets/{petId}": {
+                "get": {
+                    "summary": "Implicit id",
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "no_op_id")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        assert len(caps) == 1
+        assert caps[0].skill.id == "get_pets_petId"
+        assert caps[0].operation_id is None
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_parameter_reference_from_components() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "components": {
+            "parameters": {
+                "PetId": {
+                    "name": "petId",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                },
+            },
+        },
+        "paths": {
+            "/pets/{petId}": {
+                "get": {
+                    "operationId": "getPetRefParam",
+                    "parameters": [{"$ref": "#/components/parameters/PetId"}],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "param_ref")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        inp = caps[0].skill.input_schema
+        assert inp is not None
+        assert inp["properties"]["petId"]["type"] == "string"
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_openapi_3_1_document() -> None:
+    path = _FIXTURES / "minimal-3.1.0.json"
+    doc = await load_spec(path)
+    caps = map_openapi_to_capabilities(doc)
+    assert caps == []
+
+
+_MULTI_OP_RAW: dict[str, Any] = {
+    "openapi": "3.0.3",
+    "info": {"title": "T", "version": "1"},
+    "paths": {
+        "/items": {
+            "get": {
+                "operationId": "listItems",
+                "responses": {"200": {"description": "ok"}},
+            },
+            "head": {
+                "operationId": "listItemsHead",
+                "responses": {"200": {"description": "ok"}},
+            },
+            "post": {
+                "operationId": "createItem",
+                "responses": {"200": {"description": "ok"}},
+            },
+        },
+        "/items/{id}": {
+            "get": {
+                "operationId": "getItem",
+                "responses": {"200": {"description": "ok"}},
+            },
+            "delete": {
+                "operationId": "deleteItem",
+                "responses": {"200": {"description": "ok"}},
+            },
+        },
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_single_method_keeps_get_operations() -> None:
+    path = _write_tmp(_MULTI_OP_RAW, "filter_get")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc, default_capabilities="GET")
+        ids = {c.skill.id for c in caps}
+        assert ids == {"listItems", "getItem"}
+        assert all(c.http_method == "get" for c in caps)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_single_method_post_case_insensitive() -> None:
+    path = _write_tmp(_MULTI_OP_RAW, "filter_post")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc, default_capabilities="post")
+        assert [c.skill.id for c in caps] == ["createItem"]
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_single_method_no_match_returns_empty() -> None:
+    path = _write_tmp(_MULTI_OP_RAW, "filter_patch")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc, default_capabilities="patch")
+        assert caps == []
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_sequence_get_and_head() -> None:
+    path = _write_tmp(_MULTI_OP_RAW, "filter_get_head")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc, default_capabilities=["GET", "HEAD"])
+        ids = {c.skill.id for c in caps}
+        assert ids == {"listItems", "listItemsHead", "getItem"}
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_sequence_excludes_unlisted_verbs() -> None:
+    path = _write_tmp(_MULTI_OP_RAW, "filter_no_delete")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(
+            doc,
+            default_capabilities=["GET", "HEAD", "POST"],
+        )
+        ids = {c.skill.id for c in caps}
+        assert "deleteItem" not in ids
+        assert "createItem" in ids
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_sequence_is_case_insensitive() -> None:
+    path = _write_tmp(_MULTI_OP_RAW, "filter_mixed_case")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(
+            doc,
+            default_capabilities=("get", "HeAd"),
+        )
+        ids = {c.skill.id for c in caps}
+        assert ids == {"listItems", "listItemsHead", "getItem"}
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_all_includes_every_operation() -> None:
+    path = _write_tmp(_MULTI_OP_RAW, "filter_all")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc, default_capabilities="all")
+        assert len(caps) == 5
+        assert {c.skill.id for c in caps} == {
+            "listItems",
+            "listItemsHead",
+            "createItem",
+            "getItem",
+            "deleteItem",
+        }
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_default_equals_explicit_all() -> None:
+    path = _write_tmp(_MULTI_OP_RAW, "filter_default_all")
+    try:
+        doc = await load_spec(path)
+        assert map_openapi_to_capabilities(doc) == map_openapi_to_capabilities(
+            doc,
+            default_capabilities="all",
+        )
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_all_on_empty_paths() -> None:
+    doc = await load_spec(_FIXTURES / "minimal-3.0.3.json")
+    assert map_openapi_to_capabilities(doc, default_capabilities="all") == []
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_callable_filters_by_operation_id() -> None:
+    path = _write_tmp(_MULTI_OP_RAW, "filter_callable_id")
+    try:
+        doc = await load_spec(path)
+
+        def _pred(ctx: OpenAPIOperationContext) -> bool:
+            return ctx.operation_id is not None and ctx.operation_id.startswith("list")
+
+        caps = map_openapi_to_capabilities(doc, default_capabilities=_pred)
+        ids = {c.skill.id for c in caps}
+        assert ids == {"listItems", "listItemsHead"}
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_callable_filters_by_path_and_method() -> None:
+    path = _write_tmp(_MULTI_OP_RAW, "filter_callable_path")
+    try:
+        doc = await load_spec(path)
+
+        def _pred(ctx: OpenAPIOperationContext) -> bool:
+            return ctx.path_template.startswith("/items/") and ctx.http_method == "get"
+
+        caps = map_openapi_to_capabilities(doc, default_capabilities=_pred)
+        assert [c.skill.id for c in caps] == ["getItem"]
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_callable_rejects_everything() -> None:
+    path = _write_tmp(_MULTI_OP_RAW, "filter_callable_empty")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc, default_capabilities=lambda _ctx: False)
+        assert caps == []
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execution_kind_streaming_when_text_event_stream_response() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/events": {
+                "get": {
+                    "operationId": "subscribe",
+                    "responses": {
+                        "200": {
+                            "description": "sse",
+                            "content": {
+                                "text/event-stream": {"schema": {"type": "string"}},
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "exec_sse")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        assert len(caps) == 1
+        assert caps[0].execution_kind == OpenAPIExecutionKind.STREAMING
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execution_kind_async_polling_when_202_and_location_header() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/jobs": {
+                "post": {
+                    "operationId": "startJob",
+                    "responses": {
+                        "202": {
+                            "description": "Accepted",
+                            "headers": {
+                                "Location": {"schema": {"type": "string", "format": "uri"}},
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "exec_202")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        assert len(caps) == 1
+        assert caps[0].execution_kind == OpenAPIExecutionKind.ASYNC_POLLING
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execution_kind_sync_for_typical_json_ok_response() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/items": {
+                "get": {
+                    "operationId": "listItems",
+                    "responses": {
+                        "200": {
+                            "description": "ok",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "array", "items": {"type": "string"}},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "exec_sync")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        assert len(caps) == 1
+        assert caps[0].execution_kind == OpenAPIExecutionKind.SYNC
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_default_capabilities_invalid_type_raises_type_error() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/z": {"get": {"operationId": "z", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "bad_filter_type")
+    try:
+        doc = await load_spec(path)
+        with pytest.raises(TypeError, match="default_capabilities"):
+            map_openapi_to_capabilities(doc, default_capabilities=object())
+    finally:
+        path.unlink(missing_ok=True)

--- a/tests/adapters/openapi/test_factory.py
+++ b/tests/adapters/openapi/test_factory.py
@@ -185,7 +185,7 @@ async def test_manifest_streaming_true_when_operation_is_sse() -> None:
 
 
 @pytest.mark.asyncio
-async def test_kwargs_are_ignored_for_forward_compatibility() -> None:
+async def test_kwargs_unknown_keys_emit_warning() -> None:
     payload = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -196,9 +196,19 @@ async def test_kwargs_are_ignored_for_forward_compatibility() -> None:
     }
     transport = _transport_json(payload)
     async with httpx.AsyncClient(transport=transport) as client:
-        bundle = await create_from_openapi(
-            spec_url="https://ex/o.json",
-            http_client=client,
-            _forward_compat_reserved=True,
-        )
+        with pytest.warns(
+            UserWarning, match=r"create_from_openapi ignored unexpected keyword arguments"
+        ):
+            bundle = await create_from_openapi(
+                spec_url="https://ex/o.json",
+                http_client=client,
+                _forward_compat_reserved=True,
+            )
     assert bundle.upstream_base_url == "https://api.example"
+
+
+def test_asap_package_lazy_exports_create_from_openapi() -> None:
+    """Top-level ``asap.create_from_openapi`` is a lazy alias (RF-3)."""
+    import asap as asap_mod
+
+    assert asap_mod.create_from_openapi is create_from_openapi

--- a/tests/adapters/openapi/test_factory.py
+++ b/tests/adapters/openapi/test_factory.py
@@ -1,0 +1,204 @@
+"""Tests for OpenAPI adapter factory (`create_from_openapi`)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from asap.adapters.openapi.factory import create_from_openapi
+from asap.adapters.openapi.spec_loader import OpenAPISpecError
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "openapi"
+
+
+def _transport_json(data: dict[str, Any]) -> httpx.MockTransport:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=data)
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.asyncio
+async def test_create_from_openapi_requires_exactly_one_spec_source() -> None:
+    doc = {"openapi": "3.0.3", "info": {"title": "T", "version": "1"}, "paths": {}}
+    transport = _transport_json(doc)
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(OpenAPISpecError, match="Exactly one of spec_url"):
+            await create_from_openapi(spec_url=None, spec_path=None, http_client=client)
+        with pytest.raises(OpenAPISpecError, match="Exactly one of spec_url"):
+            await create_from_openapi(
+                spec_url="https://a/x.json",
+                spec_path=_FIXTURES / "minimal-3.0.3.json",
+                http_client=client,
+            )
+
+
+@pytest.mark.asyncio
+async def test_infer_upstream_from_servers_absolute_url() -> None:
+    payload = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "servers": [{"url": "https://api.example/v1"}],
+        "paths": {
+            "/p": {"get": {"operationId": "p", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    transport = _transport_json(payload)
+    async with httpx.AsyncClient(transport=transport) as client:
+        bundle = await create_from_openapi(
+            spec_url="https://spec.example/o.json", http_client=client
+        )
+    assert bundle.upstream_base_url == "https://api.example/v1"
+    assert bundle.manifest.capabilities.streaming is False
+
+
+@pytest.mark.asyncio
+async def test_infer_upstream_relative_url_joined_with_spec_url() -> None:
+    payload = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "servers": [{"url": "/v3"}],
+        "paths": {
+            "/p": {"get": {"operationId": "p", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    transport = _transport_json(payload)
+    async with httpx.AsyncClient(transport=transport) as client:
+        bundle = await create_from_openapi(
+            spec_url="https://petstore.example/api/openapi.json",
+            http_client=client,
+        )
+    assert bundle.upstream_base_url == "https://petstore.example/v3"
+
+
+@pytest.mark.asyncio
+async def test_relative_server_on_local_spec_requires_upstream_override() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "servers": [{"url": "/api"}],
+        "paths": {
+            "/z": {"get": {"operationId": "z", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    tmp = _FIXTURES / "_tmp_factory_relative_server.json"
+    tmp.write_text(json.dumps(raw), encoding="utf-8")
+    try:
+        transport = httpx.MockTransport(lambda _r: httpx.Response(500))
+        async with httpx.AsyncClient(transport=transport) as client:
+            with pytest.raises(OpenAPISpecError, match="Relative OpenAPI server URL"):
+                await create_from_openapi(spec_path=tmp, http_client=client)
+            bundle = await create_from_openapi(
+                spec_path=tmp,
+                http_client=client,
+                upstream_base_url="https://origin.example",
+            )
+        assert bundle.upstream_base_url == "https://origin.example"
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_no_servers_requires_upstream_base_url() -> None:
+    payload = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "servers": [],
+        "paths": {
+            "/x": {"get": {"operationId": "x", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    transport = _transport_json(payload)
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(OpenAPISpecError, match="no `servers`"):
+            await create_from_openapi(spec_url="https://ex/o.json", http_client=client)
+        bundle = await create_from_openapi(
+            spec_url="https://ex/o.json",
+            http_client=client,
+            upstream_base_url="https://forced.example",
+        )
+    assert bundle.upstream_base_url == "https://forced.example"
+
+
+@pytest.mark.asyncio
+async def test_empty_server_url_raises() -> None:
+    payload = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "servers": [{"url": "   "}],
+        "paths": {},
+    }
+    transport = _transport_json(payload)
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(OpenAPISpecError, match=r"servers\[0\]\.url"):
+            await create_from_openapi(spec_url="https://ex/o.json", http_client=client)
+
+
+@pytest.mark.asyncio
+async def test_upstream_base_url_override_strips_trailing_slash() -> None:
+    payload = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "servers": [{"url": "https://ignored.example/"}],
+        "paths": {
+            "/a": {"get": {"operationId": "a", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    transport = _transport_json(payload)
+    async with httpx.AsyncClient(transport=transport) as client:
+        bundle = await create_from_openapi(
+            spec_url="https://ex/o.json",
+            http_client=client,
+            upstream_base_url=" https://custom.example/base/ ",
+        )
+    assert bundle.upstream_base_url == "https://custom.example/base"
+
+
+@pytest.mark.asyncio
+async def test_manifest_streaming_true_when_operation_is_sse() -> None:
+    payload = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "servers": [{"url": "https://api.example"}],
+        "paths": {
+            "/events": {
+                "get": {
+                    "operationId": "subscribe",
+                    "responses": {
+                        "200": {
+                            "description": "sse",
+                            "content": {"text/event-stream": {"schema": {"type": "string"}}},
+                        },
+                    },
+                },
+            },
+        },
+    }
+    transport = _transport_json(payload)
+    async with httpx.AsyncClient(transport=transport) as client:
+        bundle = await create_from_openapi(spec_url="https://ex/o.json", http_client=client)
+    assert bundle.manifest.capabilities.streaming is True
+
+
+@pytest.mark.asyncio
+async def test_kwargs_are_ignored_for_forward_compatibility() -> None:
+    payload = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "servers": [{"url": "https://api.example"}],
+        "paths": {
+            "/p": {"get": {"operationId": "p", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    transport = _transport_json(payload)
+    async with httpx.AsyncClient(transport=transport) as client:
+        bundle = await create_from_openapi(
+            spec_url="https://ex/o.json",
+            http_client=client,
+            _forward_compat_reserved=True,
+        )
+    assert bundle.upstream_base_url == "https://api.example"

--- a/tests/adapters/openapi/test_handler.py
+++ b/tests/adapters/openapi/test_handler.py
@@ -1,0 +1,770 @@
+"""Unit tests for OpenAPI upstream execution (mocked httpx)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import pytest
+from unittest.mock import AsyncMock
+
+from asap.adapters.openapi.capability_mapper import (
+    OpenAPIExecutionKind,
+    OpenAPICapability,
+    map_openapi_to_capabilities,
+)
+from asap.adapters.openapi.handler import (
+    OpenAPIInvocationError,
+    OpenAPIPathParameterError,
+    OpenAPIUpstreamHandler,
+    UnknownOpenAPICapabilityError,
+    create_openapi_task_handler,
+    execute,
+    index_capabilities,
+)
+from asap.adapters.openapi.spec_loader import load_spec
+from asap.errors import FatalError, RecoverableError
+from asap.models.entities import Capability, Endpoint, Manifest, Skill
+from asap.models.envelope import Envelope
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "openapi"
+
+
+def _write_tmp(data: dict[str, Any], name: str) -> Path:
+    path = _FIXTURES / f"_tmp_handler_{name}.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+@pytest.mark.asyncio
+async def test_execute_get_path_and_query_via_mocked_httpx() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/pets/{petId}": {
+                "get": {
+                    "operationId": "getPet",
+                    "parameters": [
+                        {
+                            "name": "petId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        },
+                        {
+                            "name": "verbose",
+                            "in": "query",
+                            "required": False,
+                            "schema": {"type": "boolean"},
+                        },
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "get_proxy")
+    seen: dict[str, Any] = {}
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["url"] = str(request.url)
+        assert request.url.path == "/pets/abc-1"
+        assert request.url.params.get("verbose") == "false"
+        return httpx.Response(200, json={"ok": True})
+
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        transport = httpx.MockTransport(transport_handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://upstream.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            out = await handler.execute(
+                "getPet",
+                {"petId": "abc-1", "verbose": False},
+                session=None,
+            )
+        assert out == {"ok": True}
+        assert seen["method"] == "GET"
+        assert str(httpx.URL(seen["url"]).host) == "upstream.test"
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execute_post_json_body_and_query_via_mocked_httpx() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/pets": {
+                "post": {
+                    "operationId": "createPet",
+                    "parameters": [
+                        {
+                            "name": "dryRun",
+                            "in": "query",
+                            "schema": {"type": "boolean"},
+                        },
+                    ],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {"name": {"type": "string"}},
+                                    "required": ["name"],
+                                },
+                            },
+                        },
+                    },
+                    "responses": {"201": {"description": "created"}},
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "post_proxy")
+    captured: dict[str, Any] = {}
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["query"] = dict(request.url.params)
+        captured["json"] = json.loads(request.content.decode())
+        assert request.url.path == "/pets"
+        return httpx.Response(201, json={"id": 42})
+
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        transport = httpx.MockTransport(transport_handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://api.items",
+                capabilities=caps,
+                http_client=client,
+            )
+            out = await execute(
+                handler,
+                "createPet",
+                {"dryRun": True, "name": "Neko"},
+            )
+        assert out == {"id": 42}
+        assert captured["method"] == "POST"
+        assert captured["query"].get("dryRun") == "true"
+        assert captured["json"] == {"name": "Neko"}
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execute_unknown_capability_raises() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/x": {"get": {"operationId": "onlyOne", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "unknown_cap")
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        transport = httpx.MockTransport(transport_handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://e.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            with pytest.raises(UnknownOpenAPICapabilityError) as exc_info:
+                await handler.execute("missingCapability", {})
+        assert exc_info.value.capability_name == "missingCapability"
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execute_module_wrapper_delegates() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/ping": {"get": {"operationId": "ping", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "wrapper")
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(204)
+
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        transport = httpx.MockTransport(transport_handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://p.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            assert await execute(handler, "ping", {}) == {}
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_resolve_headers_merged_with_openapi_header_params() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/items": {
+                "get": {
+                    "operationId": "listItems",
+                    "parameters": [
+                        {
+                            "name": "X-Request-Label",
+                            "in": "header",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        },
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "resolve_merge")
+    seen: dict[str, Any] = {}
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        seen["authorization"] = request.headers.get("authorization")
+        seen["x_request_label"] = request.headers.get("x-request-label")
+        seen["x_session"] = request.headers.get("x-session-ctx")
+        return httpx.Response(200, json={"items": []})
+
+    class _Session:
+        token = "secret"
+
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+
+        def resolve_headers(session: object | None) -> dict[str, str]:
+            assert isinstance(session, _Session)
+            return {
+                "Authorization": f"Bearer {session.token}",
+                "X-Session-Ctx": "host",
+            }
+
+        transport = httpx.MockTransport(transport_handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://svc.test",
+                capabilities=caps,
+                http_client=client,
+                resolve_headers=resolve_headers,
+            )
+            out = await handler.execute(
+                "listItems",
+                {"X-Request-Label": "job-1"},
+                session=_Session(),
+            )
+        assert out == {"items": []}
+        assert seen["authorization"] == "Bearer secret"
+        assert seen["x_request_label"] == "job-1"
+        assert seen["x_session"] == "host"
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_resolve_headers_openapi_header_params_override_callback() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/r": {
+                "get": {
+                    "operationId": "r",
+                    "parameters": [
+                        {
+                            "name": "X-Trace",
+                            "in": "header",
+                            "schema": {"type": "string"},
+                        },
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "resolve_override")
+    seen: dict[str, Any] = {}
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        seen["x_trace"] = request.headers.get("x-trace")
+        return httpx.Response(200, json={})
+
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+
+        def resolve_headers(_session: object | None) -> dict[str, str]:
+            return {"X-Trace": "from-resolve", "Authorization": "Bearer z"}
+
+        transport = httpx.MockTransport(transport_handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://svc.test",
+                capabilities=caps,
+                http_client=client,
+                resolve_headers=resolve_headers,
+            )
+            await handler.execute("r", {"X-Trace": "from-args"}, session=None)
+        assert seen["x_trace"] == "from-args"
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_resolve_headers_callback_failure_is_recoverable_unauthorized() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/z": {"get": {"operationId": "z", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "resolve_fail")
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+
+        def resolve_headers(_session: object | None) -> dict[str, str]:
+            raise PermissionError("missing OAuth token")
+
+        transport = httpx.MockTransport(transport_handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://svc.test",
+                capabilities=caps,
+                http_client=client,
+                resolve_headers=resolve_headers,
+            )
+            with pytest.raises(RecoverableError, match="resolve_headers callback failed"):
+                await handler.execute("z", {}, session=None)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_resolve_headers_invalid_return_type_is_recoverable() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/z": {"get": {"operationId": "z2", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "resolve_bad_type")
+
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+
+        def resolve_headers(_session: object | None) -> dict[str, str]:
+            bad: object = [("only", "list")]
+            return cast("dict[str, str]", bad)
+
+        transport = httpx.MockTransport(lambda _r: httpx.Response(200, json={}))
+        async with httpx.AsyncClient(transport=transport) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://svc.test",
+                capabilities=caps,
+                http_client=client,
+                resolve_headers=resolve_headers,
+            )
+            with pytest.raises(RecoverableError, match="resolve_headers must return dict"):
+                await handler.execute("z2", {}, session=None)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_index_capabilities_duplicate_skill_id_raises() -> None:
+    skill = Skill(id="dup", description="d")
+    c1 = OpenAPICapability(
+        skill=skill,
+        http_method="get",
+        path_template="/a",
+        execution_kind=OpenAPIExecutionKind.SYNC,
+    )
+    c2 = OpenAPICapability(
+        skill=skill,
+        http_method="get",
+        path_template="/b",
+        execution_kind=OpenAPIExecutionKind.SYNC,
+    )
+    with pytest.raises(ValueError, match="Duplicate OpenAPI capability"):
+        index_capabilities([c1, c2])
+
+
+@pytest.mark.asyncio
+async def test_execute_cookie_parameter_sets_cookie_header() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/c": {
+                "get": {
+                    "operationId": "withCookie",
+                    "parameters": [
+                        {
+                            "name": "sid",
+                            "in": "cookie",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        },
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "cookie_param")
+    seen: dict[str, Any] = {}
+
+    def transport_handler(request: httpx.Request) -> httpx.Response:
+        seen["cookie"] = request.headers.get("cookie")
+        return httpx.Response(200, json={"ok": True})
+
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        transport = httpx.MockTransport(transport_handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://upstream.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            await handler.execute("withCookie", {"sid": "abc123"}, session=None)
+        assert seen.get("cookie") == "sid=abc123"
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execute_missing_path_parameter_raises() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/pets/{petId}": {
+                "get": {
+                    "operationId": "getPet",
+                    "parameters": [
+                        {
+                            "name": "petId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        },
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    path = _write_tmp(raw, "missing_path")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200))
+        ) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://u.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            with pytest.raises(OpenAPIPathParameterError, match="Missing path parameter"):
+                await handler.execute("getPet", {}, session=None)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execute_unexpected_argument_raises() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/z": {"get": {"operationId": "z", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "unexpected_arg")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200))
+        ) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://u.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            with pytest.raises(OpenAPIInvocationError, match="Unexpected argument"):
+                await handler.execute("z", {"extra": "nope"}, session=None)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_resolve_headers_non_string_values_are_recoverable() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/z": {"get": {"operationId": "z3", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "resolve_non_str")
+
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+
+        def resolve_headers(_session: object | None) -> dict[str, str]:
+            return cast("dict[str, str]", {"Authorization": 123})
+
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200))
+        ) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://svc.test",
+                capabilities=caps,
+                http_client=client,
+                resolve_headers=resolve_headers,
+            )
+            with pytest.raises(RecoverableError, match="str keys and str values"):
+                await handler.execute("z3", {}, session=None)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execute_upstream_connection_error_is_recoverable() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/z": {"get": {"operationId": "z4", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "conn_err")
+    req = httpx.Request("GET", "https://upstream.test/z")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        mock_http = AsyncMock()
+        mock_http.request = AsyncMock(
+            side_effect=httpx.ConnectError("unreachable", request=req),
+        )
+        handler = OpenAPIUpstreamHandler.from_capabilities(
+            base_url="https://upstream.test",
+            capabilities=caps,
+            http_client=mock_http,
+        )
+        with pytest.raises(RecoverableError, match="Upstream request failed"):
+            await handler.execute("z4", {}, session=None)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execute_upstream_502_is_recoverable() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/z": {"get": {"operationId": "z5", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "502")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(502))
+        ) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://upstream.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            with pytest.raises(RecoverableError, match="Upstream HTTP 502"):
+                await handler.execute("z5", {}, session=None)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execute_upstream_404_is_fatal() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/z": {"get": {"operationId": "z6", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "404")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(404))
+        ) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://upstream.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            with pytest.raises(FatalError, match="Upstream HTTP 404"):
+                await handler.execute("z6", {}, session=None)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execute_non_json_response_wraps_text() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/z": {"get": {"operationId": "z7", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "plain_text")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda _r: httpx.Response(
+                    200, content=b"hello", headers={"content-type": "text/plain"}
+                ),
+            ),
+        ) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://upstream.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            out = await handler.execute("z7", {}, session=None)
+        assert out["_text"] == "hello"
+        assert out["content_type"] == "text/plain"
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_execute_json_array_body_wraps_under_json_key() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/z": {"get": {"operationId": "z8", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "json_arr")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda _r: httpx.Response(
+                    200,
+                    json=[1, 2, 3],
+                    headers={"content-type": "application/json"},
+                ),
+            ),
+        ) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://upstream.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            out = await handler.execute("z8", {}, session=None)
+        assert out == {"_json": [1, 2, 3]}
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_create_openapi_task_handler_returns_task_response_envelope() -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/ping": {"get": {"operationId": "ping", "responses": {"200": {"description": "ok"}}}},
+        },
+    }
+    path = _write_tmp(raw, "task_handler")
+    try:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        transport = httpx.MockTransport(lambda _r: httpx.Response(200, json={"pong": True}))
+        async with httpx.AsyncClient(transport=transport) as http_client:
+            upstream = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://agent_upstream.test",
+                capabilities=caps,
+                http_client=http_client,
+            )
+            task_fn = create_openapi_task_handler(upstream)
+            manifest = Manifest(
+                id="urn:asap:agent:openapi-test",
+                name="Adapter",
+                version="1.0.0",
+                description="d",
+                capabilities=Capability(
+                    asap_version="0.1",
+                    skills=[Skill(id="ping", description="p")],
+                    state_persistence=False,
+                ),
+                endpoints=Endpoint(asap="http://localhost:8000/asap"),
+            )
+            envelope_in = Envelope(
+                asap_version="0.1",
+                sender="urn:asap:agent:caller",
+                recipient=manifest.id,
+                payload_type="task.request",
+                payload={
+                    "conversation_id": "conv-1",
+                    "skill_id": "ping",
+                    "input": {},
+                },
+            )
+            envelope_out = await task_fn(envelope_in, manifest)
+        assert envelope_out.payload_type == "task.response"
+        assert envelope_out.payload_dict["result"] == {"pong": True}
+        assert envelope_out.correlation_id == envelope_in.id
+    finally:
+        path.unlink(missing_ok=True)

--- a/tests/adapters/openapi/test_handler.py
+++ b/tests/adapters/openapi/test_handler.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
-from unittest.mock import AsyncMock
 
 from asap.adapters.openapi.capability_mapper import (
     OpenAPIExecutionKind,
@@ -29,17 +29,11 @@ from asap.errors import FatalError, RecoverableError
 from asap.models.entities import Capability, Endpoint, Manifest, Skill
 from asap.models.envelope import Envelope
 
-_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "openapi"
-
-
-def _write_tmp(data: dict[str, Any], name: str) -> Path:
-    path = _FIXTURES / f"_tmp_handler_{name}.json"
-    path.write_text(json.dumps(data), encoding="utf-8")
-    return path
+from tests.adapters.openapi.conftest import tmp_openapi_spec
 
 
 @pytest.mark.asyncio
-async def test_execute_get_path_and_query_via_mocked_httpx() -> None:
+async def test_execute_get_path_and_query_via_mocked_httpx(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -66,7 +60,6 @@ async def test_execute_get_path_and_query_via_mocked_httpx() -> None:
             },
         },
     }
-    path = _write_tmp(raw, "get_proxy")
     seen: dict[str, Any] = {}
 
     def transport_handler(request: httpx.Request) -> httpx.Response:
@@ -76,7 +69,7 @@ async def test_execute_get_path_and_query_via_mocked_httpx() -> None:
         assert request.url.params.get("verbose") == "false"
         return httpx.Response(200, json={"ok": True})
 
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "get_proxy") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         transport = httpx.MockTransport(transport_handler)
@@ -94,12 +87,10 @@ async def test_execute_get_path_and_query_via_mocked_httpx() -> None:
         assert out == {"ok": True}
         assert seen["method"] == "GET"
         assert str(httpx.URL(seen["url"]).host) == "upstream.test"
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_execute_post_json_body_and_query_via_mocked_httpx() -> None:
+async def test_execute_post_json_body_and_query_via_mocked_httpx(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -130,7 +121,6 @@ async def test_execute_post_json_body_and_query_via_mocked_httpx() -> None:
             },
         },
     }
-    path = _write_tmp(raw, "post_proxy")
     captured: dict[str, Any] = {}
 
     def transport_handler(request: httpx.Request) -> httpx.Response:
@@ -140,7 +130,7 @@ async def test_execute_post_json_body_and_query_via_mocked_httpx() -> None:
         assert request.url.path == "/pets"
         return httpx.Response(201, json={"id": 42})
 
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "post_proxy") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         transport = httpx.MockTransport(transport_handler)
@@ -159,12 +149,10 @@ async def test_execute_post_json_body_and_query_via_mocked_httpx() -> None:
         assert captured["method"] == "POST"
         assert captured["query"].get("dryRun") == "true"
         assert captured["json"] == {"name": "Neko"}
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_execute_unknown_capability_raises() -> None:
+async def test_execute_unknown_capability_raises(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -172,12 +160,11 @@ async def test_execute_unknown_capability_raises() -> None:
             "/x": {"get": {"operationId": "onlyOne", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "unknown_cap")
 
     def transport_handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500)
 
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "unknown_cap") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         transport = httpx.MockTransport(transport_handler)
@@ -190,12 +177,10 @@ async def test_execute_unknown_capability_raises() -> None:
             with pytest.raises(UnknownOpenAPICapabilityError) as exc_info:
                 await handler.execute("missingCapability", {})
         assert exc_info.value.capability_name == "missingCapability"
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_execute_module_wrapper_delegates() -> None:
+async def test_execute_module_wrapper_delegates(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -203,12 +188,11 @@ async def test_execute_module_wrapper_delegates() -> None:
             "/ping": {"get": {"operationId": "ping", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "wrapper")
 
     def transport_handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(204)
 
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "wrapper") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         transport = httpx.MockTransport(transport_handler)
@@ -219,12 +203,10 @@ async def test_execute_module_wrapper_delegates() -> None:
                 http_client=client,
             )
             assert await execute(handler, "ping", {}) == {}
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_resolve_headers_merged_with_openapi_header_params() -> None:
+async def test_resolve_headers_merged_with_openapi_header_params(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -245,7 +227,6 @@ async def test_resolve_headers_merged_with_openapi_header_params() -> None:
             },
         },
     }
-    path = _write_tmp(raw, "resolve_merge")
     seen: dict[str, Any] = {}
 
     def transport_handler(request: httpx.Request) -> httpx.Response:
@@ -257,7 +238,7 @@ async def test_resolve_headers_merged_with_openapi_header_params() -> None:
     class _Session:
         token = "secret"
 
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "resolve_merge") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
 
@@ -285,12 +266,10 @@ async def test_resolve_headers_merged_with_openapi_header_params() -> None:
         assert seen["authorization"] == "Bearer secret"
         assert seen["x_request_label"] == "job-1"
         assert seen["x_session"] == "host"
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_resolve_headers_openapi_header_params_override_callback() -> None:
+async def test_resolve_headers_openapi_header_params_override_callback(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -310,14 +289,13 @@ async def test_resolve_headers_openapi_header_params_override_callback() -> None
             },
         },
     }
-    path = _write_tmp(raw, "resolve_override")
     seen: dict[str, Any] = {}
 
     def transport_handler(request: httpx.Request) -> httpx.Response:
         seen["x_trace"] = request.headers.get("x-trace")
         return httpx.Response(200, json={})
 
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "resolve_override") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
 
@@ -334,12 +312,10 @@ async def test_resolve_headers_openapi_header_params_override_callback() -> None
             )
             await handler.execute("r", {"X-Trace": "from-args"}, session=None)
         assert seen["x_trace"] == "from-args"
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_resolve_headers_callback_failure_is_recoverable_unauthorized() -> None:
+async def test_resolve_headers_callback_failure_is_recoverable_unauthorized(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -347,12 +323,11 @@ async def test_resolve_headers_callback_failure_is_recoverable_unauthorized() ->
             "/z": {"get": {"operationId": "z", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "resolve_fail")
 
     def transport_handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500)
 
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "resolve_fail") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
 
@@ -369,12 +344,10 @@ async def test_resolve_headers_callback_failure_is_recoverable_unauthorized() ->
             )
             with pytest.raises(RecoverableError, match="resolve_headers callback failed"):
                 await handler.execute("z", {}, session=None)
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_resolve_headers_invalid_return_type_is_recoverable() -> None:
+async def test_resolve_headers_invalid_return_type_is_recoverable(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -382,9 +355,8 @@ async def test_resolve_headers_invalid_return_type_is_recoverable() -> None:
             "/z": {"get": {"operationId": "z2", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "resolve_bad_type")
 
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "resolve_bad_type") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
 
@@ -402,8 +374,6 @@ async def test_resolve_headers_invalid_return_type_is_recoverable() -> None:
             )
             with pytest.raises(RecoverableError, match="resolve_headers must return dict"):
                 await handler.execute("z2", {}, session=None)
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
@@ -426,7 +396,7 @@ async def test_index_capabilities_duplicate_skill_id_raises() -> None:
 
 
 @pytest.mark.asyncio
-async def test_execute_cookie_parameter_sets_cookie_header() -> None:
+async def test_execute_cookie_parameter_sets_cookie_header(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -447,14 +417,13 @@ async def test_execute_cookie_parameter_sets_cookie_header() -> None:
             },
         },
     }
-    path = _write_tmp(raw, "cookie_param")
     seen: dict[str, Any] = {}
 
     def transport_handler(request: httpx.Request) -> httpx.Response:
         seen["cookie"] = request.headers.get("cookie")
         return httpx.Response(200, json={"ok": True})
 
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "cookie_param") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         transport = httpx.MockTransport(transport_handler)
@@ -466,12 +435,10 @@ async def test_execute_cookie_parameter_sets_cookie_header() -> None:
             )
             await handler.execute("withCookie", {"sid": "abc123"}, session=None)
         assert seen.get("cookie") == "sid=abc123"
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_execute_missing_path_parameter_raises() -> None:
+async def test_execute_missing_path_parameter_raises(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -492,8 +459,7 @@ async def test_execute_missing_path_parameter_raises() -> None:
             },
         },
     }
-    path = _write_tmp(raw, "missing_path")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "missing_path") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         async with httpx.AsyncClient(
@@ -506,12 +472,126 @@ async def test_execute_missing_path_parameter_raises() -> None:
             )
             with pytest.raises(OpenAPIPathParameterError, match="Missing path parameter"):
                 await handler.execute("getPet", {}, session=None)
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_execute_unexpected_argument_raises() -> None:
+async def test_execute_empty_path_parameter_string_raises(tmp_path: Path) -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/pets/{petId}": {
+                "get": {
+                    "operationId": "getPet",
+                    "parameters": [
+                        {
+                            "name": "petId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        },
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    with tmp_openapi_spec(tmp_path, raw, "empty_path_val") as path:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200))
+        ) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://u.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            with pytest.raises(OpenAPIPathParameterError, match="Invalid path parameter"):
+                await handler.execute("getPet", {"petId": ""}, session=None)
+
+
+@pytest.mark.asyncio
+async def test_execute_whitespace_only_path_parameter_raises(tmp_path: Path) -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/pets/{petId}": {
+                "get": {
+                    "operationId": "getPet",
+                    "parameters": [
+                        {
+                            "name": "petId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        },
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    with tmp_openapi_spec(tmp_path, raw, "ws_path_val") as path:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200))
+        ) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://u.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            with pytest.raises(OpenAPIPathParameterError) as exc_info:
+                await handler.execute("getPet", {"petId": " \t "}, session=None)
+            assert "petId" in exc_info.value.invalid
+
+
+@pytest.mark.asyncio
+async def test_execute_none_path_parameter_raises(tmp_path: Path) -> None:
+    raw = {
+        "openapi": "3.0.3",
+        "info": {"title": "T", "version": "1"},
+        "paths": {
+            "/pets/{petId}": {
+                "get": {
+                    "operationId": "getPet",
+                    "parameters": [
+                        {
+                            "name": "petId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        },
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+    }
+    with tmp_openapi_spec(tmp_path, raw, "none_path_val") as path:
+        doc = await load_spec(path)
+        caps = map_openapi_to_capabilities(doc)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200))
+        ) as client:
+            handler = OpenAPIUpstreamHandler.from_capabilities(
+                base_url="https://u.test",
+                capabilities=caps,
+                http_client=client,
+            )
+            with pytest.raises(OpenAPIPathParameterError, match="Invalid path parameter"):
+                await handler.execute(
+                    "getPet",
+                    cast("dict[str, Any]", {"petId": None}),
+                    session=None,
+                )
+
+
+@pytest.mark.asyncio
+async def test_execute_unexpected_argument_raises(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -519,8 +599,7 @@ async def test_execute_unexpected_argument_raises() -> None:
             "/z": {"get": {"operationId": "z", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "unexpected_arg")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "unexpected_arg") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         async with httpx.AsyncClient(
@@ -533,12 +612,10 @@ async def test_execute_unexpected_argument_raises() -> None:
             )
             with pytest.raises(OpenAPIInvocationError, match="Unexpected argument"):
                 await handler.execute("z", {"extra": "nope"}, session=None)
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_resolve_headers_non_string_values_are_recoverable() -> None:
+async def test_resolve_headers_non_string_values_are_recoverable(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -546,9 +623,8 @@ async def test_resolve_headers_non_string_values_are_recoverable() -> None:
             "/z": {"get": {"operationId": "z3", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "resolve_non_str")
 
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "resolve_non_str") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
 
@@ -566,12 +642,10 @@ async def test_resolve_headers_non_string_values_are_recoverable() -> None:
             )
             with pytest.raises(RecoverableError, match="str keys and str values"):
                 await handler.execute("z3", {}, session=None)
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_execute_upstream_connection_error_is_recoverable() -> None:
+async def test_execute_upstream_connection_error_is_recoverable(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -579,9 +653,8 @@ async def test_execute_upstream_connection_error_is_recoverable() -> None:
             "/z": {"get": {"operationId": "z4", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "conn_err")
     req = httpx.Request("GET", "https://upstream.test/z")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "conn_err") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         mock_http = AsyncMock()
@@ -595,12 +668,10 @@ async def test_execute_upstream_connection_error_is_recoverable() -> None:
         )
         with pytest.raises(RecoverableError, match="Upstream request failed"):
             await handler.execute("z4", {}, session=None)
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_execute_upstream_502_is_recoverable() -> None:
+async def test_execute_upstream_502_is_recoverable(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -608,8 +679,7 @@ async def test_execute_upstream_502_is_recoverable() -> None:
             "/z": {"get": {"operationId": "z5", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "502")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "502") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         async with httpx.AsyncClient(
@@ -620,14 +690,13 @@ async def test_execute_upstream_502_is_recoverable() -> None:
                 capabilities=caps,
                 http_client=client,
             )
-            with pytest.raises(RecoverableError, match="Upstream HTTP 502"):
+            with pytest.raises(RecoverableError, match="Upstream HTTP 502") as exc_info:
                 await handler.execute("z5", {}, session=None)
-    finally:
-        path.unlink(missing_ok=True)
+            assert "body_snippet" not in exc_info.value.details
 
 
 @pytest.mark.asyncio
-async def test_execute_upstream_404_is_fatal() -> None:
+async def test_execute_upstream_404_is_fatal(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -635,26 +704,26 @@ async def test_execute_upstream_404_is_fatal() -> None:
             "/z": {"get": {"operationId": "z6", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "404")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "404") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
+        long_body = "x" * 500
         async with httpx.AsyncClient(
-            transport=httpx.MockTransport(lambda _r: httpx.Response(404))
+            transport=httpx.MockTransport(lambda _r: httpx.Response(404, text=long_body))
         ) as client:
             handler = OpenAPIUpstreamHandler.from_capabilities(
                 base_url="https://upstream.test",
                 capabilities=caps,
                 http_client=client,
             )
-            with pytest.raises(FatalError, match="Upstream HTTP 404"):
+            with pytest.raises(FatalError, match="Upstream HTTP 404") as fi:
                 await handler.execute("z6", {}, session=None)
-    finally:
-        path.unlink(missing_ok=True)
+            snippet = fi.value.details.get("body_snippet", "") if fi.value.details else ""
+            assert len(snippet) <= 200
 
 
 @pytest.mark.asyncio
-async def test_execute_non_json_response_wraps_text() -> None:
+async def test_execute_non_json_response_wraps_text(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -662,8 +731,7 @@ async def test_execute_non_json_response_wraps_text() -> None:
             "/z": {"get": {"operationId": "z7", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "plain_text")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "plain_text") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         async with httpx.AsyncClient(
@@ -681,12 +749,10 @@ async def test_execute_non_json_response_wraps_text() -> None:
             out = await handler.execute("z7", {}, session=None)
         assert out["_text"] == "hello"
         assert out["content_type"] == "text/plain"
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_execute_json_array_body_wraps_under_json_key() -> None:
+async def test_execute_json_array_body_wraps_under_json_key(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -694,8 +760,7 @@ async def test_execute_json_array_body_wraps_under_json_key() -> None:
             "/z": {"get": {"operationId": "z8", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "json_arr")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "json_arr") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         async with httpx.AsyncClient(
@@ -714,12 +779,10 @@ async def test_execute_json_array_body_wraps_under_json_key() -> None:
             )
             out = await handler.execute("z8", {}, session=None)
         assert out == {"_json": [1, 2, 3]}
-    finally:
-        path.unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
-async def test_create_openapi_task_handler_returns_task_response_envelope() -> None:
+async def test_create_openapi_task_handler_returns_task_response_envelope(tmp_path: Path) -> None:
     raw = {
         "openapi": "3.0.3",
         "info": {"title": "T", "version": "1"},
@@ -727,8 +790,7 @@ async def test_create_openapi_task_handler_returns_task_response_envelope() -> N
             "/ping": {"get": {"operationId": "ping", "responses": {"200": {"description": "ok"}}}},
         },
     }
-    path = _write_tmp(raw, "task_handler")
-    try:
+    with tmp_openapi_spec(tmp_path, raw, "task_handler") as path:
         doc = await load_spec(path)
         caps = map_openapi_to_capabilities(doc)
         transport = httpx.MockTransport(lambda _r: httpx.Response(200, json={"pong": True}))
@@ -766,5 +828,3 @@ async def test_create_openapi_task_handler_returns_task_response_envelope() -> N
         assert envelope_out.payload_type == "task.response"
         assert envelope_out.payload_dict["result"] == {"pong": True}
         assert envelope_out.correlation_id == envelope_in.id
-    finally:
-        path.unlink(missing_ok=True)

--- a/tests/adapters/openapi/test_spec_loader.py
+++ b/tests/adapters/openapi/test_spec_loader.py
@@ -1,0 +1,234 @@
+"""Unit tests for OpenAPI spec loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from openapi_pydantic.v3.v3_0.open_api import OpenAPI as OpenAPI_3_0
+from openapi_pydantic.v3.v3_1.open_api import OpenAPI as OpenAPI_3_1
+from unittest.mock import AsyncMock
+
+from asap.adapters.openapi.spec_loader import OpenAPISpecError, load_spec
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "openapi"
+
+
+@pytest.mark.asyncio
+async def test_load_spec_from_path_openapi_3_0() -> None:
+    path = _FIXTURES / "minimal-3.0.3.json"
+    doc = await load_spec(path)
+    assert isinstance(doc, OpenAPI_3_0)
+    assert doc.openapi == "3.0.3"
+    assert doc.info.title == "Fixture API"
+
+
+@pytest.mark.asyncio
+async def test_load_spec_from_path_openapi_3_1() -> None:
+    path = _FIXTURES / "minimal-3.1.0.json"
+    doc = await load_spec(path)
+    assert isinstance(doc, OpenAPI_3_1)
+    assert doc.openapi == "3.1.0"
+
+
+@pytest.mark.asyncio
+async def test_load_spec_from_str_path() -> None:
+    path = _FIXTURES / "minimal-3.0.3.json"
+    doc = await load_spec(str(path))
+    assert isinstance(doc, OpenAPI_3_0)
+
+
+@pytest.mark.asyncio
+async def test_load_spec_rejects_openapi_2() -> None:
+    bad = {
+        "openapi": "2.0",
+        "info": {"title": "x", "version": "1"},
+        "paths": {},
+    }
+    path = Path(__file__).resolve().parent / "_tmp_invalid_openapi.json"
+    path.write_text(json.dumps(bad), encoding="utf-8")
+    try:
+        with pytest.raises(OpenAPISpecError, match="Unsupported OpenAPI"):
+            await load_spec(path)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_load_spec_missing_openapi_field() -> None:
+    path = Path(__file__).resolve().parent / "_tmp_no_version.json"
+    path.write_text(
+        json.dumps({"info": {"title": "x", "version": "1"}, "paths": {}}),
+        encoding="utf-8",
+    )
+    try:
+        with pytest.raises(OpenAPISpecError, match="Missing required 'openapi'"):
+            await load_spec(path)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_load_spec_missing_file() -> None:
+    with pytest.raises(OpenAPISpecError, match="not found"):
+        await load_spec(_FIXTURES / "does-not-exist.json")
+
+
+@pytest.mark.asyncio
+async def test_load_spec_from_url_with_injected_client() -> None:
+    payload: dict[str, Any] = {
+        "openapi": "3.0.3",
+        "info": {"title": "Remote Fixture", "version": "2"},
+        "paths": {},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/openapi.json"
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://example.test") as client:
+        doc = await load_spec("https://example.test/openapi.json", http_client=client)
+
+    assert isinstance(doc, OpenAPI_3_0)
+    assert doc.info.title == "Remote Fixture"
+
+
+@pytest.mark.asyncio
+async def test_load_spec_url_http_error_wraps() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://example.test") as client:
+        with pytest.raises(OpenAPISpecError, match="HTTP 404"):
+            await load_spec("https://example.test/missing.json", http_client=client)
+
+
+@pytest.mark.asyncio
+async def test_load_spec_url_connect_error_wraps() -> None:
+    req = httpx.Request("GET", "https://example.test/o.json")
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=httpx.ConnectError("refused", request=req))
+    with pytest.raises(OpenAPISpecError, match="HTTP error"):
+        await load_spec("https://example.test/o.json", http_client=client)
+
+
+@pytest.mark.asyncio
+async def test_load_spec_url_non_json_body() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="not-json")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://example.test") as client:
+        with pytest.raises(OpenAPISpecError, match="did not return JSON"):
+            await load_spec("https://example.test/o.json", http_client=client)
+
+
+@pytest.mark.asyncio
+async def test_load_spec_url_json_root_not_object() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://example.test") as client:
+        with pytest.raises(OpenAPISpecError, match="root must be a JSON object"):
+            await load_spec("https://example.test/o.json", http_client=client)
+
+
+@pytest.mark.asyncio
+async def test_load_spec_openapi_field_must_be_string(tmp_path: Path) -> None:
+    bad_path = tmp_path / "bad-version-type.json"
+    bad_path.write_text(
+        json.dumps({"openapi": 3, "info": {"title": "x", "version": "1"}, "paths": {}}),
+        encoding="utf-8",
+    )
+    with pytest.raises(OpenAPISpecError, match="must be a string"):
+        await load_spec(bad_path)
+
+
+@pytest.mark.asyncio
+async def test_load_spec_invalid_document_raises(tmp_path: Path) -> None:
+    bad_path = tmp_path / "invalid-doc.json"
+    bad_path.write_text(
+        json.dumps({"openapi": "3.0.3", "info": [], "paths": {}}),
+        encoding="utf-8",
+    )
+    with pytest.raises(OpenAPISpecError, match="Invalid OpenAPI"):
+        await load_spec(bad_path)
+
+
+@pytest.mark.asyncio
+async def test_load_spec_file_invalid_json(tmp_path: Path) -> None:
+    bad_path = tmp_path / "broken.json"
+    bad_path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(OpenAPISpecError, match="not valid JSON"):
+        await load_spec(bad_path)
+
+
+@pytest.mark.asyncio
+async def test_load_spec_file_root_not_object(tmp_path: Path) -> None:
+    bad_path = tmp_path / "array-root.json"
+    bad_path.write_text(json.dumps(["x"]), encoding="utf-8")
+    with pytest.raises(OpenAPISpecError, match="root must be a JSON object"):
+        await load_spec(bad_path)
+
+
+@pytest.mark.asyncio
+async def test_load_spec_file_read_os_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "unreadable.json"
+    target.write_text(
+        json.dumps({"openapi": "3.0.3", "info": {"title": "x", "version": "1"}, "paths": {}}),
+        encoding="utf-8",
+    )
+    real_read = Path.read_text
+
+    def patched_read(self: Path, *a: Any, **kw: Any) -> str:
+        if self.resolve() == target.resolve():
+            raise OSError("permission denied")
+        return real_read(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_text", patched_read)
+    with pytest.raises(OpenAPISpecError, match="Cannot read"):
+        await load_spec(target)
+
+
+@pytest.mark.asyncio
+async def test_load_spec_url_without_client_opens_temporary_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from asap.adapters.openapi import spec_loader as spec_loader_mod
+
+    payload = {"openapi": "3.0.3", "info": {"title": "T", "version": "1"}, "paths": {}}
+    instances: list[Any] = []
+    real_async_client = spec_loader_mod.httpx.AsyncClient
+
+    class _CapturingClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            instances.append(kwargs)
+            self._inner = real_async_client(
+                transport=httpx.MockTransport(
+                    lambda _r: httpx.Response(200, json=payload),
+                ),
+                **kwargs,
+            )
+
+        async def __aenter__(self) -> httpx.AsyncClient:
+            return await self._inner.__aenter__()
+
+        async def __aexit__(self, *exc: Any) -> bool | None:
+            return await self._inner.__aexit__(*exc)
+
+    monkeypatch.setattr(
+        "asap.adapters.openapi.spec_loader.httpx.AsyncClient",
+        _CapturingClient,
+    )
+    doc = await load_spec("https://remote.example/openapi.json")
+    assert doc.openapi == "3.0.3"
+    assert instances and instances[0].get("follow_redirects") is True

--- a/tests/fixtures/openapi/minimal-3.0.3.json
+++ b/tests/fixtures/openapi/minimal-3.0.3.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {}
+}

--- a/tests/fixtures/openapi/minimal-3.1.0.json
+++ b/tests/fixtures/openapi/minimal-3.1.0.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {}
+}

--- a/tests/integrations/test_crewai.py
+++ b/tests/integrations/test_crewai.py
@@ -12,7 +12,7 @@ from asap.client.market import MarketClient
 from asap.discovery.registry import LiteRegistry, RegistryEntry
 from asap.errors import SignatureVerificationError
 from asap.models.entities import Capability, Endpoint, Manifest, Skill
-from asap.models.payloads import TaskResponse
+from asap.models.payloads import TaskRequest, TaskResponse
 
 pytest.importorskip("crewai")
 
@@ -197,3 +197,62 @@ def test_crewai_tool_returns_error_string_on_signature_error() -> None:
 
     assert isinstance(out, str)
     assert "Error:" in out
+
+
+@pytest.mark.asyncio
+async def test_crewai_tool_arun_value_error_returns_error_string() -> None:
+    """When agent.run raises ValueError, _arun returns a prefixed error string."""
+    mock_send = AsyncMock(side_effect=ValueError("upstream rejected"))
+    mock_transport = AsyncMock()
+    mock_transport.send = mock_send
+    mock_transport.__aenter__ = AsyncMock(return_value=mock_transport)
+    mock_transport.__aexit__ = AsyncMock(return_value=None)
+
+    p_get, p_verify, p_revoked, p_http = _resolve_patches()
+    with p_get as mock_get, p_verify as mock_verify, p_revoked as mock_revoked, p_http:
+        mock_get.return_value = _lite_registry()
+        mock_verify.return_value = True
+        mock_revoked.return_value = False
+        with patch("asap.client.market.ASAPClient", return_value=mock_transport):
+            tool = CrewAIAsapTool(
+                TEST_URN, client=MarketClient(registry_url="https://reg.example/registry.json")
+            )
+            out = await tool._arun(input={"q": "x"})
+
+    assert isinstance(out, str)
+    assert "Error:" in out
+    assert "upstream rejected" in out
+
+
+def test_crewai_tool_run_wraps_non_dict_positional_input() -> None:
+    """_run string input is wrapped; result is JSON string for CrewAI."""
+    task_response = TaskResponse(
+        task_id="task-1",
+        status="completed",
+        result={"ok": True},
+        final_state=None,
+        metrics=None,
+    )
+    response_envelope = AsyncMock()
+    response_envelope.payload = task_response
+    mock_send = AsyncMock(return_value=response_envelope)
+    mock_transport = AsyncMock()
+    mock_transport.send = mock_send
+    mock_transport.__aenter__ = AsyncMock(return_value=mock_transport)
+    mock_transport.__aexit__ = AsyncMock(return_value=None)
+
+    p_get, p_verify, p_revoked, p_http = _resolve_patches()
+    with p_get as mock_get, p_verify as mock_verify, p_revoked as mock_revoked, p_http:
+        mock_get.return_value = _lite_registry()
+        mock_verify.return_value = True
+        mock_revoked.return_value = False
+        with patch("asap.client.market.ASAPClient", return_value=mock_transport):
+            tool = CrewAIAsapTool(
+                TEST_URN, client=MarketClient(registry_url="https://reg.example/registry.json")
+            )
+            out = tool._run("literal")
+
+    assert json.loads(out) == {"ok": True}
+    sent_envelope = mock_send.await_args.args[0]
+    inner = TaskRequest.model_validate(sent_envelope.payload)
+    assert inner.input == {"raw": "literal"}

--- a/tests/integrations/test_langchain.py
+++ b/tests/integrations/test_langchain.py
@@ -11,7 +11,7 @@ from asap.client.market import MarketClient
 from asap.discovery.registry import LiteRegistry, RegistryEntry
 from asap.errors import SignatureVerificationError
 from asap.models.entities import Capability, Endpoint, Manifest, Skill
-from asap.models.payloads import TaskResponse
+from asap.models.payloads import TaskRequest, TaskResponse
 
 pytest.importorskip("langchain_core")
 
@@ -194,3 +194,62 @@ def test_langchain_tool_returns_error_string_on_signature_error() -> None:
 
     assert isinstance(out, str)
     assert "Error:" in out
+
+
+@pytest.mark.asyncio
+async def test_langchain_tool_arun_value_error_returns_error_string() -> None:
+    """When agent.run raises ValueError, _arun returns a prefixed error string."""
+    mock_send = AsyncMock(side_effect=ValueError("task execution failed"))
+    mock_transport = AsyncMock()
+    mock_transport.send = mock_send
+    mock_transport.__aenter__ = AsyncMock(return_value=mock_transport)
+    mock_transport.__aexit__ = AsyncMock(return_value=None)
+
+    p_get, p_verify, p_revoked, p_http = _resolve_patches()
+    with p_get as mock_get, p_verify as mock_verify, p_revoked as mock_revoked, p_http:
+        mock_get.return_value = _lite_registry()
+        mock_verify.return_value = True
+        mock_revoked.return_value = False
+        with patch("asap.client.market.ASAPClient", return_value=mock_transport):
+            tool = LangChainAsapTool(
+                TEST_URN, client=MarketClient(registry_url="https://reg.example/registry.json")
+            )
+            out = await tool._arun(input={"q": "x"})
+
+    assert isinstance(out, str)
+    assert "Error:" in out
+    assert "task execution failed" in out
+
+
+def test_langchain_tool_run_wraps_non_dict_positional_input() -> None:
+    """_run with a non-dict positional wraps payload for the skill."""
+    task_response = TaskResponse(
+        task_id="task-1",
+        status="completed",
+        result={"ok": True},
+        final_state=None,
+        metrics=None,
+    )
+    response_envelope = AsyncMock()
+    response_envelope.payload = task_response
+    mock_send = AsyncMock(return_value=response_envelope)
+    mock_transport = AsyncMock()
+    mock_transport.send = mock_send
+    mock_transport.__aenter__ = AsyncMock(return_value=mock_transport)
+    mock_transport.__aexit__ = AsyncMock(return_value=None)
+
+    p_get, p_verify, p_revoked, p_http = _resolve_patches()
+    with p_get as mock_get, p_verify as mock_verify, p_revoked as mock_revoked, p_http:
+        mock_get.return_value = _lite_registry()
+        mock_verify.return_value = True
+        mock_revoked.return_value = False
+        with patch("asap.client.market.ASAPClient", return_value=mock_transport):
+            tool = LangChainAsapTool(
+                TEST_URN, client=MarketClient(registry_url="https://reg.example/registry.json")
+            )
+            out = tool._run("literal")
+
+    assert out == {"ok": True}
+    sent_envelope = mock_send.await_args.args[0]
+    inner = TaskRequest.model_validate(sent_envelope.payload)
+    assert inner.input == {"raw": "literal"}

--- a/tests/integrations/test_optional_package_helpers.py
+++ b/tests/integrations/test_optional_package_helpers.py
@@ -1,0 +1,210 @@
+"""Tests for optional integration helper functions."""
+
+from __future__ import annotations
+
+import json
+from importlib import import_module
+from typing import Any
+
+import pytest
+
+from asap.models.entities import Capability, Endpoint, Manifest, Skill
+
+
+def _manifest_minimal(
+    *,
+    skills: list[Skill],
+    description: str = "Agent",
+) -> Manifest:
+    return Manifest(
+        id="urn:asap:agent:fixture",
+        name="Fixture",
+        version="1.0.0",
+        description=description,
+        capabilities=Capability(
+            asap_version="0.1",
+            skills=skills,
+            state_persistence=False,
+        ),
+        endpoints=Endpoint(asap="https://agent.example/asap"),
+    )
+
+
+@pytest.mark.parametrize(
+    "integration_module",
+    [
+        pytest.param("crewai", id="crewai"),
+        pytest.param("langchain", id="langchain"),
+        pytest.param("llamaindex", id="llamaindex"),
+    ],
+)
+def test_json_schema_helpers_cover_primitive_types(integration_module: str) -> None:
+    if integration_module == "crewai":
+        pytest.importorskip("crewai")
+        mod_name = "asap.integrations.crewai"
+    elif integration_module == "langchain":
+        pytest.importorskip("langchain_core")
+        mod_name = "asap.integrations.langchain"
+    else:
+        pytest.importorskip("llama_index.core")
+        mod_name = "asap.integrations.llamaindex"
+
+    mod = import_module(mod_name)
+    schema_fn = mod._json_schema_to_pydantic
+    default_cls = mod._default_input_schema()
+    assert schema_fn({}).__name__ == default_cls.__name__
+    assert schema_fn({"type": "array"}).__name__ == default_cls.__name__
+    empty_obj = schema_fn({"type": "object", "properties": {}})
+    assert empty_obj.__name__ == default_cls.__name__
+
+    rich: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "a": {"type": "string", "description": "sa"},
+            "b": {"type": "integer"},
+            "c": {"type": "number"},
+            "d": {"type": "boolean"},
+            "e": {"type": "array"},
+            "f": {"type": "object"},
+            "g": {"type": "other"},
+            "skip": "not-a-dict",
+        },
+        "required": ["a"],
+    }
+    Model = schema_fn(rich, model_name="RichArgs")
+    m = Model(a="x", b=1, c=1.5, d=True, e=[], f={}, g={})
+    assert m.a == "x"
+
+
+@pytest.mark.parametrize(
+    "integration_module",
+    [
+        pytest.param("crewai", id="crewai"),
+        pytest.param("langchain", id="langchain"),
+    ],
+)
+def test_build_args_schema_from_manifest_branches(integration_module: str) -> None:
+    if integration_module == "crewai":
+        pytest.importorskip("crewai")
+        mod_name = "asap.integrations.crewai"
+    else:
+        pytest.importorskip("langchain_core")
+        mod_name = "asap.integrations.langchain"
+
+    mod = import_module(mod_name)
+    empty_caps = _manifest_minimal(skills=[])
+    assert mod._build_args_schema_from_manifest(empty_caps) is None
+
+    no_schema = _manifest_minimal(
+        skills=[Skill(id="echo", description="e", input_schema=None)],
+    )
+    assert mod._build_args_schema_from_manifest(no_schema) is None
+
+    skill_schema = {
+        "type": "object",
+        "properties": {"msg": {"type": "string"}},
+        "required": ["msg"],
+    }
+    hyphen = _manifest_minimal(
+        skills=[Skill(id="my-echo", description="e", input_schema=skill_schema)],
+    )
+    built = mod._build_args_schema_from_manifest(hyphen)
+    assert built is not None
+    assert built(msg="hi").msg == "hi"
+
+
+def test_llama_index_build_fn_schema_from_manifest() -> None:
+    pytest.importorskip("llama_index.core")
+    import asap.integrations.llamaindex as mod
+
+    default_model = mod._default_input_schema()
+    empty = _manifest_minimal(skills=[])
+    assert mod._build_fn_schema_from_manifest(empty).__name__ == default_model.__name__
+
+    no_schema = _manifest_minimal(
+        skills=[Skill(id="x", description="d", input_schema=None)],
+    )
+    assert mod._build_fn_schema_from_manifest(no_schema).__name__ == default_model.__name__
+
+    skill_schema = {"type": "object", "properties": {"q": {"type": "string"}}}
+    mnf = _manifest_minimal(
+        skills=[Skill(id="search", description="s", input_schema=skill_schema)],
+    )
+    FnModel = mod._build_fn_schema_from_manifest(mnf)
+    assert FnModel(q="why").q == "why"
+
+
+def test_pydanticai_parameters_schema_and_to_str() -> None:
+    pytest.importorskip("pydantic_ai")
+    import asap.integrations.pydanticai as mod
+
+    assert json.loads(mod._to_str_result({"a": 1})) == {"a": 1}
+    assert mod._to_str_result("x") == "x"
+
+    empty = _manifest_minimal(skills=[])
+    assert mod._parameters_schema_from_manifest(empty) == mod.DEFAULT_PARAMETERS_JSON_SCHEMA
+
+    bad = _manifest_minimal(
+        skills=[Skill(id="e", description="d", input_schema={"type": "string"})],
+    )
+    assert mod._parameters_schema_from_manifest(bad) == mod.DEFAULT_PARAMETERS_JSON_SCHEMA
+
+    good = _manifest_minimal(
+        skills=[
+            Skill(
+                id="e",
+                description="d",
+                input_schema={
+                    "type": "object",
+                    "properties": {"inp": {"type": "string"}},
+                },
+            ),
+        ],
+    )
+    params = mod._parameters_schema_from_manifest(good)
+    assert params["type"] == "object"
+    assert "inp" in params["properties"]
+
+
+def test_smolagents_schema_and_name_helpers() -> None:
+    pytest.importorskip("smolagents")
+    import asap.integrations.smolagents as mod
+
+    assert mod._sanitize_tool_name("My Agent!") == "My_Agent"
+    assert mod._sanitize_tool_name("123bot") == "asap_123bot"
+    assert mod._sanitize_tool_name("___") == "asap_agent"
+
+    bad = mod._json_schema_to_smolagents_inputs({"type": "string"})
+    assert bad == mod._DEFAULT_INPUTS.copy()
+
+    rich: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "x": {"type": "string", "description": "dx"},
+            "y": {"type": "integer"},
+            "z": {"type": "weird", "description": "z"},
+            "bad": "skip",
+        },
+    }
+    inputs = mod._json_schema_to_smolagents_inputs(rich)
+    assert inputs["x"]["type"] == "string"
+    assert inputs["y"]["type"] == "integer"
+    assert inputs["z"]["type"] == "string"
+
+    empty_m = _manifest_minimal(skills=[])
+    assert mod._build_inputs_from_manifest(empty_m) == mod._DEFAULT_INPUTS.copy()
+
+    sm_manifest = _manifest_minimal(
+        skills=[
+            Skill(
+                id="s",
+                description="d",
+                input_schema={"type": "object", "properties": {"q": {"type": "boolean"}}},
+            ),
+        ],
+    )
+    built = mod._build_inputs_from_manifest(sm_manifest)
+    assert built["q"]["type"] == "boolean"
+
+    assert json.loads(mod._to_str_result({"k": "v"})) == {"k": "v"}
+    assert mod._to_str_result("plain") == "plain"

--- a/tests/integrations/test_pydanticai.py
+++ b/tests/integrations/test_pydanticai.py
@@ -136,6 +136,30 @@ def test_asap_tool_for_urn_returns_tool_with_mock_client() -> None:
     mock_send.assert_awaited_once()
 
 
+def test_pydantic_tool_invocation_value_error_returns_error_string() -> None:
+    """When agent.run raises ValueError, tool function returns error text."""
+    mock_send = AsyncMock(side_effect=ValueError("upstream boom"))
+    mock_transport = AsyncMock()
+    mock_transport.send = mock_send
+    mock_transport.__aenter__ = AsyncMock(return_value=mock_transport)
+    mock_transport.__aexit__ = AsyncMock(return_value=None)
+
+    p_get, p_verify, p_revoked, p_http = _resolve_patches()
+    with p_get as mock_get, p_verify as mock_verify, p_revoked as mock_revoked, p_http:
+        mock_get.return_value = _lite_registry()
+        mock_verify.return_value = True
+        mock_revoked.return_value = False
+        with patch("asap.client.market.ASAPClient", return_value=mock_transport):
+            tool = asap_tool_for_urn(
+                TEST_URN,
+                client=MarketClient(registry_url="https://reg.example/registry.json"),
+            )
+            result = asyncio.run(tool.function(input={"message": "hello"}))
+
+    assert isinstance(result, str)
+    assert "upstream boom" in result
+
+
 def test_asap_tool_for_urn_raises_value_error_when_resolve_fails() -> None:
     """When resolve fails (e.g. agent revoked), asap_tool_for_urn raises ValueError."""
     p_get, p_verify, p_revoked, p_http = _resolve_patches()

--- a/tests/integrations/test_smolagents.py
+++ b/tests/integrations/test_smolagents.py
@@ -167,6 +167,29 @@ def test_smolagents_tool_returns_error_string_on_signature_error() -> None:
     assert "Error:" in out
 
 
+def test_smolagents_tool_reports_value_error_when_run_fails() -> None:
+    """When agent.run raises ValueError, forward returns error string."""
+    mock_send = AsyncMock(side_effect=ValueError("run failed"))
+    mock_transport = AsyncMock()
+    mock_transport.send = mock_send
+    mock_transport.__aenter__ = AsyncMock(return_value=mock_transport)
+    mock_transport.__aexit__ = AsyncMock(return_value=None)
+
+    p_get, p_verify, p_revoked, p_http = _resolve_patches()
+    with p_get as mock_get, p_verify as mock_verify, p_revoked as mock_revoked, p_http:
+        mock_get.return_value = _lite_registry()
+        mock_verify.return_value = True
+        mock_revoked.return_value = False
+        with patch("asap.client.market.ASAPClient", return_value=mock_transport):
+            tool = SmolAgentsAsapTool(
+                TEST_URN, client=MarketClient(registry_url="https://reg.example/registry.json")
+            )
+            out = tool(input={"message": "hello"})
+
+    assert isinstance(out, str)
+    assert "run failed" in out
+
+
 def test_smolagents_tool_has_valid_attributes() -> None:
     """SmolAgentsAsapTool has name, description, inputs, output_type for smolagents agent."""
     p_get, p_verify, p_revoked, p_http = _resolve_patches()

--- a/tests/integrations/test_vercel_ai.py
+++ b/tests/integrations/test_vercel_ai.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 from fastapi import FastAPI
@@ -11,8 +12,11 @@ from fastapi.testclient import TestClient
 from asap.discovery.registry import LiteRegistry, RegistryEntry
 from asap.integrations.vercel_ai import (
     ASAP_INVOKE_TOOL_DEF,
+    _parameters_schema_from_manifest,
+    _search_registry,
     create_asap_tools_router,
 )
+from asap.models.entities import Capability, Endpoint, Manifest, Skill
 
 TEST_URN = "urn:asap:agent:test-agent"
 TEST_HTTP = "https://agent.example.com/asap"
@@ -31,8 +35,6 @@ def _registry_entry() -> RegistryEntry:
 
 
 def _lite_registry() -> LiteRegistry:
-    from datetime import datetime, timezone
-
     return LiteRegistry(
         version="1.0",
         updated_at=datetime.now(timezone.utc),
@@ -41,7 +43,8 @@ def _lite_registry() -> LiteRegistry:
 
 
 def _signed_manifest_json() -> str:
-    from asap.models.entities import Capability, Endpoint, Manifest, Skill
+    from asap.crypto.models import SignatureBlock, SignedManifest
+    from asap.crypto.trust_levels import TrustLevel
 
     manifest = Manifest(
         id=TEST_URN,
@@ -55,8 +58,6 @@ def _signed_manifest_json() -> str:
         ),
         endpoints=Endpoint(asap=TEST_HTTP),
     )
-    from asap.crypto.models import SignatureBlock, SignedManifest
-    from asap.crypto.trust_levels import TrustLevel
 
     sig = SignatureBlock(
         alg="ed25519",
@@ -240,3 +241,203 @@ def test_api_key_value_accepts_matching_value() -> None:
     assert r.status_code == 200
     data = r.json()
     assert "tools" in data
+
+
+def test_search_registry_matches_skill_string() -> None:
+    reg = LiteRegistry(
+        version="1.0",
+        updated_at=datetime.now(timezone.utc),
+        agents=[
+            RegistryEntry(
+                id="urn:asap:agent:x",
+                name="X",
+                description="Y",
+                endpoints={"http": "https://x.example.com"},
+                skills=["deep_research"],
+                asap_version="0.1",
+            ),
+        ],
+    )
+    hits = _search_registry(reg, "research")
+    assert len(hits) == 1
+    assert hits[0]["id"] == "urn:asap:agent:x"
+
+
+def test_parameters_schema_from_manifest_branches() -> None:
+    empty = Manifest(
+        id=TEST_URN,
+        name="N",
+        version="1",
+        description="D",
+        capabilities=Capability(asap_version="0.1", skills=[], state_persistence=False),
+        endpoints=Endpoint(asap=TEST_HTTP),
+    )
+    fallback = _parameters_schema_from_manifest(empty)
+    assert fallback["type"] == "object"
+    assert "input" in fallback["properties"]
+
+    rich = Manifest(
+        id=TEST_URN,
+        name="N",
+        version="1",
+        description="D",
+        capabilities=Capability(
+            asap_version="0.1",
+            skills=[
+                Skill(
+                    id="echo",
+                    description="E",
+                    input_schema={
+                        "type": "object",
+                        "properties": {"msg": {"type": "string"}},
+                    },
+                ),
+            ],
+            state_persistence=False,
+        ),
+        endpoints=Endpoint(asap=TEST_HTTP),
+    )
+    params = _parameters_schema_from_manifest(rich)
+    assert params["properties"]["msg"]["type"] == "string"
+
+
+def test_get_tools_whitelist_appends_resolved_tools() -> None:
+    manifest = Manifest(
+        id=TEST_URN,
+        name="WL Agent",
+        version="1.0.0",
+        description="With schema",
+        capabilities=Capability(
+            asap_version="0.1",
+            skills=[
+                Skill(
+                    id="do",
+                    description="d",
+                    input_schema={"type": "object", "properties": {"a": {"type": "integer"}}},
+                ),
+            ],
+            state_persistence=False,
+        ),
+        endpoints=Endpoint(asap=TEST_HTTP),
+    )
+    mock_agent = MagicMock()
+    mock_agent.manifest = manifest
+
+    with patch("asap.integrations.vercel_ai.MarketClient") as mc_class:
+        mc_class.return_value.resolve = AsyncMock(return_value=mock_agent)
+        app = FastAPI()
+        app.include_router(
+            create_asap_tools_router(whitelist_urns=[TEST_URN]),
+            prefix="/api/asap",
+        )
+        client = TestClient(app)
+        r = client.get("/api/asap/tools")
+
+    assert r.status_code == 200
+    tools = r.json()["tools"]
+    names = [t["name"] for t in tools]
+    assert "asap_invoke" in names
+    assert f"asap_{TEST_URN.replace(':', '_').replace('.', '_')}" in names
+
+
+def test_post_invoke_agent_without_skills_returns_error() -> None:
+    manifest = Manifest(
+        id=TEST_URN,
+        name="Empty",
+        version="1.0.0",
+        description="",
+        capabilities=Capability(asap_version="0.1", skills=[], state_persistence=False),
+        endpoints=Endpoint(asap=TEST_HTTP),
+    )
+    mock_agent = MagicMock()
+    mock_agent.manifest = manifest
+
+    with patch("asap.integrations.vercel_ai.MarketClient") as mc_class:
+        mc_class.return_value.resolve = AsyncMock(return_value=mock_agent)
+        app = FastAPI()
+        app.include_router(create_asap_tools_router(), prefix="/api/asap")
+        client = TestClient(app)
+        r = client.post(
+            "/api/asap/invoke",
+            json={"urn": TEST_URN, "payload": {}},
+        )
+
+    assert r.status_code == 200
+    assert r.json().get("error") == "Agent has no skills"
+
+
+def test_post_invoke_wraps_non_dict_upstream_result() -> None:
+    manifest = Manifest(
+        id=TEST_URN,
+        name="T",
+        version="1.0.0",
+        description="",
+        capabilities=Capability(
+            asap_version="0.1",
+            skills=[Skill(id="echo", description="E")],
+            state_persistence=False,
+        ),
+        endpoints=Endpoint(asap=TEST_HTTP),
+    )
+    mock_agent = MagicMock()
+    mock_agent.manifest = manifest
+    mock_agent.run = AsyncMock(return_value="plain-result")
+
+    with patch("asap.integrations.vercel_ai.MarketClient") as mc_class:
+        mc_class.return_value.resolve = AsyncMock(return_value=mock_agent)
+        app = FastAPI()
+        app.include_router(create_asap_tools_router(), prefix="/api/asap")
+        client = TestClient(app)
+        r = client.post(
+            "/api/asap/invoke",
+            json={"urn": TEST_URN, "payload": {"input": "raw"}},
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("result") == {"value": "plain-result"}
+    mock_agent.run.assert_awaited_once()
+    payload_sent = mock_agent.run.await_args.args[0]
+    assert payload_sent["skill_id"] == "echo"
+
+
+def test_post_invoke_non_dict_input_nested_value() -> None:
+    manifest = Manifest(
+        id=TEST_URN,
+        name="T",
+        version="1.0.0",
+        description="",
+        capabilities=Capability(
+            asap_version="0.1",
+            skills=[Skill(id="echo", description="E")],
+            state_persistence=False,
+        ),
+        endpoints=Endpoint(asap=TEST_HTTP),
+    )
+    mock_agent = MagicMock()
+    mock_agent.manifest = manifest
+    mock_agent.run = AsyncMock(return_value={"ok": True})
+
+    with patch("asap.integrations.vercel_ai.MarketClient") as mc_class:
+        mc_class.return_value.resolve = AsyncMock(return_value=mock_agent)
+        app = FastAPI()
+        app.include_router(create_asap_tools_router(), prefix="/api/asap")
+        client = TestClient(app)
+        r = client.post(
+            "/api/asap/invoke",
+            json={"urn": TEST_URN, "payload": {"input": 99}},
+        )
+
+    assert r.status_code == 200
+    call_kw = mock_agent.run.await_args.args[0]
+    assert call_kw["input"] == {"value": 99}
+
+
+def test_get_discover_returns_502_when_registry_fails() -> None:
+    with patch("asap.integrations.vercel_ai.get_registry", new_callable=AsyncMock) as mock_gr:
+        mock_gr.side_effect = RuntimeError("network down")
+        app = _app_with_router()
+        client = TestClient(app)
+        r = client.get("/api/asap/discover")
+
+    assert r.status_code == 502

--- a/tests/mcp/test_serve.py
+++ b/tests/mcp/test_serve.py
@@ -14,6 +14,7 @@ import pytest
 pytest.importorskip("mcp")
 
 from asap.discovery.registry import LiteRegistry, RegistryEntry
+import asap.mcp.serve as mcp_serve
 from asap.mcp.serve import (
     _create_mcp_server,
     _parse_args,
@@ -122,6 +123,42 @@ class TestSearchRegistry:
         )
         result = _search_registry(registry, "nonexistent")
         assert result == []
+
+    def test_query_strips_whitespace(self) -> None:
+        registry = LiteRegistry(
+            version="1.0",
+            updated_at=datetime.now(timezone.utc),
+            agents=[
+                RegistryEntry(
+                    id="urn:asap:agent:z",
+                    name="Z",
+                    description="Z",
+                    endpoints={"http": "https://z.example.com"},
+                    skills=[],
+                    asap_version="1.0",
+                ),
+            ],
+        )
+        assert _search_registry(registry, "  \t  ") == _search_registry(registry, "")
+
+    def test_query_matches_agent_id_substring(self) -> None:
+        registry = LiteRegistry(
+            version="1.0",
+            updated_at=datetime.now(timezone.utc),
+            agents=[
+                RegistryEntry(
+                    id="urn:asap:agent:weather-service-v2",
+                    name="Svc",
+                    description="Svc",
+                    endpoints={"http": "https://w.example.com"},
+                    skills=[],
+                    asap_version="1.0",
+                ),
+            ],
+        )
+        result = _search_registry(registry, "weather-service")
+        assert len(result) == 1
+        assert result[0]["id"] == "urn:asap:agent:weather-service-v2"
 
 
 class TestParseArgs:
@@ -240,6 +277,32 @@ class TestCreateMcpServer:
         parsed = json.loads(text)
         assert "error" in parsed
         assert "not found" in parsed["error"].lower() or "fake" in parsed["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_asap_discover_returns_error_payload_when_registry_unavailable(self) -> None:
+        with patch("asap.mcp.serve.get_registry", new_callable=AsyncMock) as mock_gr:
+            mock_gr.side_effect = RuntimeError("registry unreachable")
+            mcp = _create_mcp_server()
+            result = await mcp.call_tool("asap_discover", {"query": ""})
+        content, _ = result
+        text = content[0].text if hasattr(content[0], "text") else str(content[0])
+        parsed = json.loads(text)
+        assert "error" in parsed
+        assert "unreachable" in parsed["error"].lower()
+
+    def test_create_mcp_server_requires_fastmcp_when_unavailable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(mcp_serve, "FastMCP", None)
+        monkeypatch.setattr(
+            mcp_serve,
+            "_mcp_import_error",
+            ImportError("no mcp"),
+            raising=False,
+        )
+        with pytest.raises(RuntimeError, match="mcp package is required"):
+            mcp_serve._create_mcp_server()
 
 
 class TestMain:

--- a/uv.lock
+++ b/uv.lock
@@ -270,6 +270,9 @@ llamaindex = [
 mcp = [
     { name = "mcp" },
 ]
+openapi = [
+    { name = "openapi-pydantic" },
+]
 openclaw = [
     { name = "openclaw-sdk" },
 ]
@@ -319,6 +322,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.1" },
+    { name = "openapi-pydantic", marker = "extra == 'openapi'", specifier = ">=0.5" },
     { name = "openclaw-sdk", marker = "extra == 'openclaw'", specifier = ">=2.0" },
     { name = "opentelemetry-api", specifier = ">=1.20" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20" },
@@ -348,7 +352,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=12.0" },
     { name = "zeroconf", marker = "extra == 'dns-sd'", specifier = ">=0.80" },
 ]
-provides-extras = ["dev", "docs", "dns-sd", "redis", "webauthn", "mcp", "langchain", "crewai", "llamaindex", "smolagents", "pydanticai", "openclaw"]
+provides-extras = ["dev", "docs", "dns-sd", "redis", "webauthn", "mcp", "langchain", "crewai", "llamaindex", "smolagents", "pydanticai", "openclaw", "openapi"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What
- New `asap.adapters.openapi`: spec loading, capability mapping, handler factory, approval helpers.
- Docs (`docs/adapters/openapi.md`), index link, PetStore example under `examples/openapi_petstore/`.
- Engineering sprint/adoption notes; product PRDs/strategy URLs aligned to production domain; README/contact cleanup.

## Tests
Full CI suite run locally before push (ruff, mypy, pytest, web, compliance, coverage, security).