### PR TITLE
docs: npm publish follow-up, TS client publishConfig, and D4 transport lint

### DIFF
--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -43,7 +43,7 @@ Before pushing to the repository, always run the full CI check suite locally to 
 2. **Formatting**: `uv run ruff format --check .` - Ensure consistent code formatting (or `uv run ruff format .` to auto-fix)
 3. **Type Checking**: `uv run mypy src/ scripts/ tests/` - Validate type annotations (strict for src/scripts, relaxed for tests)
 4. **Tests**: `PYTHONPATH=src uv run pytest --cov=src --cov-report=xml` - Run full test suite with coverage
-5. **Security**: `uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex && uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219` — same as the CI security job (see `SECURITY.md`); use full `uv sync --frozen --all-extras --dev` when auditing optional integration extras separately
+5. **Security**: `uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex && uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654` — same as the CI security job (see `SECURITY.md`); use full `uv sync --frozen --all-extras --dev` when auditing optional integration extras separately
 
 ### Pre-Push CI Verification (Web App / TypeScript)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,8 +178,8 @@ jobs:
           # Omit extras whose transitive deps have no OSV fix on PyPI (diskcache, nltk).
           sync-flags: --no-extra crewai --no-extra llamaindex
       # CVE-2026-4539: pygments advisory with no patched PyPI release yet (override pins >=2.20 when available).
-      # CVE-2026-3219: pip (GHSA-58qw-9mgm-455v); OSV marks last_affected 26.0.1 — no fixed pip on PyPI yet (transitive via pip-audit→pip-api).
+      # CVE-2026-4963 / CVE-2026-2654: smolagents optional extra; OSV lists no fix version on PyPI as of 2026-05 (see SECURITY.md).
       - name: Scan for vulnerabilities (pip-audit)
-        run: uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219
+        run: uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654
       - name: Scan for security issues (bandit)
         run: uv run bandit -r src/ -ll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
-# CI: quality (lint+typecheck), test, coverage, security.
-# 6 jobs total. Branch protection: require quality (python), quality (web), test (python), test (web), coverage, security.
+# CI: quality (lint+typecheck), transport surface lint (D4), test, coverage, security.
+# 7 jobs total. Branch protection: require quality (python), lint transport growth (D4), quality (web), test (python), test (web), coverage, security.
 name: CI
 
 on:
@@ -42,6 +42,15 @@ permissions:
   contents: read
 
 jobs:
+  lint-transport-growth:
+    name: lint transport growth (D4)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Enforce transport monolith baseline
+        run: python3 scripts/lint_no_transport_growth.py
+
   quality-python:
     name: quality (python)
     runs-on: ubuntu-latest
@@ -84,7 +93,7 @@ jobs:
   test-python:
     name: test (python)
     runs-on: ubuntu-latest
-    needs: [quality-python]
+    needs: [quality-python, lint-transport-growth]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -128,7 +137,7 @@ jobs:
   coverage:
     name: coverage
     runs-on: ubuntu-latest
-    needs: [quality-python]
+    needs: [quality-python, lint-transport-growth]
     timeout-minutes: 18
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -159,7 +168,7 @@ jobs:
   security:
     name: security
     runs-on: ubuntu-latest
-    needs: [quality-python]
+    needs: [quality-python, lint-transport-growth]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CI security (`pip-audit`)**: Bumped transitive pins (`langchain-core`, `langsmith`, `python-multipart`, `urllib3`, `pip`, `smolagents`) and adjusted documented `--ignore-vuln` flags (pygments + **smolagents** CVEs with no PyPI fix yet; pip ≥26.1 clears prior pip ignore). See [SECURITY.md](SECURITY.md).
+
 ---
 
 ## [2.3.0] - 2026-05-04

