### PR TITLE
chore(cursor): no Co-authored-by / Cursor commit trailers

### DIFF
--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -34,6 +34,7 @@ Use the [Conventional Commits](https://www.conventionalcommits.org/) specificati
 3. **Description**: Short, imperative summary of the change.
 4. **Body**: Longer description of "what" and "why" (not "how").
 5. **Footers**: Used for tracking issues (e.g., `Refs: #123`) or breaking changes.
+6. **No agent co-author or Cursor attribution**: Do not append `Co-authored-by:` (including Cursor Bot / cursoragent), `Made with Cursor`, or similar trailers to commit messages or pull request bodies. Commits must reflect only the human author's git identity for this project—same intent as **Cursor Settings → Agent → Attribution** off.
 
 ## Pre-Push CI Verification
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The IDE setting **Agent → Attribution** (and, for the CLI, `~/.cursor/cli-config.json` with `attribution.attributeCommitsToAgent` / `attribution.attributePRsToAgent`) is the official way to turn off automatic Cursor trailers. Project-level `.cursor/settings.json` does not expose that schema in the docs, so this PR encodes the same intent for **in-repo** Agent runs.

## Changes

- Extend `.cursor/rules/git-commits.mdc` with an explicit rule: do not append `Co-authored-by` (e.g. cursoragent), `Made with Cursor`, or similar footers to commits or PR bodies; human git identity only for this project.

## Notes

- Cloud/remote agents that append trailers at the platform layer may still need the product toggle; this rule ensures any Agent that reads project rules will not add those lines in messages it controls.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35d5bb64-57a3-4b14-b265-7cd90382eeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35d5bb64-57a3-4b14-b265-7cd90382eeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