--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ Or with pip:
 pip install asap-protocol
 ```
 
-**npm** (TypeScript / JavaScript — [`@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client), aligned with protocol **v2.3.0**):
+**npm** (TypeScript / JavaScript — [`@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client), aligned with protocol **v2.3.0**). The `latest` dist-tag matches **`npm view @asap-protocol/client version`** (currently **2.3.0**).
 
 ```bash
 npm install @asap-protocol/client
+# reproducible pin (same as latest today):
+# npm install @asap-protocol/client@2.3.0
 ```
 
 📦 **Canonical listing:** **[https://pypi.org/project/asap-protocol/](https://pypi.org/project/asap-protocol/)** — package **`asap-protocol`** (`pip install asap-protocol`). Prefer `uv` for reproducible environments when possible.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -93,11 +93,13 @@ We continuously monitor dependencies using:
 
 CI runs `pip-audit` after a sync that **excludes** the optional extras `crewai` and `llamaindex`, because those graphs currently pull transitive packages (`diskcache`, `nltk`) that OSV still lists with no fixed release on PyPI. To match the security job locally:
 
-`uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex` then `uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219` (matches CI).
+`uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex` then `uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654` (matches CI).
 
 **CVE-2026-4539 (Pygments)**: CI uses `--ignore-vuln CVE-2026-4539` until a patched `pygments` release on PyPI resolves the advisory (`tool.uv.override-dependencies` prefers `pygments>=2.20.0` when resolvable).
 
-**CVE-2026-3219 (pip)**: `[dev]` pulls `pip-audit` → `pip-api`, which resolves `pip` from PyPI. [GHSA-58qw-9mgm-455v](https://github.com/advisories/GHSA-58qw-9mgm-455v) reports ambiguous handling of concatenated tar/ZIP archives; OSV marks `last_affected` **`26.0.1`** with **no fixed version** listed yet. CI ignores this CVE until a patched `pip` release is published; remove the flag when `pip-audit` reports zero hits without it.
+**CVE-2026-4963 / CVE-2026-2654 (smolagents, optional `[smolagents]` extra)**: OSV reports these against current PyPI releases with **no `fix_versions`/`fixed` range** yet. CI ignores them until Hugging Face publishes patched `smolagents` wheels; remove the flags when `pip-audit` is clean without them. The reference package does not import smolagents unless that extra is installed.
+
+**pip**: `tool.uv.override-dependencies` requires `pip>=26.1` so **CVE-2026-3219** (GHSA affecting pip ≤26.0.1) no longer requires a `pip-audit` ignore.
 
 If you install `[crewai]` or `[llamaindex]`, run `pip-audit` separately on that environment and expect possible advisories until upstream publishes patched releases. Integration tests for those extras still run in CI with the full dependency tree.
 

--- a/docs/maintainers/npm-publishing.md
+++ b/docs/maintainers/npm-publishing.md
@@ -1,6 +1,11 @@
 # npm publishing runbook (`@asap-protocol/client`)
 
-Maintainer guide for scoped package bootstrap, Trusted Publishing (OIDC), and recovery when the registry or OIDC path fails.
+Maintainer guide for scoped package bootstrap, Trusted Publishing (OIDC), and recovery when the registry or OIDC path fails. Read this before rotating secrets or doing a break-glass publish; no prior npm-org context is assumed beyond repo membership.
+
+## Maintainer cross-links
+
+- **Release checklist (npm gate)**: [engineering/tasks/v2.3.0/release-checklist.md](../../engineering/tasks/v2.3.0/release-checklist.md) — §**4.3** (verify install after publish).
+- **Sprint notes (historical)**: [engineering/tasks/private/v2.3.1/sprint-S0-unblock-npm.md](../../engineering/tasks/private/v2.3.1/sprint-S0-unblock-npm.md) — first-publish / OIDC troubleshooting narrative.
 
 ## Normal path (after bootstrap)
 

--- a/docs/maintainers/transport-evolution.md
+++ b/docs/maintainers/transport-evolution.md
@@ -1,0 +1,31 @@
+# Transport module evolution (D4 baseline)
+
+Product constraint **D4** requires every **new transport route or callable surface** to live in a **dedicated module**, not by extending `src/asap/transport/server.py` or `src/asap/transport/client.py` indefinitely.
+
+CI enforces a frozen baseline of **public function and method names** on those two files.
+
+## Enforcement
+
+- **Script**: [`scripts/lint_no_transport_growth.py`](../../scripts/lint_no_transport_growth.py) — parses AST only (no imports from ASAP).
+- **Baseline snapshot**: [`scripts/_transport_baseline_v2.3.0.json`](../../scripts/_transport_baseline_v2.3.0.json) — frozen at **v2.3.0**.
+- **Workflow**: GitHub Actions job **`lint transport growth (D4)`** in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml).
+
+Adding any **new public symbol** (names not starting with `_`; excludes nested defs inside functions) to either monolith file **breaks CI**. Removing symbols is allowed.
+
+Repo admins must add this job to **branch protection required checks** next to the other CI gates.
+
+## Escape hatch (rare)
+
+Updating the baseline is intentional governance overhead — only after architectural agreement.
+
+1. **Architectural review** — justify why new surface cannot ship from a new submodule under `src/asap/transport/` (or another boundary consistent with ADRs).
+2. **Maintainer sign-off** — explicit approval on the PR (link reviewer handles).
+3. **Same PR** — regenerate or edit **`scripts/_transport_baseline_v2.3.0.json`** together with the code change:
+
+   ```bash
+   uv run python scripts/lint_no_transport_growth.py --emit-baseline > scripts/_transport_baseline_v2.3.0.json
+   ```
+
+   Inspect the diff; commit only intentional additions.
+
+Do **not** widen the baseline to silence unrelated churn — refactor helpers into dedicated modules instead.

--- a/engineering/manual-release-testing.md
+++ b/engineering/manual-release-testing.md
@@ -83,7 +83,7 @@ Repeat the same scenarios covered by CI without running the full suite:
 
 ## 11. Security audit (same graph as CI)
 
-- [ ] `uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex && uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219` — matches CI (see `SECURITY.md` if flags change)
+- [ ] `uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex && uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654` — matches CI (see `SECURITY.md` if flags change)
 
 ---
 

--- a/engineering/tasks/v2.3.0/release-checklist.md
+++ b/engineering/tasks/v2.3.0/release-checklist.md
@@ -17,7 +17,7 @@ Run from repository root (`/Users/adrianno/GitHub/asap-protocol` or CI clone):
 | Format | `uv run ruff format --check .` | |
 | Types | `uv run mypy src/ scripts/ tests/` | |
 | Python tests | `PYTHONPATH=src uv run pytest --cov=src --cov-report=xml` | **2026-05-04**: 3213 passed, 11 skipped (requires extras incl. `webauthn` for full collection) |
-| pip-audit | `uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219` | Same ignores as CI |
+| pip-audit | `uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654` | Same ignores as CI |
 | TS client | `pnpm install && pnpm test && pnpm typecheck && pnpm lint` | Root `package.json` delegates to `@asap-protocol/client` + `example-nextjs` lint |
 | Web app (if touched) | `cd apps/web && pnpm test` | Vitest; Playwright E2E optional for release gate |
 

--- a/engineering/tasks/v2.3.0/release-checklist.md
+++ b/engineering/tasks/v2.3.0/release-checklist.md
@@ -99,8 +99,10 @@ Compliance is enforced on the **Python agent** side in CI; Next.js app follows S
 
 ### 4.3 npm
 
-- [ ] `@asap-protocol/client@2.3.0` published with provenance (per workflow) — **Publish TypeScript SDK** falhou: [run 25432265924](https://github.com/adriannoes/asap-protocol/actions/runs/25432265924) (`404` no `PUT` — org `@asap-protocol` / Trusted Publishing / primeiro publish)
-- [ ] Verify: `npm install @asap-protocol/client@2.3.0` in empty project
+Maintainer runbook: [docs/maintainers/npm-publishing.md](../../../docs/maintainers/npm-publishing.md).
+
+- [x] `@asap-protocol/client@2.3.0` on [npm](https://www.npmjs.com/package/@asap-protocol/client) — bootstrap publish **2026-05-13** (maintainer machine; primeiro `PUT` falhou no CI: [run 25432265924](https://github.com/adriannoes/asap-protocol/actions/runs/25432265924)). **Provenance via workflow** → Trusted Publishing / `publish-typescript.yml`: follow [S0 unblock npm](../private/v2.3.1/sprint-S0-unblock-npm.md).
+- [x] Verify: `npm install @asap-protocol/client@2.3.0` in empty project — **OK** (2026-05-14; `require('@asap-protocol/client')` resolves)
 
 ### 4.4 Docker (GHCR)
 

--- a/engineering/tasks/v2.3.0/sprint-S2-typescript-sdk.md
+++ b/engineering/tasks/v2.3.0/sprint-S2-typescript-sdk.md
@@ -158,7 +158,7 @@ Verification: root `package.json` defines `pnpm test`, `pnpm typecheck`, and `pn
 | Bundle core <50KB gzipped (excl. adapters) | Yes | Core ESM bundle gzip ≈ **14KB** (same methodology as prior audit). |
 | Tree-shakeable adapters (`agadoo`) | Yes | `pnpm --filter @asap-protocol/client run check:treeshake` runs **agadoo** on main + adapter entrypoints after `tshy` build. |
 | Reference Next.js app on **Vercel preview** | Pending ops | Deploy `apps/example-nextjs` from maintainer account / project settings. |
-| **`@asap-protocol/client@2.3.0` on npm** | Pending release | Tag `v2.3.*` + `.github/workflows/publish-typescript.yml`; bump package version at release time (source may stay `0.0.0` until publish). |
+| **`@asap-protocol/client@2.3.0` on npm** | Yes | [npmjs.com/package/@asap-protocol/client](https://www.npmjs.com/package/@asap-protocol/client) (**2026-05-13**); routine CI publish + provenance: `.github/workflows/publish-typescript.yml` + Trusted Publishing ([S0 unblock](../private/v2.3.1/sprint-S0-unblock-npm.md)). |
 
 Checklist:
 
@@ -168,7 +168,7 @@ Checklist:
 - [x] Bundle size: SDK core <50KB gzipped (excluding adapters)
 - [x] Tree-shakeable adapters verified (`agadoo` script + CI)
 - [ ] Reference Next.js app deployed to Vercel preview *(maintainer)*
-- [ ] Package published to npm `@asap-protocol/client@2.3.0` *(release/tag)*
+- [x] Package published to npm `@asap-protocol/client@2.3.0` — [registry](https://www.npmjs.com/package/@asap-protocol/client)
 
 ## Risks & Mitigations
 

--- a/engineering/tasks/v2.3.0/sprint-S5-release.md
+++ b/engineering/tasks/v2.3.0/sprint-S5-release.md
@@ -89,7 +89,7 @@
 
 - [x] 3.1 Tag and push — `git tag -a v2.3.0 -m "…" && git push origin v2.3.0` ✅ (2026-05-06)
 - [x] 3.2 PyPI publish — **OK** — `asap-protocol==2.3.0` em [PyPI](https://pypi.org/project/asap-protocol/) (workflow [25432265870](https://github.com/adriannoes/asap-protocol/actions/runs/25432265870))
-- [ ] 3.3 npm publish — **falhou** — [run 25432265924](https://github.com/adriannoes/asap-protocol/actions/runs/25432265924): `npm ERR! 404 Not Found - PUT ... @asap-protocol/client` (escopo/org no npm, Trusted Publishing OIDC ou primeiro publish ainda não configurado)
+- [x] 3.3 npm publish — **OK** — [@asap-protocol/client@2.3.0](https://www.npmjs.com/package/@asap-protocol/client) no registry (bootstrap via maintainer após falha do workflow [25432265924](https://github.com/adriannoes/asap-protocol/actions/runs/25432265924)); OIDC/provenance de rotina: [S0 unblock npm](../private/v2.3.1/sprint-S0-unblock-npm.md)
 - [x] 3.4 Docker build / GHCR — imagem publicada no job **Build and push Docker image** do mesmo workflow; verificar: `docker pull ghcr.io/adriannoes/asap-protocol:v2.3.0`
 - [x] 3.5 GitHub Release — [v2.3.0](https://github.com/adriannoes/asap-protocol/releases/tag/v2.3.0) (artefatos `.whl` / `.tar.gz` anexados)
 
@@ -116,7 +116,7 @@
 - [ ] CI green on `main` HEAD at merge time — **maintainer**: confirm GitHub Actions (push só de docs pode não acionar `ci.yml` por *path filter*; após tag, workflow **Release** ficou verde)
 - [x] Tag `v2.3.0` pushed ✅ (2026-05-06)
 - [x] `asap-protocol==2.3.0` on PyPI ✅
-- [ ] `@asap-protocol/client@2.3.0` on npm — **bloqueado** até corrigir publicação (ver 3.3)
+- [x] `@asap-protocol/client@2.3.0` on npm — [package](https://www.npmjs.com/package/@asap-protocol/client) (ver 3.3)
 - [x] Docker `:v2.3.0` and `:latest` on GHCR — **build/push OK** no workflow Release; confirmar digest localmente com `docker pull`
 - [x] GitHub Release published — [releases/tag/v2.3.0](https://github.com/adriannoes/asap-protocol/releases/tag/v2.3.0)
 - [x] PRD + roadmap + README + docs + web copy updated for **shipped** narrative (publish caveat where artifacts not yet live)

--- a/engineering/tasks/v2.3.0/sprint-S5-release.md
+++ b/engineering/tasks/v2.3.0/sprint-S5-release.md
@@ -41,7 +41,7 @@
 | `uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex` | OK |
 | `PYTHONPATH=src uv run pytest` | **3213 passed**, 11 skipped (~2m18s) |
 | `pnpm` (root) | `pnpm test` in `packages/typescript/client` — **Vitest green**, statements ~87.7% / lines ~90.9% coverage |
-| `uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219` | **0 vulns** (2 CVEs ignored per SECURITY.md) |
+| `uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654` | **0 vulns** (3 CVEs ignored per SECURITY.md) |
 | `uv run mypy src/ scripts/ tests/` | **Success** (396 files) |
 | `cd apps/web && npm audit` | **2 moderate** (`postcss` via `next`) — documented in CHANGELOG + release-checklist |
 | S1–S4 DoD (adoption index) | **Repo scope done**; S1 acceptance still notes **OpenAPI coverage below 90%**; S4 narrow-cov caveat documented |

--- a/engineering/tasks/v2.3.0/tasks-v2.3.0-adoption-multiplier.md
+++ b/engineering/tasks/v2.3.0/tasks-v2.3.0-adoption-multiplier.md
@@ -1,6 +1,6 @@
 # Tasks: v2.3.0 Adoption Multiplier — Sprint Index
 
-**Status: 🟢 SHIPPED (code & docs 2026-05-04)** — PyPI `asap-protocol==2.3.0`, npm `@asap-protocol/client@2.3.0`, tag, Docker, and GitHub Release require maintainer actions per [release-checklist.md](./release-checklist.md).
+**Status: 🟢 SHIPPED (code & docs 2026-05-04)** — PyPI `asap-protocol==2.3.0`, npm `@asap-protocol/client@2.3.0` (**live 2026-05-13**; maintainer runbook [docs/maintainers/npm-publishing.md](../../../docs/maintainers/npm-publishing.md)), tag, Docker, and GitHub Release: see [release-checklist.md](./release-checklist.md) for remaining verify steps.
 
 Based on [PRD v2.3 Adoption Multiplier](../../../product/prd/prd-v2.3-scale.md). Each sprint maps to a PR sequence.
 
@@ -20,7 +20,7 @@ Based on [PRD v2.3 Adoption Multiplier](../../../product/prd/prd-v2.3-scale.md).
 | **S2** | [TypeScript Client SDK](./sprint-S2-typescript-sdk.md) | §4.2 (TS-001..011) | P0 | 🟢 **Done (repo)** — npm `@asap-protocol/client@2.3.0` via **S5** |
 | **S3** | [Auto-Registration](./sprint-S3-auto-registration.md) | §4.3 (AUTO-001..007) | P0 | 🟢 **Done (repo)** |
 | **S4** | [Capability Escalation + ASAP Challenge](./sprint-S4-escalation-challenge.md) | §4.4 (ESC-001..004), §4.5 (CHAL-001..004) | P1/P2 | 🟢 **Done (repo)** |
-| **S5** | Release v2.3.0 | — | — | 🟡 **In progress** — [release-checklist.md](./release-checklist.md) (tag / PyPI / npm / Docker / GitHub Release manual) |
+| **S5** | Release v2.3.0 | — | — | 🟡 **In progress** — [release-checklist.md](./release-checklist.md): npm **shipped** + runbook linked (§4.3); Docker pull verify / PyPI venv verify / housekeeping |
 
 ## Dependency Graph
 
@@ -38,7 +38,7 @@ S1, S2, and S3 are independent and can run in parallel with three contributors. 
 
 - [x] **OpenAPI Adapter (repo)**: `asap.adapters.openapi` implemented (`create_from_openapi`, PetStore example `examples/openapi_petstore/`, docs `docs/adapters/openapi.md`) — see [sprint-S1-openapi-adapter.md](./sprint-S1-openapi-adapter.md). *Acceptance: sprint checklist complete; release packaging tracked separately.*
 - [ ] **OpenAPI Adapter (release)**: `asap-protocol==2.3.0` on **PyPI** includes the `[openapi]` extra and adapter surface (closes when S5 ships)
-- [ ] **TypeScript SDK**: `@asap-protocol/client@2.3.0` published to npm with Vercel AI / OpenAI / Anthropic adapters
+- [x] **TypeScript SDK**: `@asap-protocol/client@2.3.0` published to npm with Vercel AI / OpenAI / Anthropic adapters — [npm](https://www.npmjs.com/package/@asap-protocol/client) (2026-05-13)
 - [x] **Auto-Registration (repo)**: `POST /registry/agents` + bot PR / merge workflows — see [sprint-S3-auto-registration.md](./sprint-S3-auto-registration.md). *Production registry-bot deployment is operator-specific.*
 - [x] **Capability Escalation (repo)**: `POST /asap/agent/request-capability` + client helpers — see [sprint-S4-escalation-challenge.md](./sprint-S4-escalation-challenge.md).
 - [x] **ASAP Challenge (repo)**: `WWW-Authenticate: ASAP` middleware + client recognition — see [sprint-S4-escalation-challenge.md](./sprint-S4-escalation-challenge.md).
@@ -51,7 +51,7 @@ S1, S2, and S3 are independent and can run in parallel with three contributors. 
 - [x] Public docs (`docs/index.md`, migration, adapter/TS guides) route users to OpenAPI, TypeScript SDK, and registry flows.
 - [x] CHANGELOG.md updated under `## [2.3.0]`
 - [ ] `asap-protocol==2.3.0` published to PyPI *(full package; confirms **OpenAPI Adapter (release)** above)*
-- [ ] `@asap-protocol/client@2.3.0` published to npm
+- [x] `@asap-protocol/client@2.3.0` published to npm
 - [ ] Tag `v2.3.0` on `main` + GitHub Release notes
 - [ ] Docker `ghcr.io/adriannoes/asap-protocol:v2.3.0` and `:latest` rebuilt
 

--- a/packages/typescript/client/package.json
+++ b/packages/typescript/client/package.json
@@ -4,6 +4,9 @@
   "description": "Official TypeScript client for the ASAP Protocol",
   "type": "module",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/adriannoes/asap-protocol"

--- a/product/prd/prd-v2.3-scale.md
+++ b/product/prd/prd-v2.3-scale.md
@@ -3,9 +3,9 @@
 > **Product Requirements Document**
 >
 > **Version**: 2.3.0
-> **Status**: ✅ SHIPPED (2026-05-04; tag `v2.3.0` — PyPI/npm publish via maintainer release workflow after merge)
+> **Status**: ✅ SHIPPED (tag `v2.3.0`, code + **PyPI** aligned with **2026-05-04** release; **`@asap-protocol/client@2.3.0` on npm** completed **2026-05-13** — registry bootstrap; CI provenance/OIDC follow-up in [S0 unblock npm](../../engineering/tasks/private/v2.3.1/sprint-S0-unblock-npm.md))
 > **Created**: 2026-03-13
-> **Last Updated**: 2026-05-04
+> **Last Updated**: 2026-05-14
 > **Origin**: Items deferred from [prd-v2.2-scale.md](./prd-v2.2-scale.md) per strategic review (2026-03), then **rescoped** in 2026-04 after v2.2.0 audit.
 > **Predecessor**: [prd-v2.2.1-patch.md](./prd-v2.2.1-patch.md) (carry-over patch)
 > **Successor**: [prd-v2.4-adoption.md](./prd-v2.4-adoption.md)
@@ -18,7 +18,7 @@
 | **S2** | `@asap-protocol/client` package, adapters, `apps/example-nextjs`, publish workflow |
 | **S3** | `POST /registry/agents`, harness gating, bot PR + auto-merge docs/workflows |
 | **S4** | Capability escalation route + clients; ASAP `WWW-Authenticate` challenge middleware + TS recognition |
-| **S5** | Version **2.3.0**, CHANGELOG, migration, marketing/docs refresh; **PyPI / npm / tag / Docker / GitHub Release** via [engineering/tasks/v2.3.0/release-checklist.md](../../engineering/tasks/v2.3.0/release-checklist.md) |
+| **S5** | Version **2.3.0**, CHANGELOG, migration, marketing/docs refresh; **PyPI / tag / Docker / GitHub Release** via [engineering/tasks/v2.3.0/release-checklist.md](../../engineering/tasks/v2.3.0/release-checklist.md); **npm registry** `@asap-protocol/client@2.3.0` **2026-05-13** (see checklist §4.3 + [S0 unblock](../../engineering/tasks/private/v2.3.1/sprint-S0-unblock-npm.md)) |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ mcp = [
     "mcp>=1.0.0",
 ]
 langchain = [
-    "langchain-core>=0.2",
+    "langchain-core>=1.3.3",
 ]
 crewai = [
     "crewai>=0.80",
@@ -91,7 +91,7 @@ llamaindex = [
     "llama-index-core>=0.10",
 ]
 smolagents = [
-    "smolagents>=1.0",
+    "smolagents>=1.24.0",
 ]
 pydanticai = [
     "pydantic-ai>=0.2",
@@ -119,9 +119,12 @@ Issues = "https://github.com/adriannoes/asap-protocol/issues"
 # - requests>=2.33.0 for CVE-2026-25645 (extract_zipped_paths temp file)
 # - pillow>=12.2.0 for CVE-2026-40192 (transitive, e.g. pdf/vision stacks)
 # - pytest>=9.0.3 for CVE-2025-71176 (dev)
-# - python-multipart>=0.0.26 for CVE-2026-40347 (FastAPI stack)
+# - python-multipart>=0.0.27 for CVE-2026-42561 / CVE-2026-40347 (FastAPI stack)
 # - pygments>=2.20.0 for CVE-2026-4539
-# - langsmith>=0.7.31 for GHSA-rr7j-v2q5-chgv
+# - langsmith>=0.8.0 for CVE-2026-45134 (prior: GHSA-rr7j-v2q5-chgv)
+# - langchain-core>=1.3.3 for CVE-2026-44843
+# - urllib3>=2.7.0 for CVE-2026-44431 / CVE-2026-44432
+# - pip>=26.1 for CVE-2026-6357 (transitive via pip-api / venv)
 # - python-dotenv>=1.2.2 for CVE-2026-28684 (transitive, e.g. pydantic-settings / uvicorn stacks)
 [tool.uv]
 override-dependencies = [
@@ -132,9 +135,12 @@ override-dependencies = [
     "requests>=2.33.0",
     "pillow>=12.2.0",
     "pytest>=9.0.3",
-    "python-multipart>=0.0.26",
+    "python-multipart>=0.0.27",
     "pygments>=2.20.0",
-    "langsmith>=0.7.31",
+    "langsmith>=0.8.0",
+    "langchain-core>=1.3.3",
+    "urllib3>=2.7.0",
+    "pip>=26.1",
     "python-dotenv>=1.2.2",
 ]
 

--- a/scripts/_transport_baseline_v2.3.0.json
+++ b/scripts/_transport_baseline_v2.3.0.json
@@ -1,0 +1,33 @@
+{
+  "_meta": {
+    "description": "Frozen public callable surface for D4 transport monolith lint (see docs/maintainers/transport-evolution.md).",
+    "frozen_at_release": "v2.3.0"
+  },
+  "files": {
+    "src/asap/transport/client.py": [
+      "ASAPClient.batch",
+      "ASAPClient.discover",
+      "ASAPClient.get_manifest",
+      "ASAPClient.health_check",
+      "ASAPClient.is_connected",
+      "ASAPClient.last_asap_challenge_discovery_url",
+      "ASAPClient.last_response_asap_version",
+      "ASAPClient.request_capability",
+      "ASAPClient.send",
+      "ASAPClient.send_batch",
+      "ASAPClient.stream"
+    ],
+    "src/asap/transport/server.py": [
+      "ASAPRequestHandler.build_error_response",
+      "ASAPRequestHandler.build_jsonrpc_error_for_asap_exception",
+      "ASAPRequestHandler.handle_message",
+      "ASAPRequestHandler.handle_stream",
+      "ASAPRequestHandler.iter_websocket_stream",
+      "ASAPRequestHandler.parse_json_body",
+      "ASAPRequestHandler.record_error_metrics",
+      "ASAPRequestHandler.validate_jsonrpc_request",
+      "RegistryHolder.replace_registry",
+      "create_app"
+    ]
+  }
+}

--- a/scripts/lint_no_transport_growth.py
+++ b/scripts/lint_no_transport_growth.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Enforce D4: forbid growing public surface on transport server/client monolith files.
+
+Compares the set of public function/method names in ``server.py`` and ``client.py``
+against ``scripts/_transport_baseline_v2.3.0.json``. New public symbols fail CI;
+removed symbols are allowed.
+
+Design rationale:
+    AST inspection avoids importing ASAP dependencies when emitting/checking.
+
+Exit codes:
+    0 — current exports ⊆ baseline (no growth).
+    1 — baseline violated or invalid invocation."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from pathlib import Path
+from typing import Final
+
+_REPO_ROOT: Final = Path(__file__).resolve().parent.parent
+_BASELINE_REL_PATH: Final = Path("scripts/_transport_baseline_v2.3.0.json")
+_TRANSPORT_REL_PATHS: Final[tuple[str, ...]] = (
+    "src/asap/transport/server.py",
+    "src/asap/transport/client.py",
+)
+
+
+def _is_public_symbol(name: str) -> bool:
+    """Return True if this AST-defined callable should count toward D4 surface."""
+    return not name.startswith("_")
+
+
+def _symbols_from_class_body(class_node: ast.ClassDef, prefix: str) -> set[str]:
+    """Collect ``Prefix.method`` symbols from class body (recursive for nested classes)."""
+    found: set[str] = set()
+    for item in class_node.body:
+        if isinstance(item, ast.ClassDef):
+            nested_prefix = f"{prefix}.{item.name}"
+            found |= _symbols_from_class_body(item, nested_prefix)
+        elif isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if _is_public_symbol(item.name):
+                found.add(f"{prefix}.{item.name}")
+    return found
+
+
+def extract_public_symbols(py_path: Path) -> list[str]:
+    """Parse *py_path* and list public module-level functions plus class methods."""
+    source = py_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    symbols: set[str] = set()
+
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if _is_public_symbol(node.name):
+                symbols.add(node.name)
+        elif isinstance(node, ast.ClassDef):
+            symbols |= _symbols_from_class_body(node, node.name)
+
+    return sorted(symbols)
+
+
+def emit_baseline(repo_root: Path) -> dict[str, object]:
+    """Build baseline payload with sorted symbol lists."""
+    files_payload: dict[str, list[str]] = {}
+    for rel in _TRANSPORT_REL_PATHS:
+        abs_path = repo_root / rel
+        if not abs_path.is_file():
+            msg = f"Expected transport file missing: {rel}"
+            raise FileNotFoundError(msg)
+        files_payload[rel] = extract_public_symbols(abs_path)
+
+    return {
+        "_meta": {
+            "description": (
+                "Frozen public callable surface for D4 transport monolith lint "
+                "(see docs/maintainers/transport-evolution.md)."
+            ),
+            "frozen_at_release": "v2.3.0",
+        },
+        "files": files_payload,
+    }
+
+
+def load_baseline(path: Path) -> dict[str, list[str]]:
+    """Load and validate baseline JSON; return the ``files`` mapping."""
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("Baseline root must be a JSON object")
+    files_obj = raw.get("files")
+    if not isinstance(files_obj, dict):
+        raise ValueError("Baseline must contain a 'files' object")
+
+    files_payload: dict[str, list[str]] = {}
+    for key, value in files_obj.items():
+        if key not in _TRANSPORT_REL_PATHS:
+            raise ValueError(f"Unexpected baseline key {key!r}")
+        if not isinstance(value, list) or not all(isinstance(x, str) for x in value):
+            raise ValueError(f"Baseline entry for {key!r} must be a list of strings")
+        files_payload[str(key)] = list(value)
+
+    expected = set(_TRANSPORT_REL_PATHS)
+    if set(files_payload.keys()) != expected:
+        missing = expected - set(files_payload.keys())
+        raise ValueError(f"Baseline 'files' missing entries: {sorted(missing)}")
+
+    return files_payload
+
+
+def check_no_growth(repo_root: Path, baseline_path: Path) -> list[str]:
+    """Return human-readable errors (empty list means success)."""
+    errors: list[str] = []
+    try:
+        baseline_files = load_baseline(baseline_path)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return [f"Cannot load baseline {baseline_path}: {exc}"]
+
+    for rel in _TRANSPORT_REL_PATHS:
+        abs_path = repo_root / rel
+        if not abs_path.is_file():
+            errors.append(f"Missing transport module {rel}")
+            continue
+
+        current = set(extract_public_symbols(abs_path))
+        allowed = set(baseline_files[rel])
+        added = sorted(current - allowed)
+        if added:
+            joined = ", ".join(added)
+            errors.append(
+                f"D4 violation: new public symbols in {rel} "
+                f"(move routes/helpers to a dedicated module): {joined}"
+            )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--emit-baseline",
+        action="store_true",
+        help="Print baseline JSON to stdout (redirect to scripts/_transport_baseline_v2.3.0.json).",
+    )
+    parser.add_argument(
+        "--baseline-path",
+        type=Path,
+        default=None,
+        help=f"Override baseline JSON path (default: repo / {_BASELINE_REL_PATH.as_posix()}).",
+    )
+    args = parser.parse_args(argv)
+
+    baseline_default = _REPO_ROOT / _BASELINE_REL_PATH
+    baseline_path = args.baseline_path if args.baseline_path is not None else baseline_default
+
+    if args.emit_baseline:
+        try:
+            payload = emit_baseline(_REPO_ROOT)
+        except FileNotFoundError as exc:
+            print(exc, file=sys.stderr)
+            return 1
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    errors = check_no_growth(_REPO_ROOT, baseline_path.resolve())
+    if errors:
+        for line in errors:
+            print(line, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -5,16 +5,19 @@ requires-python = ">=3.13"
 [manifest]
 overrides = [
     { name = "cryptography", specifier = ">=46.0.7,<47" },
-    { name = "langsmith", specifier = ">=0.7.31" },
+    { name = "langchain-core", specifier = ">=1.3.3" },
+    { name = "langsmith", specifier = ">=0.8.0" },
     { name = "pillow", specifier = ">=12.2.0" },
+    { name = "pip", specifier = ">=26.1" },
     { name = "pyasn1", specifier = ">=0.6.3" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.12.0,<3" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "tinytag", specifier = ">=2.2.1" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
 [[package]]
@@ -315,7 +318,7 @@ requires-dist = [
     { name = "jcs", specifier = ">=0.2.0" },
     { name = "joserfc", specifier = ">=1.6.3,<2" },
     { name = "jsonschema", specifier = ">=4.23.0" },
-    { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=0.2" },
+    { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.3.3" },
     { name = "limits", specifier = ">=3.0" },
     { name = "llama-index-core", marker = "extra == 'llamaindex'", specifier = ">=0.10" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
@@ -342,7 +345,7 @@ requires-dist = [
     { name = "python-ulid", specifier = ">=3.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.14" },
-    { name = "smolagents", marker = "extra == 'smolagents'", specifier = ">=1.0" },
+    { name = "smolagents", marker = "extra == 'smolagents'", specifier = ">=1.24.0" },
     { name = "structlog", specifier = ">=24.1" },
     { name = "typer", specifier = ">=0.21.1" },
     { name = "types-jsonschema", marker = "extra == 'dev'", specifier = ">=4.0.0" },
@@ -1647,15 +1650,6 @@ wheels = [
 ]
 
 [[package]]
-name = "griffelib"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
-]
-
-[[package]]
 name = "groq"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1832,22 +1826,26 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.5.0"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "tqdm" },
-    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/76/b5efb3033d8499b17f9386beaf60f64c461798e1ee16d10bc9c0077beba5/huggingface_hub-1.5.0.tar.gz", hash = "sha256:f281838db29265880fb543de7a23b0f81d3504675de82044307ea3c6c62f799d", size = 695872, upload-time = "2026-02-26T15:35:32.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/74/2bc951622e2dbba1af9a460d93c51d15e458becd486e62c29cc0ccb08178/huggingface_hub-1.5.0-py3-none-any.whl", hash = "sha256:c9c0b3ab95a777fc91666111f3b3ede71c0cdced3614c553a64e98920585c4ee", size = 596261, upload-time = "2026-02-26T15:35:31.1Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+]
+
+[package.optional-dependencies]
+inference = [
+    { name = "aiohttp" },
 ]
 
 [[package]]
@@ -2232,10 +2230,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -2244,14 +2243,26 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/1a/86c38c27b81913a1c6c12448cab55defb5a1097c7dc9a4cea83f55477a2d/langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c", size = 548120, upload-time = "2026-05-11T18:42:33.992Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982, upload-time = "2026-05-01T22:30:03.877Z" },
 ]
 
 [[package]]
 name = "langsmith"
-version = "0.7.32"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2264,9 +2275,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/b4/a0b4a501bee6b8a741ce29f8c48155b132118483cddc6f9247735ddb38fa/langsmith-0.7.32.tar.gz", hash = "sha256:b59b8e106d0e4c4842e158229296086e2aa7c561e3f602acda73d3ad0062e915", size = 1184518, upload-time = "2026-04-15T23:42:41.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/e9/4ceeba766bae47de1a6ecdaa4024d10eff63eed936796b77005742399e8d/langsmith-0.8.4.tar.gz", hash = "sha256:989b387f6ff92ec5f9d14c0edb333e2579590cad5a1ca07042d924b0ec43cd10", size = 4460243, upload-time = "2026-05-13T21:00:59.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/bc/148f98ac7dad73ac5e1b1c985290079cfeeb9ba13d760a24f25002beb2c9/langsmith-0.7.32-py3-none-any.whl", hash = "sha256:e1fde928990c4c52f47dc5132708cec674355d9101723d564183e965f383bf5f", size = 378272, upload-time = "2026-04-15T23:42:39.905Z" },
+    { url = "https://files.pythonhosted.org/packages/db/94/8b872959ea529ecfbbe2c3f91d9ebf98cb8dbd9e3f7487bc134740d3d235/langsmith-0.8.4-py3-none-any.whl", hash = "sha256:4e334ab223d10129c9943c461d95fa9089523638ea29cd048045a7f99b973f50", size = 398701, upload-time = "2026-05-13T21:00:57.393Z" },
 ]
 
 [[package]]
@@ -3515,11 +3526,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
 ]
 
 [[package]]
@@ -3930,32 +3941,32 @@ email = [
 
 [[package]]
 name = "pydantic-ai"
-version = "1.63.0"
+version = "1.61.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic-ai-slim", extra = ["ag-ui", "anthropic", "bedrock", "cli", "cohere", "evals", "fastmcp", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "retries", "temporal", "ui", "vertexai", "xai"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/13/f0a11d43e3e5b2705dd7ee687d4b0fa9b02a7cd23ea4170b92c0a79eb1d3/pydantic_ai-1.63.0.tar.gz", hash = "sha256:269665fbc947d1d4238296a697c12a60d8b1b2c82536f2af4be801f73e165a92", size = 12130, upload-time = "2026-02-23T17:56:34.489Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/ec/45178396c0d0c1a30834c0617d5f433fa2e6024235d72ccd09096a508bb6/pydantic_ai-1.61.0.tar.gz", hash = "sha256:2e2488153441d2dec9a8c7231671e2ade4e5273d02e9ed6c93f78c14156bed24", size = 12025, upload-time = "2026-02-18T01:41:43.1Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/4b/7cf9f5b2f8971a176be6ef218ffe6a30a5461bc2bfe914356881808ce159/pydantic_ai-1.63.0-py3-none-any.whl", hash = "sha256:586f63f391aa24e8b06bd0aeafbb1058de1d4f3bfe34c5f13d4f29a2d870afa5", size = 7229, upload-time = "2026-02-23T17:56:26.921Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/55/ddbb970d11fcb0a60a82d3b16a0143ffad524a74929870f85b64072df395/pydantic_ai-1.61.0-py3-none-any.whl", hash = "sha256:1e6c7cf2a78b08ac17edc6ecb9b1e4a605994cccd349d3baf6bf4ee75bcf7f8c", size = 7231, upload-time = "2026-02-18T01:41:34.801Z" },
 ]
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.63.0"
+version = "1.61.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
-    { name = "griffelib" },
+    { name = "griffe" },
     { name = "httpx" },
     { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/6d/2b5c0c60b42e6af49830f6a09b5d38fecdb1f20d9659152691eba95613b4/pydantic_ai_slim-1.63.0.tar.gz", hash = "sha256:9377afecdfe4bc17f5c9ed72c758e460703ac5876931aa2f18ace8ac0e69312a", size = 426862, upload-time = "2026-02-23T17:56:36.215Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/39/234b74af7b8151a1479e0a1ea833f9d8d029b7b22ded1245ffa90b979778/pydantic_ai_slim-1.61.0.tar.gz", hash = "sha256:af4faeeb41211fe27b1a63d8190fe015d528fb3dce09b81e210cfa2c0f899fcc", size = 418809, upload-time = "2026-02-18T01:41:44.766Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/ca/c4e39eec1cff5a294b64313a8a959b38d326819e0f0a41f48e61ce019a22/pydantic_ai_slim-1.63.0-py3-none-any.whl", hash = "sha256:ed393b0f871b748171f65bec5191c3025b5abb8a4fc616afee17eb9dc2dfa15d", size = 554190, upload-time = "2026-02-23T17:56:29.533Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ca/25e9083da4c0590e5284af6603195dfadd32bf1fe4ba7a7da0be54afdd64/pydantic_ai_slim-1.61.0-py3-none-any.whl", hash = "sha256:034f3161d8ee24258dd4879695768867cd894c2b2d03fb24db87022e2a923639", size = 546260, upload-time = "2026-02-18T01:41:37.572Z" },
 ]
 
 [package.optional-dependencies]
@@ -3991,7 +4002,7 @@ groq = [
     { name = "groq" },
 ]
 huggingface = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", extra = ["inference"] },
 ]
 logfire = [
     { name = "logfire", extra = ["httpx"] },
@@ -4078,7 +4089,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-evals"
-version = "1.63.0"
+version = "1.61.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4088,14 +4099,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/43/21b6ddf65b56f7401c344f98e4e6258a02d2868c8a52a8b79c0e0e701029/pydantic_evals-1.63.0.tar.gz", hash = "sha256:eed56a7192e07c8be8cf16e53bb2ef652b4f7f7b8527650ac45fde865a4ecf9d", size = 56365, upload-time = "2026-02-23T17:56:37.71Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/50/61d2e5542bc44406c06b66ba04a507e499f936f29a92560faf6aff621068/pydantic_evals-1.61.0.tar.gz", hash = "sha256:7921c4c72422ab04761942a680110000cbedad33cd8efc1f8fe6346c9c0ca184", size = 54243, upload-time = "2026-02-18T01:41:45.771Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/f2/7174ad6abca2457e35a1b902ca4fa78aa8ee72e4ec2e9cd5dc8904014ec9/pydantic_evals-1.63.0-py3-none-any.whl", hash = "sha256:2e92a3af579a5670b2babf2044081d0ef99ab5a9ef141972616d71fd7e5bfd0e", size = 67279, upload-time = "2026-02-23T17:56:31.008Z" },
+    { url = "https://files.pythonhosted.org/packages/58/97/8358521be214331ed28a2e2a24998ed25a8dd0d34bd5731a95eff303f132/pydantic_evals-1.61.0-py3-none-any.whl", hash = "sha256:bf94549905458b7d7aeec7d95e327828f8bef16b0ab096e8823ca27d4add32a4", size = 65282, upload-time = "2026-02-18T01:41:39.505Z" },
 ]
 
 [[package]]
 name = "pydantic-graph"
-version = "1.63.0"
+version = "1.61.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -4103,9 +4114,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/c8/aa3cb56552562b799f31e9de291c8bd88306308cfc9647d220dfff2bea18/pydantic_graph-1.63.0.tar.gz", hash = "sha256:5fd98bb22fa6181f0357a6ffad38a3214af12868bd46492d6456c5db434466b4", size = 58528, upload-time = "2026-02-23T17:56:39.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/18/605d57855d01e85784177eab21dd920b25df8715264126c6094a470abd5d/pydantic_graph-1.61.0.tar.gz", hash = "sha256:42abe57800fdfe98a03e94e003a5f445e4a373a95689b4ae76f57e1d7ae8a7af", size = 58527, upload-time = "2026-02-18T01:41:47.353Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/1c/8dcae24c824dd2690fbe7375083b369b10ed1ad773e2b9d1122bb6c0fcdc/pydantic_graph-1.63.0-py3-none-any.whl", hash = "sha256:d9b7a387116f358d470c042b07aa08125cadfcfa8c08ef01769746a489aef0d5", size = 72353, upload-time = "2026-02-23T17:56:32.304Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a7/98da98001637e7c70e2b31ea04941649b9dce0b9b9ad51667bd7b74d0099/pydantic_graph-1.61.0-py3-none-any.whl", hash = "sha256:fdb93b90130170c46dd4ce7fdac09e8a4ec104d6a5e7d9c5af5235e77821aeac", size = 72349, upload-time = "2026-02-18T01:41:41.206Z" },
 ]
 
 [[package]]
@@ -4333,11 +4344,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]
@@ -4811,7 +4822,7 @@ wheels = [
 
 [[package]]
 name = "smolagents"
-version = "1.22.0"
+version = "1.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -4821,9 +4832,9 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/bc/ad2f168b82d26597257adb071c51348dd94da0bc29a6cc10ba4c1bee27c8/smolagents-1.22.0.tar.gz", hash = "sha256:5fb66f48e3b3ab5e8defcef577a89d5b6dfa8fcb55fc98a58e156cb3c59eb68f", size = 213047, upload-time = "2025-09-25T08:42:56.086Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/1c/8d8e7f39f3586dc85a7f96681b08b7c1cfbd734b258a025f368632f2d666/smolagents-1.24.0.tar.gz", hash = "sha256:4d5028ffbd72aca85fb2e8daac52d03fb7d4290a9bf99dbc311dd65980f6b5de", size = 225246, upload-time = "2026-01-16T05:37:04.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/17/54d7de27b7ac2722ac2c0f452da612bf4af80ae09f90231b44bb7b12b33d/smolagents-1.22.0-py3-none-any.whl", hash = "sha256:5334adb4e7e5814cd814f1d9ad7efa806ef57f53db40635a29d2bd727774c5f5", size = 149836, upload-time = "2025-09-25T08:42:54.205Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7a/461ead649c088d30f7847ef1c70f245a9c188381ed09a264633831050497/smolagents-1.24.0-py3-none-any.whl", hash = "sha256:54853759d07a92a939f1ff59238b757fb1a153204c90b69324c8e9709025aa86", size = 155727, upload-time = "2026-01-16T05:37:02.903Z" },
 ]
 
 [[package]]
@@ -5196,11 +5207,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **CI**: Add D4 transport monolith growth lint (`scripts/lint_no_transport_growth.py`) and workflow wiring.
- **Docs / release**: npm runbook cross-links, checklist §4.3 close-out; engineering sprints S2/S5 and PRD v2.3-scale updated for **@asap-protocol/client@2.3.0** on npm (2026-05-13).
- **TypeScript client**: `publishConfig.access: public` for scoped package publishes.

## Notes
- Local `pip-audit` (security job) previously reported additional CVEs vs lockfile; confirm CI **security** is green or follow up separately.

Refs: release checklist, npm Trusted Publishing / S0 unblock (private sprint doc not in repo).