### PR TITLE
feat: adoption telemetry collectors, web CTR bridge, weekly CI (S1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/adapter-request.yml
+++ b/.github/ISSUE_TEMPLATE/adapter-request.yml
@@ -1,0 +1,57 @@
+name: Adapter request
+description: Request a new framework adapter (telemetry label adapter-request).
+title: "[adapter]: "
+labels: ["adapter-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping prioritize adapters. **Automation:** weekly telemetry parses **Framework name**
+        below (or a line `Framework: YourFramework` in the description) to roll up demand — see
+        `docs/maintainers/telemetry.md`.
+
+  - type: input
+    id: framework
+    attributes:
+      label: Framework name
+      description: Short name (e.g. Mastra, LangGraph, Microsoft Agent Framework).
+      placeholder: e.g. Mastra
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: What you are building and why this adapter matters.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: test_prerelease
+    attributes:
+      label: Willing to test a pre-release adapter?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: company_integrate
+    attributes:
+      label: Willing to integrate at your company (if applicable)?
+      options:
+        - "Yes"
+        - "No"
+        - "Maybe"
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context (optional)
+      description: Links, constraints, versions, corporate policies, etc.
+    validations:
+      required: false

--- a/.github/workflows/telemetry-weekly.yml
+++ b/.github/workflows/telemetry-weekly.yml
@@ -1,6 +1,11 @@
 # Weekly adoption telemetry: public-source collectors + optional site CTR fetch.
 # Does not commit to main; uploads JSON + dashboard as workflow artifacts.
 # Optional: copy artifacts to a private branch manually if you want git history.
+#
+# Dependency graph: `.github/actions/setup-python` runs `uv sync --frozen --all-extras --dev`,
+# which installs `[telemetry]` (pypistats). To audit that optional graph locally, see
+# SECURITY.md ("Optional `[telemetry]` extra"): sync with `--extra telemetry` or `--all-extras`,
+# then run `uv run pip-audit` with the same CI ignore flags where applicable.
 name: Telemetry (weekly)
 
 on:
@@ -10,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
 
 jobs:
   aggregate:
@@ -23,8 +29,10 @@ jobs:
 
       - name: Run telemetry aggregate
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Optional: production `/api/telemetry` URL (e.g. https://asap-protocol.com/api/telemetry).
+          PYTHONPATH: ${{ github.workspace }}
+          # Traffic + labeled issue reads need a maintainer PAT (default GITHUB_TOKEN lacks traffic).
+          TELEMETRY_GITHUB_TOKEN: ${{ secrets.TELEMETRY_GITHUB_TOKEN }}
+          # Optional: production `/api/telemetry` URL (must be https://, no redirects).
           TELEMETRY_SITE_ENDPOINT: ${{ vars.TELEMETRY_SITE_ENDPOINT }}
           # Required only when TELEMETRY_SITE_ENDPOINT is set (Bearer must match the web app).
           TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}

--- a/.github/workflows/telemetry-weekly.yml
+++ b/.github/workflows/telemetry-weekly.yml
@@ -1,0 +1,40 @@
+# Weekly adoption telemetry: public-source collectors + optional site CTR fetch.
+# Does not commit to main; uploads JSON + dashboard as workflow artifacts.
+# Optional: copy artifacts to a private branch manually if you want git history.
+name: Telemetry (weekly)
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  aggregate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python (uv)
+        uses: ./.github/actions/setup-python
+
+      - name: Run telemetry aggregate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional: production `/api/telemetry` URL (e.g. https://asap-protocol.com/api/telemetry).
+          TELEMETRY_SITE_ENDPOINT: ${{ vars.TELEMETRY_SITE_ENDPOINT }}
+          # Required only when TELEMETRY_SITE_ENDPOINT is set (Bearer must match the web app).
+          TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}
+        run: uv run python scripts/telemetry/aggregate.py
+
+      - name: Upload snapshot and dashboard
+        uses: actions/upload-artifact@v4
+        with:
+          name: telemetry-${{ github.run_id }}
+          path: |
+            private/telemetry/snapshot-*.json
+            private/telemetry/dashboard.md
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,6 @@ node_modules/
 eslint-report.json
 .vercel
 .env*.local
+
+# Local weekly telemetry outputs (snapshots + dashboard; CI uses artifacts)
+private/telemetry/

--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,7 @@ product/strategy/
 product/private/
 product/private-roadmap/
 product/prd/private/
+engineering/code-review/private/
 # Tactical PRDs outside private/ (patch train); single-digit and double-digit patch (e.g. v2.3.10)
 product/prd/prd-v2.3.[1-9]-*.md
 product/prd/prd-v2.3.[1-9][0-9]-*.md

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,58 @@
+# Privacy — ASAP Protocol (website and adoption telemetry)
+
+This document describes **aggregate adoption and infrastructure metrics** for the ASAP Protocol project, the public website, and **maintainer-only** dashboards. It is **not** legal advice.
+
+## What we collect (high level)
+
+### Public-source aggregates
+
+We derive **non-identifying** statistics from public data sources where possible, for example:
+
+- **npm** — public download count APIs for `@asap-protocol/*` packages.
+- **PyPI** — public download statistics for the `asap-protocol` project.
+- **GitHub** — public repository metadata (for example stars and forks) and repository traffic endpoints available to maintainers with appropriate access.
+- **Lite registry** — counts of entries in the public `registry.json` mirror.
+
+These aggregates **do not** include agent IDs, end-user identity, or message payloads from the protocol.
+
+### Website (Vercel)
+
+The public site uses **Vercel Web Analytics** and related Vercel product defaults as configured in the deployment. Analytics is intended to measure **aggregate** traffic and feature usage (for example which documentation links are used), **not** to build per-person behavioral profiles.
+
+- **No PII in weekly maintainer dashboards** — published snapshots are counts and ratios only.
+- **Client-side signals** follow Vercel’s product privacy posture for Web Analytics (cookie-light / privacy-oriented design — see [Vercel’s documentation](https://vercel.com/docs/analytics) for current detail).
+
+### Optional operator-supplied site metrics
+
+Maintainership tooling may merge **manually exported** or **backend-relayed** CTR summaries into weekly snapshots (see `docs/maintainers/telemetry.md`). Those values are **aggregates** and must not include personal data.
+
+## What we do not do (telemetry scope)
+
+We **do not** use:
+
+- Protocol **agent IDs** or tenant identifiers in public telemetry files.
+- SDK “phone home” telemetry from embedded agents (out of scope for this repository’s weekly dashboard).
+
+## Do Not Track and preferences
+
+Where technically practical, we honor **Do Not Track** (`DNT`) and similar browser privacy signals for site delivery paths that support them. For product-specific handling, refer to the hosting provider’s current documentation (for example Vercel).
+
+Visitors who prefer not to be included in aggregate analytics should use standard browser controls and provider opt-out paths described in Vercel’s **Web Analytics** documentation.
+
+## Lawful basis (GDPR Art. 6 — summary)
+
+For visitors to the website in jurisdictions where the GDPR applies, maintainer dashboards rely on **legitimate interests (Art. 6(1)(f))**, specifically:
+
+- **Understanding aggregate product adoption** (documentation usage, package installs in aggregate) to prioritize engineering work and documentation.
+- **Securing and operating the site** (abuse detection at the infrastructure layer — via the hosting provider’s tooling where applicable).
+
+We apply **data minimization**: we work with **counts and trends**, not with identifiable visitor profiles, in the committed and artifact outputs from this repository’s telemetry scripts.
+
+## Retention
+
+Raw provider-side analytics data is governed by the hosting provider’s retention settings. Weekly snapshots in CI artifacts are intended for **short-to-medium-term planning**; rotate or delete artifacts per your org policy.
+
+## Contact
+
+General inquiries: [info@asap-protocol.com](mailto:info@asap-protocol.com).  
+Security issues: see [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ For **general questions** about the protocol, the marketplace, partnerships, or 
 
 You can also use [GitHub Discussions](https://github.com/adriannoes/asap-protocol/discussions) or [Issues](https://github.com/adriannoes/asap-protocol/issues) for public project topics.
 
+## Privacy
+
+See [PRIVACY.md](PRIVACY.md) for how the public site and maintainer telemetry use aggregate metrics (including Vercel Web Analytics) without collecting agent IDs or end-user PII in repository outputs.
+
 ## License
 
 This project is licensed under the Apache 2.0 License - see the [license](https://github.com/adriannoes/asap-protocol/blob/main/LICENSE) file for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -103,6 +103,10 @@ CI runs `pip-audit` after a sync that **excludes** the optional extras `crewai` 
 
 If you install `[crewai]` or `[llamaindex]`, run `pip-audit` separately on that environment and expect possible advisories until upstream publishes patched releases. Integration tests for those extras still run in CI with the full dependency tree.
 
+**Optional `[telemetry]` extra**: Weekly PyPI stats use `pypistats`, declared under `[telemetry]` in `pyproject.toml` so default installs avoid that dependency graph. The composite `.github/actions/setup-python` step runs `uv sync --frozen --all-extras --dev`, which installs `[telemetry]` for workflows that use it (including the weekly telemetry job). When auditing **without** `--all-extras`, refresh an environment that includes telemetry before judging related CVEs:
+
+`uv sync --frozen --extra telemetry --dev` then `uv run pip-audit` (reuse the same `--ignore-vuln` flags as in the Monitoring section above when you need parity with CI).
+
 ### Version Update Schedule
 
 - **Security Updates**: Automatic and immediate (no schedule)

--- a/apps/example-agent/uv.lock
+++ b/apps/example-agent/uv.lock
@@ -89,7 +89,7 @@ requires-dist = [
     { name = "jcs", specifier = ">=0.2.0" },
     { name = "joserfc", specifier = ">=1.6.3,<2" },
     { name = "jsonschema", specifier = ">=4.23.0" },
-    { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=0.2" },
+    { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.3.3" },
     { name = "limits", specifier = ">=3.0" },
     { name = "llama-index-core", marker = "extra == 'llamaindex'", specifier = ">=0.10" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
@@ -108,6 +108,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5,<3" },
     { name = "pydantic-ai", marker = "extra == 'pydanticai'", specifier = ">=0.2" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21" },
+    { name = "pypistats", marker = "extra == 'telemetry'", specifier = ">=1.11.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.1" },
@@ -116,7 +117,7 @@ requires-dist = [
     { name = "python-ulid", specifier = ">=3.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.14" },
-    { name = "smolagents", marker = "extra == 'smolagents'", specifier = ">=1.0" },
+    { name = "smolagents", marker = "extra == 'smolagents'", specifier = ">=1.24.0" },
     { name = "structlog", specifier = ">=24.1" },
     { name = "typer", specifier = ">=0.21.1" },
     { name = "types-jsonschema", marker = "extra == 'dev'", specifier = ">=4.0.0" },
@@ -126,7 +127,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=12.0" },
     { name = "zeroconf", marker = "extra == 'dns-sd'", specifier = ">=0.80" },
 ]
-provides-extras = ["dev", "docs", "dns-sd", "redis", "webauthn", "mcp", "langchain", "crewai", "llamaindex", "smolagents", "pydanticai", "openclaw", "openapi"]
+provides-extras = ["dev", "docs", "dns-sd", "redis", "webauthn", "mcp", "langchain", "crewai", "llamaindex", "smolagents", "pydanticai", "openclaw", "openapi", "telemetry"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -34,6 +34,16 @@ NEXT_PUBLIC_APP_URL=
 NEXT_PUBLIC_AGENT_BUILDER_URL=https://open-agentic-flow.vercel.app
 
 # -----------------------------------------------------------------------------
+# Maintainer telemetry (/api/telemetry — Bearer-protected aggregate hook)
+# -----------------------------------------------------------------------------
+# Shared secret for GET /api/telemetry (see docs/maintainers/telemetry.md).
+TELEMETRY_TOKEN=
+# Optional: non-secret JSON merged into ctr_per_cta when the Vercel Analytics REST API
+# cannot supply aggregates (paste export / drain processor output).
+# Example shape: {"ctr_per_cta":{"docs-typescript":{"clicks":10,"views":100}}}
+TELEMETRY_SITE_METRICS_JSON=
+
+# -----------------------------------------------------------------------------
 # Optional / Development
 # -----------------------------------------------------------------------------
 # Enable fixture routes (e.g. test-login, mock registry) for E2E/Playwright

--- a/apps/web/src/app/api/telemetry/route.test.ts
+++ b/apps/web/src/app/api/telemetry/route.test.ts
@@ -49,6 +49,20 @@ describe('GET /api/telemetry', () => {
     expect(bad.status).toBe(401);
   });
 
+  it('returns 503 when TELEMETRY_SITE_METRICS_JSON is invalid JSON', async () => {
+    process.env.TELEMETRY_SITE_METRICS_JSON = '{';
+    const res = await GET(createRequest({ Authorization: 'Bearer test-telemetry-token' }));
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 503 when TELEMETRY_SITE_METRICS_JSON fails schema validation', async () => {
+    process.env.TELEMETRY_SITE_METRICS_JSON = JSON.stringify({
+      ctr_per_cta: { x: { clicks: -1 } },
+    });
+    const res = await GET(createRequest({ Authorization: 'Bearer test-telemetry-token' }));
+    expect(res.status).toBe(503);
+  });
+
   it('returns ctr_per_cta with merged env metrics when authorized', async () => {
     process.env.TELEMETRY_SITE_METRICS_JSON = JSON.stringify({
       ctr_per_cta: {

--- a/apps/web/src/app/api/telemetry/route.test.ts
+++ b/apps/web/src/app/api/telemetry/route.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { GET } from './route';
+
+const originalEnv: Record<string, string | undefined> = {};
+
+function saveEnv(key: string): void {
+  if (!(key in originalEnv)) {
+    originalEnv[key] = process.env[key];
+  }
+}
+
+function createRequest(headers?: Record<string, string>): Request {
+  return new Request('http://localhost/api/telemetry', {
+    method: 'GET',
+    headers: headers ?? {},
+  });
+}
+
+describe('GET /api/telemetry', () => {
+  beforeEach(() => {
+    saveEnv('TELEMETRY_TOKEN');
+    saveEnv('TELEMETRY_SITE_METRICS_JSON');
+    process.env.TELEMETRY_TOKEN = 'test-telemetry-token';
+    delete process.env.TELEMETRY_SITE_METRICS_JSON;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(originalEnv)) {
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  });
+
+  it('returns 503 when TELEMETRY_TOKEN is unset', async () => {
+    delete process.env.TELEMETRY_TOKEN;
+    const res = await GET(createRequest());
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 401 when Authorization is missing or invalid', async () => {
+    const missing = await GET(createRequest());
+    expect(missing.status).toBe(401);
+
+    const bad = await GET(createRequest({ Authorization: 'Bearer wrong' }));
+    expect(bad.status).toBe(401);
+  });
+
+  it('returns ctr_per_cta with merged env metrics when authorized', async () => {
+    process.env.TELEMETRY_SITE_METRICS_JSON = JSON.stringify({
+      ctr_per_cta: {
+        'docs-typescript': { clicks: 10, views: 100 },
+      },
+    });
+    const res = await GET(
+      createRequest({ Authorization: 'Bearer test-telemetry-token' }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      site: { ctr_per_cta: Record<string, { ctr?: number; clicks?: number }> };
+    };
+    expect(json.site.ctr_per_cta['docs-typescript']?.clicks).toBe(10);
+    expect(json.site.ctr_per_cta['docs-typescript']?.ctr).toBeCloseTo(0.1);
+  });
+});

--- a/apps/web/src/app/api/telemetry/route.ts
+++ b/apps/web/src/app/api/telemetry/route.ts
@@ -2,6 +2,14 @@ import { createHash, timingSafeEqual } from 'node:crypto';
 
 import { NextResponse } from 'next/server';
 
+import { HOMEPAGE_CTA_IDS } from '@/lib/telemetry/homepage-cta-ids';
+import {
+  computeCtr,
+  emptyCtrShell,
+  mergeCtrPerCta,
+  parseOptionalSiteMetricsJsonFromEnv,
+} from '@/lib/telemetry/site-metrics';
+
 /**
  * Server-only telemetry snapshot for weekly aggregation (S1 adoption telemetry).
  *
@@ -18,38 +26,6 @@ import { NextResponse } from 'next/server';
  * Token comparison uses fixed-length SHA-256 digests (timingSafeEqual) to reduce timing leaks.
  */
 export const runtime = 'nodejs';
-
-/** Known homepage `data-cta` values (keep in sync with landing components). */
-const HOMEPAGE_CTA_IDS = [
-  'hero-release-badge',
-  'hero-explore-agents',
-  'hero-register-agent',
-  'docs-openapi',
-  'docs-typescript',
-  'docs-auto-registration',
-  'docs-capabilities-escalation',
-  'feature-openapi-adapter',
-  'feature-typescript-sdk',
-  'feature-auto-registration',
-  'feature-lite-registry',
-  'feature-verified-trust',
-  'feature-1-click-integration',
-  'feature-full-observability',
-  'feature-per-agent-identity',
-  'feature-scoped-capabilities',
-  'feature-streaming-responses',
-  'release-changelog-github',
-] as const;
-
-type CtaMetrics = {
-  clicks?: number;
-  views?: number;
-  ctr?: number;
-};
-
-type SiteMetricsFile = {
-  ctr_per_cta?: Record<string, CtaMetrics>;
-};
 
 function tokensEqual(provided: string, expected: string): boolean {
   const left = createHash('sha256').update(provided, 'utf8').digest();
@@ -69,48 +45,6 @@ function parseBearerToken(request: Request): string | null {
   return raw.slice(prefix.length).trim();
 }
 
-function computeCtr(metrics: CtaMetrics): CtaMetrics {
-  const { clicks, views } = metrics;
-  if (typeof clicks === 'number' && typeof views === 'number' && views > 0) {
-    return { ...metrics, ctr: clicks / views };
-  }
-  return { ...metrics };
-}
-
-function mergeCtrPerCta(
-  base: Record<string, CtaMetrics>,
-  fromEnv?: Record<string, CtaMetrics>,
-): Record<string, CtaMetrics> {
-  const out: Record<string, CtaMetrics> = { ...base };
-  if (!fromEnv) {
-    return out;
-  }
-  for (const [k, v] of Object.entries(fromEnv)) {
-    out[k] = { ...(out[k] ?? {}), ...v };
-  }
-  return out;
-}
-
-function parseOptionalSiteMetricsJson(): SiteMetricsFile | null {
-  const raw = process.env.TELEMETRY_SITE_METRICS_JSON?.trim();
-  if (!raw) {
-    return null;
-  }
-  try {
-    return JSON.parse(raw) as SiteMetricsFile;
-  } catch {
-    return null;
-  }
-}
-
-function emptyCtrShell(): Record<string, CtaMetrics> {
-  const shell: Record<string, CtaMetrics> = {};
-  for (const id of HOMEPAGE_CTA_IDS) {
-    shell[id] = {};
-  }
-  return shell;
-}
-
 export async function GET(request: Request): Promise<NextResponse> {
   const expected = process.env.TELEMETRY_TOKEN?.trim() ?? '';
   if (!expected) {
@@ -125,13 +59,22 @@ export async function GET(request: Request): Promise<NextResponse> {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  let parsedEnv;
+  try {
+    parsedEnv = parseOptionalSiteMetricsJsonFromEnv();
+  } catch {
+    return NextResponse.json(
+      { error: 'Invalid TELEMETRY_SITE_METRICS_JSON (malformed JSON or schema).' },
+      { status: 503 },
+    );
+  }
+
   const collectedAt = new Date().toISOString();
-  const parsed = parseOptionalSiteMetricsJson();
-  const fromEnv = parsed?.ctr_per_cta;
+  const fromEnv = parsedEnv?.ctr_per_cta;
 
   let shell = emptyCtrShell();
   shell = mergeCtrPerCta(shell, fromEnv ?? undefined);
-  const ctrPerCta: Record<string, CtaMetrics> = {};
+  const ctrPerCta: Record<string, { clicks?: number; views?: number; ctr?: number }> = {};
   for (const [k, v] of Object.entries(shell)) {
     ctrPerCta[k] = computeCtr(v);
   }

--- a/apps/web/src/app/api/telemetry/route.ts
+++ b/apps/web/src/app/api/telemetry/route.ts
@@ -1,0 +1,154 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+import { NextResponse } from 'next/server';
+
+/**
+ * Server-only telemetry snapshot for weekly aggregation (S1 adoption telemetry).
+ *
+ * **Vercel Web Analytics limitation:** Vercel does not ship a public REST API to read
+ * aggregated page views / custom events / `data-cta` click breakdowns as of 2026.
+ * Dashboard CSV export, [Web Analytics Drains](https://vercel.com/docs/analytics/web-analytics-drains),
+ * or a future API would be required for fully automated CTR without an intermediate store.
+ *
+ * For CI and operators, optional env **`TELEMETRY_SITE_METRICS_JSON`** may hold JSON shaped as
+ * `{ "ctr_per_cta": { "docs-typescript": { "clicks": 10, "views": 100 } } }` (pasted from an
+ * export or another backend). This is **not** a secret; keep tokens in `TELEMETRY_TOKEN` only.
+ *
+ * Required: **`TELEMETRY_TOKEN`** — send `Authorization: Bearer <TELEMETRY_TOKEN>`.
+ * Token comparison uses fixed-length SHA-256 digests (timingSafeEqual) to reduce timing leaks.
+ */
+export const runtime = 'nodejs';
+
+/** Known homepage `data-cta` values (keep in sync with landing components). */
+const HOMEPAGE_CTA_IDS = [
+  'hero-release-badge',
+  'hero-explore-agents',
+  'hero-register-agent',
+  'docs-openapi',
+  'docs-typescript',
+  'docs-auto-registration',
+  'docs-capabilities-escalation',
+  'feature-openapi-adapter',
+  'feature-typescript-sdk',
+  'feature-auto-registration',
+  'feature-lite-registry',
+  'feature-verified-trust',
+  'feature-1-click-integration',
+  'feature-full-observability',
+  'feature-per-agent-identity',
+  'feature-scoped-capabilities',
+  'feature-streaming-responses',
+  'release-changelog-github',
+] as const;
+
+type CtaMetrics = {
+  clicks?: number;
+  views?: number;
+  ctr?: number;
+};
+
+type SiteMetricsFile = {
+  ctr_per_cta?: Record<string, CtaMetrics>;
+};
+
+function tokensEqual(provided: string, expected: string): boolean {
+  const left = createHash('sha256').update(provided, 'utf8').digest();
+  const right = createHash('sha256').update(expected, 'utf8').digest();
+  return timingSafeEqual(left, right);
+}
+
+function parseBearerToken(request: Request): string | null {
+  const raw = request.headers.get('authorization');
+  if (!raw) {
+    return null;
+  }
+  const prefix = 'bearer ';
+  if (!raw.toLowerCase().startsWith(prefix)) {
+    return null;
+  }
+  return raw.slice(prefix.length).trim();
+}
+
+function computeCtr(metrics: CtaMetrics): CtaMetrics {
+  const { clicks, views } = metrics;
+  if (typeof clicks === 'number' && typeof views === 'number' && views > 0) {
+    return { ...metrics, ctr: clicks / views };
+  }
+  return { ...metrics };
+}
+
+function mergeCtrPerCta(
+  base: Record<string, CtaMetrics>,
+  fromEnv?: Record<string, CtaMetrics>,
+): Record<string, CtaMetrics> {
+  const out: Record<string, CtaMetrics> = { ...base };
+  if (!fromEnv) {
+    return out;
+  }
+  for (const [k, v] of Object.entries(fromEnv)) {
+    out[k] = { ...(out[k] ?? {}), ...v };
+  }
+  return out;
+}
+
+function parseOptionalSiteMetricsJson(): SiteMetricsFile | null {
+  const raw = process.env.TELEMETRY_SITE_METRICS_JSON?.trim();
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as SiteMetricsFile;
+  } catch {
+    return null;
+  }
+}
+
+function emptyCtrShell(): Record<string, CtaMetrics> {
+  const shell: Record<string, CtaMetrics> = {};
+  for (const id of HOMEPAGE_CTA_IDS) {
+    shell[id] = {};
+  }
+  return shell;
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const expected = process.env.TELEMETRY_TOKEN?.trim() ?? '';
+  if (!expected) {
+    return NextResponse.json(
+      { error: 'TELEMETRY_TOKEN is not configured on the server.' },
+      { status: 503 },
+    );
+  }
+
+  const provided = parseBearerToken(request);
+  if (!provided || !tokensEqual(provided, expected)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const collectedAt = new Date().toISOString();
+  const parsed = parseOptionalSiteMetricsJson();
+  const fromEnv = parsed?.ctr_per_cta;
+
+  let shell = emptyCtrShell();
+  shell = mergeCtrPerCta(shell, fromEnv ?? undefined);
+  const ctrPerCta: Record<string, CtaMetrics> = {};
+  for (const [k, v] of Object.entries(shell)) {
+    ctrPerCta[k] = computeCtr(v);
+  }
+
+  const hasEnvMetrics = Boolean(fromEnv && Object.keys(fromEnv).length > 0);
+
+  return NextResponse.json({
+    collected_at: collectedAt,
+    site: {
+      ctr_per_cta: ctrPerCta,
+      homepage_cta_ids: [...HOMEPAGE_CTA_IDS],
+      vercel_web_analytics: {
+        api_for_aggregates: 'unavailable_public_rest',
+        note: hasEnvMetrics
+          ? 'Merged metrics from TELEMETRY_SITE_METRICS_JSON (operator-supplied).'
+          : 'No operator metrics env set; counts are empty until TELEMETRY_SITE_METRICS_JSON is provided, a drain is configured, or Vercel exposes an analytics query API.',
+      },
+    },
+  });
+}

--- a/apps/web/src/components/landing/FeaturesSection.tsx
+++ b/apps/web/src/components/landing/FeaturesSection.tsx
@@ -121,7 +121,12 @@ export function FeaturesSection() {
           {features.map((feature, i) => {
             const Icon = feature.icon;
             return (
-              <Link key={i} href={`/features/${feature.slug}`} className={`group ${feature.className}`}>
+              <Link
+                key={i}
+                href={`/features/${feature.slug}`}
+                data-cta={`feature-${feature.slug}`}
+                className={`group ${feature.className}`}
+              >
                 <Card
                   className={`relative h-full overflow-hidden border-zinc-800 bg-zinc-950 transition-all duration-300 hover:border-indigo-500/50`}
                 >

--- a/apps/web/src/components/landing/FeaturesSection.tsx
+++ b/apps/web/src/components/landing/FeaturesSection.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { LANDING_FEATURE_SLUGS } from '@/lib/telemetry/homepage-cta-ids';
 import { Database, ShieldCheck, Zap, Activity, ArrowRight, Fingerprint, KeySquare, Radio, FileCode, Braces, CloudUpload } from 'lucide-react';
 
 const INLINE_CODE = 'rounded bg-zinc-800 px-1 py-0.5 text-sm text-indigo-300';
@@ -13,18 +14,18 @@ type FeatureCard = {
   className: string;
 };
 
-const features: FeatureCard[] = [
-  {
+type FeatureSlug = (typeof LANDING_FEATURE_SLUGS)[number];
+
+const FEATURE_DEFINITIONS: Record<FeatureSlug, Omit<FeatureCard, 'slug'>> = {
+  'openapi-adapter': {
     title: 'OpenAPI Adapter',
-    slug: 'openapi-adapter',
     description:
       'Generate ASAP capabilities from an OpenAPI 3.x document so existing HTTP APIs become agent-callable with minimal glue code.',
     icon: FileCode,
     className: 'md:col-span-2',
   },
-  {
+  'typescript-sdk': {
     title: 'TypeScript SDK',
-    slug: 'typescript-sdk',
     description: (
       <>
         Official <code className={INLINE_CODE}>@asap-protocol/client</code> on npm — discovery, envelopes, streaming, plus optional
@@ -34,9 +35,8 @@ const features: FeatureCard[] = [
     icon: Braces,
     className: 'md:col-span-1',
   },
-  {
+  'auto-registration': {
     title: 'Auto-Registration',
-    slug: 'auto-registration',
     description: (
       <>
         <code className={INLINE_CODE}>POST /registry/agents</code> with Compliance Harness gating — shrink the time from
@@ -46,63 +46,61 @@ const features: FeatureCard[] = [
     icon: CloudUpload,
     className: 'md:col-span-1',
   },
-  {
+  'lite-registry': {
     title: 'Lite Registry',
-    slug: 'lite-registry',
     description:
       'Built for speed and resilience. Pull agent manifests directly from a statically served JSON registry with zero database overhead.',
     icon: Database,
     className: 'md:col-span-2',
   },
-  {
+  'verified-trust': {
     title: 'Verified Trust',
-    slug: 'verified-trust',
     description:
       'Manual operations-based verification processes to ensure quality and safety across the ecosystem.',
     icon: ShieldCheck,
     className: 'md:col-span-1',
   },
-  {
+  '1-click-integration': {
     title: '1-Click Integration',
-    slug: '1-click-integration',
     description:
       'Launch sub-agents through a standard protocol that orchestrates connections over WebSockets natively.',
     icon: Zap,
     className: 'md:col-span-1',
   },
-  {
+  'full-observability': {
     title: 'Full Observability',
-    slug: 'full-observability',
     description:
       'Real-time stream of agent events, state snapshots, and task updates standardized across the network.',
     icon: Activity,
     className: 'md:col-span-2',
   },
-  {
+  'per-agent-identity': {
     title: 'Per-Agent Identity',
-    slug: 'per-agent-identity',
     description:
       'Every runtime agent gets its own Ed25519 keypair under a persistent Host. Audit, scope, and revoke individual sessions without touching the rest of your fleet.',
     icon: Fingerprint,
     className: 'md:col-span-1',
   },
-  {
+  'scoped-capabilities': {
     title: 'Scoped Capabilities',
-    slug: 'scoped-capabilities',
     description:
       'Fine-grained capabilities with constraint operators — transfer up to $1,000, only in USD, to one destination. Precise grants replace coarse OAuth scopes.',
     icon: KeySquare,
     className: 'md:col-span-1',
   },
-  {
+  'streaming-responses': {
     title: 'Streaming Responses',
-    slug: 'streaming-responses',
     description:
       'TaskStream chunks over Server-Sent Events. Show partial results and progress in real time instead of blocking until completion.',
     icon: Radio,
     className: 'md:col-span-1',
   },
-];
+};
+
+const features: FeatureCard[] = LANDING_FEATURE_SLUGS.map((slug) => ({
+  slug,
+  ...FEATURE_DEFINITIONS[slug],
+}));
 
 export function FeaturesSection() {
   return (

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -20,6 +20,7 @@ export function HeroSection() {
                 href="https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md#230---2026-05-04"
                 target="_blank"
                 rel="noopener noreferrer"
+                data-cta="hero-release-badge"
                 aria-label="View ASAP Protocol v2.3.0 changelog on GitHub"
               >
                 <div className="inline-flex items-center rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-sm font-medium text-indigo-300 backdrop-blur-sm transition-colors hover:border-indigo-500/60 hover:bg-indigo-500/15">
@@ -45,7 +46,7 @@ export function HeroSection() {
                 size="lg"
                 className="w-full bg-white text-black hover:bg-zinc-200 min-[400px]:w-auto"
               >
-                <Link href="/browse">
+                <Link href="/browse" data-cta="hero-explore-agents">
                   Explore Agents
                 </Link>
               </Button>
@@ -55,7 +56,7 @@ export function HeroSection() {
                 variant="outline"
                 className="w-full border-zinc-800 text-zinc-300 hover:bg-zinc-900 hover:text-white min-[400px]:w-auto"
               >
-                <Link href="/dashboard/register">
+                <Link href="/dashboard/register" data-cta="hero-register-agent">
                   Register Agent
                 </Link>
               </Button>

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { BackgroundPaths } from '@/components/ui/background-paths';
 import { HeroTerminal } from '@/components/landing/HeroTerminal';
 import Link from 'next/link';
+import { HOMEPAGE_HERO_CTA_IDS } from '@/lib/telemetry/homepage-cta-ids';
 
 export function HeroSection() {
   return (
@@ -20,7 +21,7 @@ export function HeroSection() {
                 href="https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md#230---2026-05-04"
                 target="_blank"
                 rel="noopener noreferrer"
-                data-cta="hero-release-badge"
+                data-cta={HOMEPAGE_HERO_CTA_IDS.releaseBadge}
                 aria-label="View ASAP Protocol v2.3.0 changelog on GitHub"
               >
                 <div className="inline-flex items-center rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-sm font-medium text-indigo-300 backdrop-blur-sm transition-colors hover:border-indigo-500/60 hover:bg-indigo-500/15">
@@ -46,7 +47,7 @@ export function HeroSection() {
                 size="lg"
                 className="w-full bg-white text-black hover:bg-zinc-200 min-[400px]:w-auto"
               >
-                <Link href="/browse" data-cta="hero-explore-agents">
+                <Link href="/browse" data-cta={HOMEPAGE_HERO_CTA_IDS.exploreAgents}>
                   Explore Agents
                 </Link>
               </Button>
@@ -56,7 +57,7 @@ export function HeroSection() {
                 variant="outline"
                 className="w-full border-zinc-800 text-zinc-300 hover:bg-zinc-900 hover:text-white min-[400px]:w-auto"
               >
-                <Link href="/dashboard/register" data-cta="hero-register-agent">
+                <Link href="/dashboard/register" data-cta={HOMEPAGE_HERO_CTA_IDS.registerAgent}>
                   Register Agent
                 </Link>
               </Button>

--- a/apps/web/src/components/landing/WhatsNewRibbon.tsx
+++ b/apps/web/src/components/landing/WhatsNewRibbon.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { WHATS_NEW_RIBBON_CTA_IDS } from '@/lib/telemetry/homepage-cta-ids';
 import {
   Fingerprint,
   KeySquare,
@@ -32,29 +33,53 @@ const DOCS_ESCALATION =
   'https://github.com/adriannoes/asap-protocol/blob/main/docs/capabilities/escalation.md';
 
 const PILLS: Pill[] = [
-  { label: 'OpenAPI', href: DOCS_OPENAPI, icon: Layers, external: true, dataCta: 'docs-openapi' },
-  { label: 'TypeScript SDK', href: DOCS_TS_SDK, icon: Code, external: true, dataCta: 'docs-typescript' },
-  { label: 'Auto-Reg', href: DOCS_AUTO_REG, icon: Sparkles, external: true, dataCta: 'docs-auto-registration' },
+  {
+    label: 'OpenAPI',
+    href: DOCS_OPENAPI,
+    icon: Layers,
+    external: true,
+    dataCta: WHATS_NEW_RIBBON_CTA_IDS.docsOpenapi,
+  },
+  {
+    label: 'TypeScript SDK',
+    href: DOCS_TS_SDK,
+    icon: Code,
+    external: true,
+    dataCta: WHATS_NEW_RIBBON_CTA_IDS.docsTypescript,
+  },
+  {
+    label: 'Auto-Reg',
+    href: DOCS_AUTO_REG,
+    icon: Sparkles,
+    external: true,
+    dataCta: WHATS_NEW_RIBBON_CTA_IDS.docsAutoRegistration,
+  },
   {
     label: 'Identity',
     href: '/features/per-agent-identity',
     icon: Fingerprint,
-    dataCta: 'feature-per-agent-identity',
+    dataCta: WHATS_NEW_RIBBON_CTA_IDS.featurePerAgentIdentity,
   },
   {
     label: 'Capabilities',
     href: '/features/scoped-capabilities',
     icon: KeySquare,
-    dataCta: 'feature-scoped-capabilities',
+    dataCta: WHATS_NEW_RIBBON_CTA_IDS.featureScopedCapabilities,
   },
   {
     label: 'Escalation',
     href: DOCS_ESCALATION,
     icon: ShieldCheck,
     external: true,
-    dataCta: 'docs-capabilities-escalation',
+    dataCta: WHATS_NEW_RIBBON_CTA_IDS.docsCapabilitiesEscalation,
   },
-  { label: 'Changelog', href: CHANGELOG_URL, icon: GitBranch, external: true, dataCta: 'release-changelog-github' },
+  {
+    label: 'Changelog',
+    href: CHANGELOG_URL,
+    icon: GitBranch,
+    external: true,
+    dataCta: WHATS_NEW_RIBBON_CTA_IDS.releaseChangelogGithub,
+  },
 ];
 
 export function WhatsNewRibbon() {

--- a/apps/web/src/components/landing/WhatsNewRibbon.tsx
+++ b/apps/web/src/components/landing/WhatsNewRibbon.tsx
@@ -16,6 +16,8 @@ type Pill = {
   href: string;
   icon: LucideIcon;
   external?: boolean;
+  /** Stable id for analytics (Vercel / site→docs CTR). */
+  dataCta: string;
 };
 
 const CHANGELOG_URL =
@@ -30,13 +32,29 @@ const DOCS_ESCALATION =
   'https://github.com/adriannoes/asap-protocol/blob/main/docs/capabilities/escalation.md';
 
 const PILLS: Pill[] = [
-  { label: 'OpenAPI', href: DOCS_OPENAPI, icon: Layers, external: true },
-  { label: 'TypeScript SDK', href: DOCS_TS_SDK, icon: Code, external: true },
-  { label: 'Auto-Reg', href: DOCS_AUTO_REG, icon: Sparkles, external: true },
-  { label: 'Identity', href: '/features/per-agent-identity', icon: Fingerprint },
-  { label: 'Capabilities', href: '/features/scoped-capabilities', icon: KeySquare },
-  { label: 'Escalation', href: DOCS_ESCALATION, icon: ShieldCheck, external: true },
-  { label: 'Changelog', href: CHANGELOG_URL, icon: GitBranch, external: true },
+  { label: 'OpenAPI', href: DOCS_OPENAPI, icon: Layers, external: true, dataCta: 'docs-openapi' },
+  { label: 'TypeScript SDK', href: DOCS_TS_SDK, icon: Code, external: true, dataCta: 'docs-typescript' },
+  { label: 'Auto-Reg', href: DOCS_AUTO_REG, icon: Sparkles, external: true, dataCta: 'docs-auto-registration' },
+  {
+    label: 'Identity',
+    href: '/features/per-agent-identity',
+    icon: Fingerprint,
+    dataCta: 'feature-per-agent-identity',
+  },
+  {
+    label: 'Capabilities',
+    href: '/features/scoped-capabilities',
+    icon: KeySquare,
+    dataCta: 'feature-scoped-capabilities',
+  },
+  {
+    label: 'Escalation',
+    href: DOCS_ESCALATION,
+    icon: ShieldCheck,
+    external: true,
+    dataCta: 'docs-capabilities-escalation',
+  },
+  { label: 'Changelog', href: CHANGELOG_URL, icon: GitBranch, external: true, dataCta: 'release-changelog-github' },
 ];
 
 export function WhatsNewRibbon() {
@@ -68,6 +86,7 @@ export function WhatsNewRibbon() {
               <li key={pill.label}>
                 <Link
                   href={pill.href}
+                  data-cta={pill.dataCta}
                   {...linkProps}
                   className="group inline-flex items-center gap-1.5 rounded-full border border-zinc-800 bg-zinc-900/50 px-3 py-1.5 text-xs font-medium text-zinc-400 backdrop-blur-sm transition-colors hover:border-indigo-500/40 hover:bg-indigo-500/10 hover:text-indigo-300"
                 >

--- a/apps/web/src/lib/telemetry/homepage-cta-ids.ts
+++ b/apps/web/src/lib/telemetry/homepage-cta-ids.ts
@@ -1,0 +1,48 @@
+/**
+ * Stable homepage `data-cta` ids for Vercel analytics and `/api/telemetry`.
+ * Keep landing components aligned with these constants to avoid dashboard drift.
+ */
+
+export const HOMEPAGE_HERO_CTA_IDS = {
+  releaseBadge: 'hero-release-badge',
+  exploreAgents: 'hero-explore-agents',
+  registerAgent: 'hero-register-agent',
+} as const;
+
+/** CTA ids used by the “What’s new” ribbon (subset also appears in {@link HOMEPAGE_CTA_IDS}). */
+export const WHATS_NEW_RIBBON_CTA_IDS = {
+  docsOpenapi: 'docs-openapi',
+  docsTypescript: 'docs-typescript',
+  docsAutoRegistration: 'docs-auto-registration',
+  featurePerAgentIdentity: 'feature-per-agent-identity',
+  featureScopedCapabilities: 'feature-scoped-capabilities',
+  docsCapabilitiesEscalation: 'docs-capabilities-escalation',
+  releaseChangelogGithub: 'release-changelog-github',
+} as const;
+
+/** Slugs from `/features/[slug]` cards — order matches the homepage grid. */
+export const LANDING_FEATURE_SLUGS = [
+  'openapi-adapter',
+  'typescript-sdk',
+  'auto-registration',
+  'lite-registry',
+  'verified-trust',
+  '1-click-integration',
+  'full-observability',
+  'per-agent-identity',
+  'scoped-capabilities',
+  'streaming-responses',
+] as const;
+
+/** Ordered shell keys returned by `/api/telemetry` (`ctr_per_cta`). */
+export const HOMEPAGE_CTA_IDS = [
+  HOMEPAGE_HERO_CTA_IDS.releaseBadge,
+  HOMEPAGE_HERO_CTA_IDS.exploreAgents,
+  HOMEPAGE_HERO_CTA_IDS.registerAgent,
+  WHATS_NEW_RIBBON_CTA_IDS.docsOpenapi,
+  WHATS_NEW_RIBBON_CTA_IDS.docsTypescript,
+  WHATS_NEW_RIBBON_CTA_IDS.docsAutoRegistration,
+  WHATS_NEW_RIBBON_CTA_IDS.docsCapabilitiesEscalation,
+  ...LANDING_FEATURE_SLUGS.map((slug) => `feature-${slug}` as const),
+  WHATS_NEW_RIBBON_CTA_IDS.releaseChangelogGithub,
+] as const;

--- a/apps/web/src/lib/telemetry/site-metrics.test.ts
+++ b/apps/web/src/lib/telemetry/site-metrics.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { HOMEPAGE_CTA_IDS } from '@/lib/telemetry/homepage-cta-ids';
+import {
+  computeCtr,
+  emptyCtrShell,
+  mergeCtrPerCta,
+  parseOptionalSiteMetricsJsonFromEnv,
+  parseSiteMetricsJson,
+} from '@/lib/telemetry/site-metrics';
+
+describe('site-metrics', () => {
+  describe('parseSiteMetricsJson', () => {
+    it('accepts empty object', () => {
+      expect(parseSiteMetricsJson('{}')).toEqual({});
+    });
+
+    it('parses ctr_per_cta entries', () => {
+      const raw = JSON.stringify({
+        ctr_per_cta: { 'docs-openapi': { clicks: 2, views: 10 } },
+      });
+      const got = parseSiteMetricsJson(raw);
+      expect(got.ctr_per_cta?.['docs-openapi']?.clicks).toBe(2);
+    });
+
+    it('rejects invalid ctr range', () => {
+      const raw = JSON.stringify({
+        ctr_per_cta: { x: { ctr: 2 } },
+      });
+      expect(() => parseSiteMetricsJson(raw)).toThrow();
+    });
+  });
+
+  describe('parseOptionalSiteMetricsJsonFromEnv', () => {
+    const original = process.env.TELEMETRY_SITE_METRICS_JSON;
+
+    beforeEach(() => {
+      delete process.env.TELEMETRY_SITE_METRICS_JSON;
+    });
+
+    afterEach(() => {
+      if (original === undefined) {
+        delete process.env.TELEMETRY_SITE_METRICS_JSON;
+      } else {
+        process.env.TELEMETRY_SITE_METRICS_JSON = original;
+      }
+    });
+
+    it('returns null when unset or whitespace', () => {
+      expect(parseOptionalSiteMetricsJsonFromEnv()).toBeNull();
+      process.env.TELEMETRY_SITE_METRICS_JSON = '   ';
+      expect(parseOptionalSiteMetricsJsonFromEnv()).toBeNull();
+    });
+
+    it('parses when set', () => {
+      process.env.TELEMETRY_SITE_METRICS_JSON = '{"ctr_per_cta":{}}';
+      expect(parseOptionalSiteMetricsJsonFromEnv()).toEqual({ ctr_per_cta: {} });
+    });
+  });
+
+  describe('computeCtr', () => {
+    it('computes ctr when views > 0', () => {
+      expect(computeCtr({ clicks: 3, views: 12 })).toEqual({
+        clicks: 3,
+        views: 12,
+        ctr: 0.25,
+      });
+    });
+
+    it('passes through when views missing or zero', () => {
+      expect(computeCtr({ clicks: 3 })).toEqual({ clicks: 3 });
+      expect(computeCtr({})).toEqual({});
+    });
+  });
+
+  describe('mergeCtrPerCta', () => {
+    it('merges env over base keys', () => {
+      const base = { a: { views: 1 } };
+      const merged = mergeCtrPerCta(base, { a: { clicks: 2 }, b: { views: 3 } });
+      expect(merged.a).toEqual({ views: 1, clicks: 2 });
+      expect(merged.b).toEqual({ views: 3 });
+    });
+
+    it('returns copy when fromEnv absent', () => {
+      const base = { a: { clicks: 1 } };
+      const merged = mergeCtrPerCta(base);
+      expect(merged).toEqual(base);
+      expect(merged).not.toBe(base);
+    });
+  });
+
+  describe('emptyCtrShell', () => {
+    it('includes every homepage CTA id', () => {
+      const shell = emptyCtrShell();
+      for (const id of HOMEPAGE_CTA_IDS) {
+        expect(shell[id]).toEqual({});
+      }
+      expect(Object.keys(shell).length).toBe(HOMEPAGE_CTA_IDS.length);
+    });
+  });
+});

--- a/apps/web/src/lib/telemetry/site-metrics.ts
+++ b/apps/web/src/lib/telemetry/site-metrics.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+import { HOMEPAGE_CTA_IDS } from '@/lib/telemetry/homepage-cta-ids';
+
+export type CtaMetrics = {
+  clicks?: number;
+  views?: number;
+  ctr?: number;
+};
+
+export type SiteMetricsFile = {
+  ctr_per_cta?: Record<string, CtaMetrics>;
+};
+
+const ctaMetricsSchema = z.object({
+  clicks: z.number().int().nonnegative().optional(),
+  views: z.number().int().nonnegative().optional(),
+  ctr: z.number().min(0).max(1).optional(),
+});
+
+const siteMetricsSchema = z.object({
+  ctr_per_cta: z.record(z.string(), ctaMetricsSchema).optional(),
+});
+
+export function parseSiteMetricsJson(rawJson: string): SiteMetricsFile {
+  const parsed: unknown = JSON.parse(rawJson);
+  return siteMetricsSchema.parse(parsed);
+}
+
+/** Parse optional operator-supplied metrics from env; throws on invalid JSON or schema. */
+export function parseOptionalSiteMetricsJsonFromEnv(): SiteMetricsFile | null {
+  const raw = process.env.TELEMETRY_SITE_METRICS_JSON?.trim();
+  if (!raw) {
+    return null;
+  }
+  return parseSiteMetricsJson(raw);
+}
+
+export function computeCtr(metrics: CtaMetrics): CtaMetrics {
+  const { clicks, views } = metrics;
+  if (typeof clicks === 'number' && typeof views === 'number' && views > 0) {
+    return { ...metrics, ctr: clicks / views };
+  }
+  return { ...metrics };
+}
+
+export function mergeCtrPerCta(
+  base: Record<string, CtaMetrics>,
+  fromEnv?: Record<string, CtaMetrics>,
+): Record<string, CtaMetrics> {
+  const out: Record<string, CtaMetrics> = { ...base };
+  if (!fromEnv) {
+    return out;
+  }
+  for (const [k, v] of Object.entries(fromEnv)) {
+    out[k] = { ...(out[k] ?? {}), ...v };
+  }
+  return out;
+}
+
+export function emptyCtrShell(): Record<string, CtaMetrics> {
+  const shell: Record<string, CtaMetrics> = {};
+  for (const id of HOMEPAGE_CTA_IDS) {
+    shell[id] = {};
+  }
+  return shell;
+}

--- a/docs/maintainers/telemetry.md
+++ b/docs/maintainers/telemetry.md
@@ -1,0 +1,101 @@
+# Telemetry runbook (weekly adoption snapshot)
+
+Maintainers use `scripts/telemetry/` to build an **aggregate JSON snapshot** plus a **markdown dashboard** for adoption signals (npm/PyPI/GitHub/registry, optional site CTR, and **adapter-request** issue counts). Outputs default to **`private/telemetry/`** (gitignored — see repo `.gitignore`).
+
+## Prerequisites
+
+- **[uv](https://docs.astral.sh/uv/)** per `pyproject.toml`
+- **Network** access to npm, PyPI Stats (`pypistats` extra), GitHub API, and the registry mirror URL
+
+Sync dependencies (includes the `telemetry` extra):
+
+```bash
+uv sync --frozen --all-extras --dev
+```
+
+The above command installs Python deps from the lockfile and enables the PyPI collector (`pypistats`).
+
+## Tokens and secrets
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `GITHUB_TOKEN` | For GitHub traffic + issues | Classic PAT with **`repo`** scope (traffic endpoints require push-equivalent access to the target repository), **or** a fine-grained token with **Contents: Read** and **Issues: Read** plus traffic access as allowed by GitHub for that token type. **Never commit this token.** |
+| `TELEMETRY_TOKEN` | For `/api/telemetry` only | Shared bearer for the Next.js route `apps/web/src/app/api/telemetry/route.ts`. Set in Vercel/hosting env; use the same value when calling the route locally or from `aggregate.py`. |
+| `TELEMETRY_SITE_ENDPOINT` | Optional | Full URL to the deployed telemetry route, e.g. `https://example.com/api/telemetry`. Passed to `aggregate.py` or set in CI **repository variables**. |
+
+### Site metrics without a public analytics API
+
+Vercel Web Analytics **does not** expose aggregate event/CTR APIs for arbitrary server-side pulls (see Vercel docs and community threads). The web route therefore supports:
+
+- Optional env **`TELEMETRY_SITE_METRICS_JSON`** on the **Next.js server** — non-secret JSON merged into `ctr_per_cta` (for example values pasted from a dashboard export or a drain pipeline).
+
+CI can omit `TELEMETRY_SITE_ENDPOINT`; the snapshot will still include an empty `site.ctr_per_cta` with a note.
+
+## Running collectors individually
+
+**npm** (public API):
+
+```bash
+uv run python scripts/telemetry/collect_npm.py --period last-week -o /tmp/npm.json
+```
+
+**PyPI** (`pypistats`):
+
+```bash
+uv run python scripts/telemetry/collect_pypi.py -o /tmp/pypi.json
+```
+
+**GitHub** (summary, traffic, referrers, **open `adapter-request` issues**):
+
+```bash
+export GITHUB_TOKEN=…
+uv run python scripts/telemetry/collect_github.py -o /tmp/github.json
+```
+
+**Registry** (agent count + optional `--previous`):
+
+```bash
+uv run python scripts/telemetry/collect_registry.py -o /tmp/registry.json
+```
+
+## Weekly aggregate (snapshot + dashboard)
+
+```bash
+export GITHUB_TOKEN=…
+export TELEMETRY_TOKEN=…   # optional if fetching site
+export TELEMETRY_SITE_ENDPOINT=https://YOUR_HOST/api/telemetry   # optional
+uv run python scripts/telemetry/aggregate.py --output-dir private/telemetry
+```
+
+The script:
+
+- Validates the snapshot against an embedded **JSON Schema** (`jsonschema`).
+- Writes `snapshot-YYYY-MM-DD.json`, `dashboard.md`, and attempts `snapshot-latest.json` → symlink (may fail on Windows without symlink rights — optional).
+
+## Adapter-request issues
+
+Ensure the GitHub label **`adapter-request`** exists on the repository (Settings → Labels) so the issue template and automation apply it correctly.
+
+Issues labeled **`adapter-request`** are grouped by **framework name** parsed from the issue body:
+
+1. GitHub Issue Form heading: `### Framework name` (or `### Framework`) followed by the value on the next line.
+2. Free-form line: `Framework: My Framework Name` (case-insensitive).
+
+The aggregator stores **slugified** keys (e.g. `OpenAI Agents SDK` → `openai-agents-sdk`). Issues that cannot be parsed increment **`_unparsed`** in the snapshot and dashboard.
+
+## CI artifacts
+
+Workflow **`.github/workflows/telemetry-weekly.yml`** runs on a weekly schedule and **`workflow_dispatch`**. It **does not push to `main`**; it uploads **`snapshot-*.json`** and **`dashboard.md`** as a **workflow artifact**.
+
+Optional: download the artifact and copy files to a **private branch** if you want historical copies in git (not required for promotion-gate review).
+
+## Revoking access
+
+- **Rotate `GITHUB_TOKEN`** at the source (GitHub developer settings) and update Secrets/ENV wherever it was stored.
+- **Rotate `TELEMETRY_TOKEN`** in the hosting provider, then update any automation (`TELEMETRY_TOKEN` / `TELEMETRY_SITE_ENDPOINT`) that calls `/api/telemetry`.
+
+## Relevant code
+
+- `scripts/telemetry/aggregate.py` — join + validate + `dashboard.md`
+- `scripts/telemetry/collect_github.py` — `adapter_requests` breakdown
+- `apps/web/src/app/api/telemetry/route.ts` — bearer-protected site metrics hook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,9 @@ openclaw = [
 openapi = [
     "openapi-pydantic>=0.5",
 ]
+telemetry = [
+    "pypistats>=1.11.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/adriannoes/asap-protocol"

--- a/scripts/lib/safe_url.py
+++ b/scripts/lib/safe_url.py
@@ -1,0 +1,54 @@
+"""Shared SSRF-safe URL checks for scripts (IssueOps, telemetry collectors).
+
+Mirrors the IssueOps guard used by agent registration: blocks private IPs, loopback,
+link-local targets, and cloud metadata hosts after optional DNS resolution.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+_BLOCKED_HOSTS = frozenset(
+    {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "0.0.0.0",
+        "metadata.google.internal",
+        "metadata.aws.internal",
+        "169.254.169.254",
+    }
+)
+
+
+def is_safe_http_url(url: str) -> bool:
+    """Return True if ``url`` may be fetched (HTTP/HTTPS) without obvious SSRF risk.
+
+    Blocks non-http(s) schemes, blocked hostnames, literal private/link-local IPs,
+    and hostnames whose DNS resolution includes private/link-local addresses.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    hostname = (parsed.hostname or "").lower()
+    if hostname in _BLOCKED_HOSTS:
+        return False
+    try:
+        addr = ipaddress.ip_address(hostname)
+    except ValueError:
+        addr = None
+    else:
+        assert addr is not None
+        if addr.is_private or addr.is_loopback or addr.is_link_local:
+            return False
+    try:
+        resolved = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC)
+        for _, _, _, _, sockaddr in resolved:
+            resolved_addr = ipaddress.ip_address(sockaddr[0])
+            if resolved_addr.is_private or resolved_addr.is_loopback or resolved_addr.is_link_local:
+                return False
+    except (socket.gaierror, ValueError, OSError):
+        return False
+    return True

--- a/scripts/process_registration.py
+++ b/scripts/process_registration.py
@@ -12,14 +12,11 @@ Usage (from GitHub Actions):
 from __future__ import annotations
 
 import argparse
-import ipaddress
 import json
 import logging
 import re
-import socket
 import sys
 from pathlib import Path
-from urllib.parse import urlparse
 
 import httpx
 from pydantic import ValidationError
@@ -40,48 +37,9 @@ from lib.registry_io import (  # noqa: E402
     save_registry,
     write_validation_result,
 )
+from lib.safe_url import is_safe_http_url  # noqa: E402
 
 logger = logging.getLogger(__name__)
-
-# Blocked hosts for SSRF protection (CWE-918)
-_BLOCKED_HOSTS = frozenset(
-    {
-        "localhost",
-        "127.0.0.1",
-        "::1",
-        "0.0.0.0",
-        "metadata.google.internal",
-        "metadata.aws.internal",
-        "169.254.169.254",
-    }
-)
-
-
-def _is_safe_url(url: str) -> bool:
-    """SSRF protection: block private IPs, loopback, cloud metadata (with DNS resolution)."""
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        return False
-    hostname = (parsed.hostname or "").lower()
-    if hostname in _BLOCKED_HOSTS:
-        return False
-    try:
-        addr = ipaddress.ip_address(hostname)
-    except ValueError:
-        addr = None
-    else:
-        assert addr is not None  # mypy: else implies try succeeded
-        if addr.is_private or addr.is_loopback or addr.is_link_local:
-            return False
-    try:
-        resolved = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC)
-        for _, _, _, _, sockaddr in resolved:
-            addr = ipaddress.ip_address(sockaddr[0])
-            if addr.is_private or addr.is_loopback or addr.is_link_local:
-                return False
-    except (socket.gaierror, ValueError, OSError):
-        return False
-    return True
 
 
 def _fail_registration(output_path: str, errors: list[str], issue_number: str) -> None:
@@ -144,7 +102,7 @@ def parse_issue_body(body: str) -> dict[str, str]:
 
 
 def fetch_manifest(url: str, timeout: float = 15.0) -> Manifest:
-    if not _is_safe_url(url):
+    if not is_safe_http_url(url):
         raise ValueError(f"Blocked URL (private/metadata): {url}")
     with httpx.Client(timeout=timeout, follow_redirects=False) as client:
         resp = client.get(url)

--- a/scripts/telemetry/__init__.py
+++ b/scripts/telemetry/__init__.py
@@ -1,0 +1,1 @@
+"""Telemetry collection scripts for adoption metrics (public sources only)."""

--- a/scripts/telemetry/aggregate.py
+++ b/scripts/telemetry/aggregate.py
@@ -16,6 +16,9 @@ Operator hints for **site / CTR**:
     Vercel Web Analytics aggregates are not available via a public REST API. The
     snapshot's ``site.ctr_per_cta`` is filled from ``--site-endpoint`` (GET with
     ``Authorization: Bearer <TELEMETRY_TOKEN>``) when passed, else placeholders.
+
+    NPM/PyPI collectors run **serially** in this script so weekly CI stays friendly
+    to upstream rate limits as additional packages are added.
 """
 
 from __future__ import annotations
@@ -25,9 +28,11 @@ import json
 import os
 import re
 import sys
+from collections.abc import Mapping
 from datetime import UTC, date, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict, cast
+from urllib.parse import urlparse
 
 import httpx
 from jsonschema import Draft202012Validator
@@ -42,6 +47,86 @@ from scripts.telemetry.collect_npm import DEFAULT_PACKAGES, collect_npm_weekly
 from scripts.telemetry.collect_pypi import collect_pypi_recent
 from scripts.telemetry.collect_registry import DEFAULT_REGISTRY_URL, collect_registry_snapshot
 from scripts.telemetry.collect_registry import fetch_registry_json
+from scripts.lib.safe_url import is_safe_http_url
+
+
+class NpmPackageRow(TypedDict, total=False):
+    """One package entry from ``collect_npm_weekly``."""
+
+    downloads: int
+    package: str
+    period: str
+
+
+class NpmWeeklyIngress(TypedDict, total=False):
+    """npm collector JSON consumed by ``build_npm_summary``."""
+
+    packages: dict[str, NpmPackageRow]
+
+
+class PyPiDownloadsIngress(TypedDict):
+    """Recent download windows from ``pypistats``."""
+
+    last_day: int
+    last_week: int
+    last_month: int
+
+
+class PyPiPackageIngress(TypedDict):
+    package: str
+    downloads: PyPiDownloadsIngress
+
+
+class PyPiWeeklyIngress(TypedDict, total=False):
+    """PyPI collector JSON merged into the snapshot ``pypi`` field."""
+
+    source: str
+    collected_at: str
+    packages: dict[str, PyPiPackageIngress]
+
+
+class AdapterRequestsIngress(TypedDict, total=False):
+    """GitHub collector ``adapter_requests`` block."""
+
+    label: str
+    open_count: int
+    by_framework: dict[str, int]
+    unparsed_open_count: int
+
+
+class GitHubTelemetryIngress(TypedDict, total=False):
+    """GitHub collector or placeholder payload stored under snapshot ``github``."""
+
+    source: str
+    repository: str
+    collected_at: str
+    skipped: bool
+    reason: str
+    repo: dict[str, int]
+    adapter_requests: AdapterRequestsIngress
+
+
+class RegistryTelemetryIngress(TypedDict, total=False):
+    """Registry snapshot block written into the weekly snapshot."""
+
+    source: str
+    registry_ref: str
+    format: str
+    collected_at: str
+    agent_count: int
+    previous_agent_count: int | None
+    growth: int | None
+
+
+class SiteCtrIngress(TypedDict, total=False):
+    """Site CTR payload from ``/api/telemetry`` or skipped/error placeholders."""
+
+    ctr_per_cta: dict[str, Any]
+    fetch_error: bool
+    note: str
+    skipped: bool
+    reason: str
+
 
 # ruff: noqa: E501 — valid JSON Schema string
 SNAPSHOT_SCHEMA: dict[str, Any] = {
@@ -63,15 +148,45 @@ SNAPSHOT_SCHEMA: dict[str, Any] = {
     "properties": {
         "snapshot_version": {"type": "integer", "const": 1},
         "collected_at": {"type": "string", "minLength": 10},
-        "npm": {"type": "object"},
-        "pypi": {"type": "object"},
-        "github": {"type": "object"},
-        "registry": {"type": "object"},
+        "npm": {
+            "type": "object",
+            "additionalProperties": {"type": "integer"},
+        },
+        "pypi": {
+            "type": "object",
+            "required": ["packages"],
+            "properties": {"packages": {"type": "object"}},
+        },
+        "github": {
+            "type": "object",
+            "required": ["adapter_requests"],
+            "properties": {
+                "adapter_requests": {
+                    "type": "object",
+                    "required": ["by_framework"],
+                    "properties": {
+                        "by_framework": {
+                            "type": "object",
+                            "additionalProperties": {"type": "integer"},
+                        },
+                    },
+                },
+            },
+        },
+        "registry": {
+            "type": "object",
+            "required": ["agent_count"],
+            "properties": {"agent_count": {"type": "integer"}},
+        },
         "site": {
             "type": "object",
             "required": ["ctr_per_cta"],
             "properties": {
                 "ctr_per_cta": {"type": "object"},
+                "fetch_error": {"type": "boolean"},
+                "note": {"type": "string"},
+                "skipped": {"type": "boolean"},
+                "reason": {"type": "string"},
             },
         },
         "adapter_requests": {
@@ -128,7 +243,7 @@ def registry_count_from_snapshot(snapshot_path: Path) -> int | None:
     return count if isinstance(count, int) else None
 
 
-def build_npm_summary(report: dict[str, Any]) -> dict[str, int]:
+def build_npm_summary(report: Mapping[str, object]) -> dict[str, int]:
     """Flatten npm collector output to ``{package: downloads}``."""
     pkgs = report.get("packages")
     if not isinstance(pkgs, dict):
@@ -143,7 +258,7 @@ def build_npm_summary(report: dict[str, Any]) -> dict[str, int]:
     return out
 
 
-def flatten_adapter_request_counts(github_report: dict[str, Any]) -> dict[str, int]:
+def flatten_adapter_request_counts(github_report: Mapping[str, object]) -> dict[str, int]:
     """Build snapshot ``adapter_requests`` counts from GitHub collector output."""
     block = github_report.get("adapter_requests")
     if not isinstance(block, dict):
@@ -160,61 +275,90 @@ def flatten_adapter_request_counts(github_report: dict[str, Any]) -> dict[str, i
     return dict(sorted(out.items(), key=lambda kv: (-kv[1], kv[0])))
 
 
+def validate_site_endpoint(endpoint: str) -> None:
+    """Require a public HTTPS URL before attaching a Bearer secret."""
+    parsed = urlparse(endpoint)
+    if parsed.scheme != "https":
+        msg = "TELEMETRY_SITE_ENDPOINT must use https://"
+        raise ValueError(msg)
+    if not parsed.netloc:
+        msg = "TELEMETRY_SITE_ENDPOINT must include a host"
+        raise ValueError(msg)
+    if not is_safe_http_url(endpoint):
+        msg = "TELEMETRY_SITE_ENDPOINT must be a public HTTPS URL"
+        raise ValueError(msg)
+
+
 def fetch_site_ctr(
     endpoint: str,
     bearer: str,
     *,
     timeout: float = _REQUEST_TIMEOUT,
-) -> dict[str, Any]:
+) -> SiteCtrIngress:
     """GET a protected telemetry route and return its JSON ``site`` object or empty."""
+    validate_site_endpoint(endpoint)
     headers = {"Authorization": f"Bearer {bearer}"}
     try:
-        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+        with httpx.Client(timeout=timeout, follow_redirects=False) as client:
             response = client.get(endpoint, headers=headers)
+            if response.is_redirect:
+                msg = "TELEMETRY_SITE_ENDPOINT must not redirect when sending Authorization"
+                raise ValueError(msg)
             response.raise_for_status()
             payload: object = response.json()
-    except (httpx.HTTPError, json.JSONDecodeError, ValueError):
+    except json.JSONDecodeError:
+        return {"ctr_per_cta": {}, "fetch_error": True}
+    except ValueError:
+        raise
+    except httpx.HTTPError:
         return {"ctr_per_cta": {}, "fetch_error": True}
     if not isinstance(payload, dict):
-        return {"ctr_per_cta": {}}
+        return {"ctr_per_cta": {}, "fetch_error": True}
     site = payload.get("site")
     if isinstance(site, dict) and isinstance(site.get("ctr_per_cta"), dict):
-        return site
-    return {"ctr_per_cta": {}}
+        return cast(SiteCtrIngress, site)
+    return {"ctr_per_cta": {}, "fetch_error": True}
 
 
 def collect_github_or_placeholder(
     owner: str,
     repo: str,
     token: str,
-) -> dict[str, Any]:
-    """Run GitHub collector or return a non-fatal placeholder."""
+) -> GitHubTelemetryIngress:
+    """Run GitHub collector or return a non-fatal placeholder (``--allow-github-skip`` only)."""
     if not token:
-        return {
-            "source": "github_rest_api",
-            "skipped": True,
-            "reason": "GITHUB_TOKEN not set",
-            "repository": f"{owner}/{repo}",
-            "adapter_requests": {
-                "label": "adapter-request",
-                "open_count": 0,
-                "by_framework": {},
+        return cast(
+            GitHubTelemetryIngress,
+            {
+                "source": "github_rest_api",
+                "skipped": True,
+                "reason": "TELEMETRY_GITHUB_TOKEN / GITHUB_TOKEN not set",
+                "repository": f"{owner}/{repo}",
+                "adapter_requests": {
+                    "label": "adapter-request",
+                    "open_count": 0,
+                    "by_framework": {},
+                },
             },
-        }
+        )
     try:
-        return collect_github_signals(owner, repo, token=token)
+        return cast(GitHubTelemetryIngress, collect_github_signals(owner, repo, token=token))
     except (httpx.HTTPError, ValueError) as exc:
-        return {
-            "source": "github_rest_api",
-            "skipped": True,
-            "reason": str(exc),
-            "repository": f"{owner}/{repo}",
-            "adapter_requests": {
-                "label": "adapter-request",
-                "open_count": 0,
-                "by_framework": {},
+        print(f"GitHub telemetry skipped: {exc}", file=sys.stderr)
+        return cast(
+            GitHubTelemetryIngress,
+            {
+                "source": "github_rest_api",
+                "skipped": True,
+                "reason": "GitHub telemetry failed; see CI logs.",
+                "repository": f"{owner}/{repo}",
+                "adapter_requests": {
+                    "label": "adapter-request",
+                    "open_count": 0,
+                    "by_framework": {},
+                },
             },
-        }
+        )
 
 
 def render_dashboard(
@@ -307,6 +451,21 @@ def render_dashboard(
         for name, count in items:
             ad_lines.append(f"| `{name}` | {count} |")
     lines.extend(ad_lines)
+
+    degraded: list[str] = []
+    gh_obj = snapshot.get("github")
+    if isinstance(gh_obj, dict) and gh_obj.get("skipped"):
+        reason = gh_obj.get("reason", "unknown")
+        degraded.append(
+            f"GitHub telemetry skipped ({reason}); adapter-request counts may be zeroed."
+        )
+    site_obj = snapshot.get("site")
+    if isinstance(site_obj, dict) and site_obj.get("fetch_error"):
+        degraded.append("Site CTR fetch failed; see `site.fetch_error` in the snapshot JSON.")
+    if degraded:
+        lines.extend(["", "## Data quality warnings", ""])
+        lines.extend(f"- {note}" for note in degraded)
+
     lines.append("")
     return "\n".join(lines)
 
@@ -359,6 +518,14 @@ def main(argv: list[str] | None = None) -> int:
         default="TELEMETRY_TOKEN",
         help="Env var for Bearer token when fetching --site-endpoint.",
     )
+    parser.add_argument(
+        "--allow-github-skip",
+        action="store_true",
+        help=(
+            "Allow missing or failing GitHub REST telemetry (placeholder snapshot data). "
+            "Do not use for CI promotion gates."
+        ),
+    )
     args = parser.parse_args(argv)
 
     output_dir: Path = args.output_dir
@@ -370,11 +537,42 @@ def main(argv: list[str] | None = None) -> int:
     prev_path = resolve_previous_snapshot_path(output_dir, snap_day)
     previous_registry_count = registry_count_from_snapshot(prev_path) if prev_path else None
 
-    npm_report = collect_npm_weekly(DEFAULT_PACKAGES)
-    pypi_report = collect_pypi_recent(("asap-protocol",))
+    npm_report = cast(NpmWeeklyIngress, collect_npm_weekly(DEFAULT_PACKAGES))
+    pypi_report = cast(PyPiWeeklyIngress, collect_pypi_recent(("asap-protocol",)))
 
-    token = os.environ.get("GITHUB_TOKEN", "").strip()
-    github_report = collect_github_or_placeholder(args.github_owner, args.github_repo, token)
+    allow_github_skip: bool = args.allow_github_skip
+    github_report: GitHubTelemetryIngress
+    if allow_github_skip:
+        gh_token = (
+            os.environ.get("TELEMETRY_GITHUB_TOKEN", "").strip()
+            or os.environ.get("GITHUB_TOKEN", "").strip()
+        )
+        github_report = collect_github_or_placeholder(
+            args.github_owner,
+            args.github_repo,
+            gh_token,
+        )
+    else:
+        gh_token = os.environ.get("TELEMETRY_GITHUB_TOKEN", "").strip()
+        if not gh_token:
+            print(
+                "Missing TELEMETRY_GITHUB_TOKEN; GitHub telemetry is required "
+                "(pass --allow-github-skip for local placeholder runs only).",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            github_report = cast(
+                GitHubTelemetryIngress,
+                collect_github_signals(
+                    args.github_owner,
+                    args.github_repo,
+                    token=gh_token,
+                ),
+            )
+        except (httpx.HTTPError, ValueError) as exc:
+            print(f"GitHub telemetry failed: {exc}", file=sys.stderr)
+            return 1
 
     try:
         raw_registry = fetch_registry_json(args.registry_url)
@@ -382,21 +580,33 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Registry fetch failed: {exc}", file=sys.stderr)
         return 1
 
-    registry_report = collect_registry_snapshot(
-        raw_registry,
-        registry_ref=args.registry_url,
-        previous_count=previous_registry_count,
+    registry_report = cast(
+        RegistryTelemetryIngress,
+        collect_registry_snapshot(
+            raw_registry,
+            registry_ref=args.registry_url,
+            previous_count=previous_registry_count,
+        ),
     )
 
-    site: dict[str, Any]
+    site_details: SiteCtrIngress
     telemetry_secret = os.environ.get(args.telemetry_token_env, "").strip()
     if args.site_endpoint and telemetry_secret:
-        site = fetch_site_ctr(args.site_endpoint, telemetry_secret)
+        try:
+            site_details = fetch_site_ctr(args.site_endpoint, telemetry_secret)
+        except ValueError as exc:
+            print(f"Site telemetry misconfigured: {exc}", file=sys.stderr)
+            return 1
     else:
-        site = {
+        site_details = {
             "ctr_per_cta": {},
             "note": "Site metrics skipped (set TELEMETRY_SITE_ENDPOINT and TELEMETRY_TOKEN to pull /api/telemetry).",
         }
+
+    snapshot_site: dict[str, Any] = {"ctr_per_cta": site_details.get("ctr_per_cta", {})}
+    for copy_key in ("fetch_error", "note", "skipped", "reason"):
+        if copy_key in site_details:
+            snapshot_site[copy_key] = site_details[copy_key]
 
     snapshot: dict[str, Any] = {
         "snapshot_version": 1,
@@ -405,7 +615,7 @@ def main(argv: list[str] | None = None) -> int:
         "pypi": pypi_report,
         "github": github_report,
         "registry": registry_report,
-        "site": {"ctr_per_cta": site.get("ctr_per_cta", {})},
+        "site": snapshot_site,
         "adapter_requests": flatten_adapter_request_counts(github_report),
     }
 

--- a/scripts/telemetry/aggregate.py
+++ b/scripts/telemetry/aggregate.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Join weekly telemetry collectors into a snapshot JSON + markdown dashboard.
+
+Writes:
+
+- ``private/telemetry/snapshot-YYYY-MM-DD.json`` — validated against an embedded JSON Schema.
+- ``private/telemetry/dashboard.md`` — ~12 week trend table + adapter request section.
+- ``private/telemetry/snapshot-latest.json`` — symlink to the dated snapshot (Unix CI).
+
+Dashboard trend rows:
+    When fewer than two historical snapshots exist under ``--output-dir``, the table
+    documents **week-over-week growth** expectations but only includes the current row;
+    re-run weekly aggregation to accumulate history locally or download CI artifacts.
+
+Operator hints for **site / CTR**:
+    Vercel Web Analytics aggregates are not available via a public REST API. The
+    snapshot's ``site.ctr_per_cta`` is filled from ``--site-endpoint`` (GET with
+    ``Authorization: Bearer <TELEMETRY_TOKEN>``) when passed, else placeholders.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from scripts.telemetry.collect_github import (
+    DEFAULT_OWNER as GITHUB_DEFAULT_OWNER,
+    DEFAULT_REPO as GITHUB_DEFAULT_REPO,
+    collect_github_signals,
+)
+from scripts.telemetry.collect_npm import DEFAULT_PACKAGES, collect_npm_weekly
+from scripts.telemetry.collect_pypi import collect_pypi_recent
+from scripts.telemetry.collect_registry import DEFAULT_REGISTRY_URL, collect_registry_snapshot
+from scripts.telemetry.collect_registry import fetch_registry_json
+
+# ruff: noqa: E501 — valid JSON Schema string
+SNAPSHOT_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://asap-protocol.com/schemas/telemetry-snapshot-v1.json",
+    "title": "ASAP telemetry weekly snapshot",
+    "type": "object",
+    "additionalProperties": True,
+    "required": [
+        "snapshot_version",
+        "collected_at",
+        "npm",
+        "pypi",
+        "github",
+        "registry",
+        "site",
+        "adapter_requests",
+    ],
+    "properties": {
+        "snapshot_version": {"type": "integer", "const": 1},
+        "collected_at": {"type": "string", "minLength": 10},
+        "npm": {"type": "object"},
+        "pypi": {"type": "object"},
+        "github": {"type": "object"},
+        "registry": {"type": "object"},
+        "site": {
+            "type": "object",
+            "required": ["ctr_per_cta"],
+            "properties": {
+                "ctr_per_cta": {"type": "object"},
+            },
+        },
+        "adapter_requests": {
+            "type": "object",
+            "additionalProperties": {"type": "integer"},
+        },
+    },
+}
+
+_REQUEST_TIMEOUT = 45.0
+_SNAPSHOT_NAME_RE = re.compile(r"^snapshot-(\d{4}-\d{2}-\d{2})\.json$")
+
+
+def validate_snapshot(instance: dict[str, Any]) -> None:
+    """Validate ``instance`` against :data:`SNAPSHOT_SCHEMA`."""
+    validator = Draft202012Validator(SNAPSHOT_SCHEMA)
+    validator.validate(instance)
+
+
+def list_snapshot_files(output_dir: Path) -> list[tuple[date, Path]]:
+    """Return dated snapshot files under ``output_dir`` (excludes ``snapshot-latest``)."""
+    rows: list[tuple[date, Path]] = []
+    for path in output_dir.glob("snapshot-*.json"):
+        if path.name == "snapshot-latest.json":
+            continue
+        match = _SNAPSHOT_NAME_RE.match(path.name)
+        if not match:
+            continue
+        rows.append((date.fromisoformat(match.group(1)), path.resolve()))
+    rows.sort(key=lambda x: x[0])
+    return rows
+
+
+def resolve_previous_snapshot_path(output_dir: Path, current: date) -> Path | None:
+    """Pick the latest snapshot strictly before ``current``."""
+    candidates = [p for d, p in list_snapshot_files(output_dir) if d < current]
+    if not candidates:
+        return None
+    return candidates[-1]
+
+
+def registry_count_from_snapshot(snapshot_path: Path) -> int | None:
+    """Read ``registry.agent_count`` from an existing snapshot, if present."""
+    try:
+        raw: object = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    reg = raw.get("registry")
+    if not isinstance(reg, dict):
+        return None
+    count = reg.get("agent_count")
+    return count if isinstance(count, int) else None
+
+
+def build_npm_summary(report: dict[str, Any]) -> dict[str, int]:
+    """Flatten npm collector output to ``{package: downloads}``."""
+    pkgs = report.get("packages")
+    if not isinstance(pkgs, dict):
+        return {}
+    out: dict[str, int] = {}
+    for name, body in pkgs.items():
+        if not isinstance(body, dict):
+            continue
+        dl = body.get("downloads")
+        if isinstance(dl, int):
+            out[str(name)] = dl
+    return out
+
+
+def flatten_adapter_request_counts(github_report: dict[str, Any]) -> dict[str, int]:
+    """Build snapshot ``adapter_requests`` counts from GitHub collector output."""
+    block = github_report.get("adapter_requests")
+    if not isinstance(block, dict):
+        return {}
+    by_fw = block.get("by_framework")
+    out: dict[str, int] = {}
+    if isinstance(by_fw, dict):
+        for k, v in by_fw.items():
+            if isinstance(k, str) and isinstance(v, int):
+                out[k] = v
+    unparsed = block.get("unparsed_open_count")
+    if isinstance(unparsed, int) and unparsed > 0:
+        out["_unparsed"] = unparsed
+    return dict(sorted(out.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def fetch_site_ctr(
+    endpoint: str,
+    bearer: str,
+    *,
+    timeout: float = _REQUEST_TIMEOUT,
+) -> dict[str, Any]:
+    """GET a protected telemetry route and return its JSON ``site`` object or empty."""
+    headers = {"Authorization": f"Bearer {bearer}"}
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            response = client.get(endpoint, headers=headers)
+            response.raise_for_status()
+            payload: object = response.json()
+    except (httpx.HTTPError, json.JSONDecodeError, ValueError):
+        return {"ctr_per_cta": {}, "fetch_error": True}
+    if not isinstance(payload, dict):
+        return {"ctr_per_cta": {}}
+    site = payload.get("site")
+    if isinstance(site, dict) and isinstance(site.get("ctr_per_cta"), dict):
+        return site
+    return {"ctr_per_cta": {}}
+
+
+def collect_github_or_placeholder(
+    owner: str,
+    repo: str,
+    token: str,
+) -> dict[str, Any]:
+    """Run GitHub collector or return a non-fatal placeholder."""
+    if not token:
+        return {
+            "source": "github_rest_api",
+            "skipped": True,
+            "reason": "GITHUB_TOKEN not set",
+            "repository": f"{owner}/{repo}",
+            "adapter_requests": {
+                "label": "adapter-request",
+                "open_count": 0,
+                "by_framework": {},
+            },
+        }
+    try:
+        return collect_github_signals(owner, repo, token=token)
+    except (httpx.HTTPError, ValueError) as exc:
+        return {
+            "source": "github_rest_api",
+            "skipped": True,
+            "reason": str(exc),
+            "repository": f"{owner}/{repo}",
+            "adapter_requests": {
+                "label": "adapter-request",
+                "open_count": 0,
+                "by_framework": {},
+            },
+        }
+
+
+def render_dashboard(
+    snapshot: dict[str, Any],
+    history_paths: list[tuple[date, Path]],
+    *,
+    weeks: int = 12,
+) -> str:
+    """Render markdown for ``dashboard.md``."""
+    lines: list[str] = [
+        "# ASAP adoption telemetry dashboard",
+        "",
+        "_Generated by `scripts/telemetry/aggregate.py`. Do not edit by hand._",
+        "",
+        "## 12-week trend (public-source signals)",
+        "",
+        "| Week ending (UTC) | npm Σ weekly DL | PyPI `last_week` | GitHub stars | Registry agents |",
+        "|------------------|-----------------|------------------|--------------|-----------------|",
+    ]
+
+    selected = history_paths[-weeks:]
+    if not selected:
+        lines.append(
+            "| _(no snapshots yet)_ | — | — | — | — |",
+        )
+    for snap_date, path in selected:
+        try:
+            raw_hist: object = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(raw_hist, dict):
+            continue
+        npm_vals = raw_hist.get("npm")
+        npm_sum = 0
+        if isinstance(npm_vals, dict):
+            for v in npm_vals.values():
+                if isinstance(v, int):
+                    npm_sum += v
+        pypi_week: str | int = "—"
+        pypi_obj = raw_hist.get("pypi")
+        if isinstance(pypi_obj, dict):
+            pkgs = pypi_obj.get("packages")
+            if isinstance(pkgs, dict):
+                first = next(iter(pkgs.values()), None)
+                if isinstance(first, dict):
+                    dl = first.get("downloads")
+                    if isinstance(dl, dict):
+                        lw = dl.get("last_week")
+                        if isinstance(lw, int):
+                            pypi_week = lw
+        gh_stars: str | int = "—"
+        gh = raw_hist.get("github")
+        if isinstance(gh, dict):
+            repo_info = gh.get("repo")
+            if isinstance(repo_info, dict):
+                sc = repo_info.get("stargazers_count")
+                if isinstance(sc, int):
+                    gh_stars = sc
+        reg_c: str | int = "—"
+        reg = raw_hist.get("registry")
+        if isinstance(reg, dict):
+            ac = reg.get("agent_count")
+            if isinstance(ac, int):
+                reg_c = ac
+        lines.append(
+            f"| {snap_date.isoformat()} | {npm_sum} | {pypi_week} | {gh_stars} | {reg_c} |",
+        )
+
+    if len(selected) < 2:
+        lines.extend(
+            [
+                "",
+                "> **Growth**: With only one snapshot on disk, week-over-week deltas are omitted. "
+                "Keep weekly artifacts (or run locally into `private/telemetry/`) to populate this table.",
+            ],
+        )
+
+    ad_lines = ["", "## Adapter requests (open issues, by framework)", ""]
+    adapter_counts = snapshot.get("adapter_requests")
+    if not isinstance(adapter_counts, dict):
+        adapter_counts = {}
+    # Sort by count desc; keep `_unparsed` last for readability.
+    items = [(k, v) for k, v in adapter_counts.items() if isinstance(v, int) and v > 0]
+    items.sort(key=lambda kv: (kv[0] == "_unparsed", -kv[1], kv[0]))
+    if not items:
+        ad_lines.append("_No open adapter-request issues counted in this snapshot._")
+    else:
+        ad_lines.append("| Framework (slug) | Open requests |")
+        ad_lines.append("|------------------|---------------|")
+        for name, count in items:
+            ad_lines.append(f"| `{name}` | {count} |")
+    lines.extend(ad_lines)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def update_latest_symlink(output_dir: Path, snapshot_filename: str) -> None:
+    """Point ``snapshot-latest.json`` at ``snapshot_filename`` (relative)."""
+    link = output_dir / "snapshot-latest.json"
+    if link.exists() or link.is_symlink():
+        link.unlink()
+    link.symlink_to(snapshot_filename, target_is_directory=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Aggregate weekly telemetry into a snapshot + dashboard."
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("private/telemetry"),
+        help="Directory for snapshot + dashboard (created if missing).",
+    )
+    parser.add_argument(
+        "--date",
+        default="",
+        help="UTC date YYYY-MM-DD for filename (default: today UTC).",
+    )
+    parser.add_argument(
+        "--registry-url",
+        default=DEFAULT_REGISTRY_URL,
+        help="HTTPS URL for registry.json mirror.",
+    )
+    parser.add_argument(
+        "--github-owner",
+        default=GITHUB_DEFAULT_OWNER,
+        help="GitHub owner for collectors.",
+    )
+    parser.add_argument(
+        "--github-repo",
+        default=GITHUB_DEFAULT_REPO,
+        help="GitHub repo for collectors.",
+    )
+    parser.add_argument(
+        "--site-endpoint",
+        default=os.environ.get("TELEMETRY_SITE_ENDPOINT", "").strip(),
+        help="Full URL to GET /api/telemetry (Bearer TELEMETRY_TOKEN).",
+    )
+    parser.add_argument(
+        "--telemetry-token-env",
+        default="TELEMETRY_TOKEN",
+        help="Env var for Bearer token when fetching --site-endpoint.",
+    )
+    args = parser.parse_args(argv)
+
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    snap_day = date.fromisoformat(args.date) if args.date else datetime.now(UTC).date()
+    snap_label = snap_day.isoformat()
+
+    prev_path = resolve_previous_snapshot_path(output_dir, snap_day)
+    previous_registry_count = registry_count_from_snapshot(prev_path) if prev_path else None
+
+    npm_report = collect_npm_weekly(DEFAULT_PACKAGES)
+    pypi_report = collect_pypi_recent(("asap-protocol",))
+
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    github_report = collect_github_or_placeholder(args.github_owner, args.github_repo, token)
+
+    try:
+        raw_registry = fetch_registry_json(args.registry_url)
+    except (httpx.HTTPError, json.JSONDecodeError, ValueError) as exc:
+        print(f"Registry fetch failed: {exc}", file=sys.stderr)
+        return 1
+
+    registry_report = collect_registry_snapshot(
+        raw_registry,
+        registry_ref=args.registry_url,
+        previous_count=previous_registry_count,
+    )
+
+    site: dict[str, Any]
+    telemetry_secret = os.environ.get(args.telemetry_token_env, "").strip()
+    if args.site_endpoint and telemetry_secret:
+        site = fetch_site_ctr(args.site_endpoint, telemetry_secret)
+    else:
+        site = {
+            "ctr_per_cta": {},
+            "note": "Site metrics skipped (set TELEMETRY_SITE_ENDPOINT and TELEMETRY_TOKEN to pull /api/telemetry).",
+        }
+
+    snapshot: dict[str, Any] = {
+        "snapshot_version": 1,
+        "collected_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+        "npm": build_npm_summary(npm_report),
+        "pypi": pypi_report,
+        "github": github_report,
+        "registry": registry_report,
+        "site": {"ctr_per_cta": site.get("ctr_per_cta", {})},
+        "adapter_requests": flatten_adapter_request_counts(github_report),
+    }
+
+    try:
+        validate_snapshot(snapshot)
+    except ValidationError as exc:
+        print(f"Snapshot failed schema validation: {exc}", file=sys.stderr)
+        return 1
+
+    snapshot_name = f"snapshot-{snap_label}.json"
+    snapshot_path = output_dir / snapshot_name
+    snapshot_path.write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    history = list_snapshot_files(output_dir)
+    dashboard_text = render_dashboard(snapshot, history, weeks=12)
+    (output_dir / "dashboard.md").write_text(dashboard_text, encoding="utf-8")
+
+    try:
+        update_latest_symlink(output_dir, snapshot_name)
+    except OSError:
+        # Windows developer machines may lack symlink privilege; CI is Linux.
+        print(
+            "Note: could not create snapshot-latest.json symlink (optional).",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/telemetry/collect_github.py
+++ b/scripts/telemetry/collect_github.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Collect public GitHub repository metrics and traffic (clones, referrers) via REST API.
+
+**Stars** and **forks** are available without auth, but **traffic** endpoints require a
+`GITHUB_TOKEN` with **push** access to the target repository (same as the Insights tab).
+
+Uses ``GITHUB_TOKEN`` from the environment by default (never print or log the token).
+
+API: https://docs.github.com/en/rest
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+GITHUB_API_BASE = "https://api.github.com"
+GITHUB_API_VERSION = "2022-11-28"
+DEFAULT_OWNER = "adriannoes"
+DEFAULT_REPO = "asap-protocol"
+DEFAULT_TOKEN_ENV = "GITHUB_TOKEN"
+DEFAULT_ADAPTER_LABEL = "adapter-request"
+REQUEST_TIMEOUT_SECONDS = 30.0
+
+_FRAMEWORK_HEADING_RE = re.compile(
+    r"(?mi)^###\s*Framework(?:\s+name)?\s*\n+\s*(.+)$",
+)
+_FRAMEWORK_LINE_RE = re.compile(r"(?mi)^\s*Framework\s*:\s*(.+)$")
+
+
+def _github_headers(token: str) -> dict[str, str]:
+    return {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    }
+
+
+def fetch_repo_summary(client: httpx.Client, owner: str, repo: str) -> dict[str, int]:
+    """Return stargazers, forks, and related counts from ``GET /repos/{owner}/{repo}``."""
+    response = client.get(f"/repos/{owner}/{repo}")
+    response.raise_for_status()
+    payload: object = response.json()
+    if not isinstance(payload, dict):
+        msg = "GitHub /repos response must be a JSON object"
+        raise ValueError(msg)
+    keys = (
+        "stargazers_count",
+        "forks_count",
+        "open_issues_count",
+        "watchers_count",
+    )
+    out: dict[str, int] = {}
+    for key in keys:
+        raw = payload.get(key)
+        if not isinstance(raw, int):
+            msg = f"GitHub /repos missing or invalid integer {key!r}"
+            raise ValueError(msg)
+        out[key] = raw
+    return out
+
+
+def fetch_traffic_clones(client: httpx.Client, owner: str, repo: str) -> dict[str, Any]:
+    """Return clone totals and daily series from ``GET .../traffic/clones``."""
+    response = client.get(f"/repos/{owner}/{repo}/traffic/clones")
+    response.raise_for_status()
+    payload: object = response.json()
+    if not isinstance(payload, dict):
+        msg = "GitHub /traffic/clones response must be a JSON object"
+        raise ValueError(msg)
+    count = payload.get("count")
+    uniques = payload.get("uniques")
+    clones = payload.get("clones")
+    if not isinstance(count, int) or not isinstance(uniques, int):
+        msg = "GitHub /traffic/clones missing count or uniques"
+        raise ValueError(msg)
+    if not isinstance(clones, list):
+        msg = "GitHub /traffic/clones missing clones array"
+        raise ValueError(msg)
+    return {
+        "count": count,
+        "uniques": uniques,
+        "clones": clones,
+    }
+
+
+def parse_framework_from_issue_body(body: str) -> str | None:
+    """Extract a framework label from GitHub issue body text.
+
+    Supports:
+
+    - GitHub Issue Form export: ``### Framework name`` / ``### Framework`` blocks.
+    - Free-form: a line ``Framework: My Framework``.
+
+    Returns:
+        The raw framework string, or ``None`` if not found.
+    """
+    if not body or not body.strip():
+        return None
+    match = _FRAMEWORK_HEADING_RE.search(body)
+    if match:
+        return match.group(1).strip()
+    match = _FRAMEWORK_LINE_RE.search(body)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def slug_framework_label(raw: str) -> str:
+    """Normalize a framework name to a lowercase ``kebab-case`` key."""
+    s = raw.strip().lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    return s.strip("-") or "unknown"
+
+
+def fetch_open_labeled_issues(
+    client: httpx.Client,
+    owner: str,
+    repo: str,
+    *,
+    label: str,
+) -> list[dict[str, Any]]:
+    """List open issues with ``label`` (excludes pull requests)."""
+    page = 1
+    out: list[dict[str, Any]] = []
+    while True:
+        response = client.get(
+            f"/repos/{owner}/{repo}/issues",
+            params={
+                "state": "open",
+                "labels": label,
+                "per_page": 100,
+                "page": page,
+            },
+        )
+        response.raise_for_status()
+        payload: object = response.json()
+        if not isinstance(payload, list):
+            msg = "GitHub /issues response must be a JSON array"
+            raise ValueError(msg)
+        if not payload:
+            break
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            if "pull_request" in item:
+                continue
+            out.append(item)
+        if len(payload) < 100:
+            break
+        page += 1
+    return out
+
+
+def summarize_adapter_requests(issues: list[dict[str, Any]]) -> dict[str, Any]:
+    """Count open adapter-request issues by parsed framework name."""
+    by_framework: dict[str, int] = defaultdict(int)
+    unparsed = 0
+    for issue in issues:
+        body = issue.get("body")
+        body_str = body if isinstance(body, str) else ""
+        parsed = parse_framework_from_issue_body(body_str)
+        if parsed is None:
+            unparsed += 1
+            continue
+        key = slug_framework_label(parsed)
+        by_framework[key] += 1
+    result: dict[str, Any] = {
+        "label": DEFAULT_ADAPTER_LABEL,
+        "open_count": len(issues),
+        "by_framework": dict(sorted(by_framework.items())),
+    }
+    if unparsed:
+        result["unparsed_open_count"] = unparsed
+    return result
+
+
+def fetch_popular_referrers(client: httpx.Client, owner: str, repo: str) -> list[dict[str, Any]]:
+    """Return top referrers from ``GET .../traffic/popular/referrers``."""
+    response = client.get(f"/repos/{owner}/{repo}/traffic/popular/referrers")
+    response.raise_for_status()
+    payload: object = response.json()
+    if not isinstance(payload, list):
+        msg = "GitHub /traffic/popular/referrers must be a JSON array"
+        raise ValueError(msg)
+    out: list[dict[str, Any]] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        ref = item.get("referrer")
+        views = item.get("views")
+        uniq = item.get("uniques")
+        if isinstance(ref, str) and isinstance(views, int) and isinstance(uniq, int):
+            out.append({"referrer": ref, "views": views, "uniques": uniq})
+    return out
+
+
+def collect_github_signals(
+    owner: str,
+    repo: str,
+    *,
+    token: str,
+    client: httpx.Client | None = None,
+) -> dict[str, Any]:
+    """Pull repo summary, traffic, popular referrers, and adapter-request breakdown."""
+    collected_at = datetime.now(UTC).replace(microsecond=0).isoformat()
+    slug = f"{owner}/{repo}"
+    close_client = client is None
+    http = client or httpx.Client(
+        base_url=GITHUB_API_BASE,
+        headers=_github_headers(token),
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    try:
+        repo_summary = fetch_repo_summary(http, owner, repo)
+        clone_stats = fetch_traffic_clones(http, owner, repo)
+        referrers = fetch_popular_referrers(http, owner, repo)
+        issues = fetch_open_labeled_issues(
+            http,
+            owner,
+            repo,
+            label=DEFAULT_ADAPTER_LABEL,
+        )
+        adapter_summary = summarize_adapter_requests(issues)
+    finally:
+        if close_client:
+            http.close()
+    return {
+        "source": "github_rest_api",
+        "repository": slug,
+        "collected_at": collected_at,
+        "repo": repo_summary,
+        "traffic_clones": clone_stats,
+        "traffic_referrers": referrers,
+        "adapter_requests": adapter_summary,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Collect GitHub repo metrics and traffic (requires GITHUB_TOKEN with push)."
+    )
+    parser.add_argument(
+        "--owner",
+        default=DEFAULT_OWNER,
+        help=f"Repository owner (default: {DEFAULT_OWNER})",
+    )
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help=f"Repository name (default: {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--token-env",
+        default=DEFAULT_TOKEN_ENV,
+        help=f"Environment variable holding a GitHub PAT (default: {DEFAULT_TOKEN_ENV})",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Write JSON to this path instead of stdout",
+    )
+    args = parser.parse_args(argv)
+    token = os.environ.get(args.token_env, "").strip()
+    if not token:
+        print(
+            f"Missing {args.token_env}: set a token with push access to "
+            f"{args.owner}/{args.repo} (traffic endpoints require it).",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        report = collect_github_signals(args.owner, args.repo, token=token)
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        detail = ""
+        try:
+            body: object = exc.response.json()
+            if isinstance(body, dict) and "message" in body:
+                detail = str(body.get("message"))
+        except (json.JSONDecodeError, ValueError):
+            detail = exc.response.text[:500]
+        print(
+            f"GitHub API HTTP {status} for {exc.request.url!s}: {detail}",
+            file=sys.stderr,
+        )
+        return 1
+    except (httpx.HTTPError, ValueError) as exc:
+        print(f"GitHub telemetry failed: {exc}", file=sys.stderr)
+        return 1
+
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/telemetry/collect_github.py
+++ b/scripts/telemetry/collect_github.py
@@ -2,9 +2,14 @@
 """Collect public GitHub repository metrics and traffic (clones, referrers) via REST API.
 
 **Stars** and **forks** are available without auth, but **traffic** endpoints require a
-`GITHUB_TOKEN` with **push** access to the target repository (same as the Insights tab).
+token with **push** access to the target repository (same as the Insights tab).
 
-Uses ``GITHUB_TOKEN`` from the environment by default (never print or log the token).
+Weekly aggregation in CI should use ``TELEMETRY_GITHUB_TOKEN`` (fine-grained or classic PAT
+with traffic scope). The legacy ``GITHUB_TOKEN`` env name is still accepted when
+``scripts/telemetry/aggregate.py`` is run with ``--allow-github-skip`` only.
+
+Uses ``GITHUB_TOKEN`` / ``TELEMETRY_GITHUB_TOKEN`` from the environment by default (never
+print or log the token).
 
 API: https://docs.github.com/en/rest
 """

--- a/scripts/telemetry/collect_npm.py
+++ b/scripts/telemetry/collect_npm.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Fetch last-week npm download counts for `@asap-protocol/*` packages via the public API.
+
+Writes a single JSON document (stdout or ``--output``) suitable for weekly aggregation.
+
+API: https://github.com/npm/registry/blob/master/docs/download-counts.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import quote
+from typing import Any
+
+import httpx
+
+NPM_DOWNLOADS_RANGE_BASE = "https://api.npmjs.org/downloads/range"
+DEFAULT_PERIOD = "last-week"
+DEFAULT_PACKAGES: tuple[str, ...] = ("@asap-protocol/client",)
+REQUEST_TIMEOUT_SECONDS = 30.0
+
+
+def _downloads_url(package: str, period: str) -> str:
+    """Build the npm downloads range URL (scoped names must be percent-encoded)."""
+    encoded = quote(package, safe="")
+    return f"{NPM_DOWNLOADS_RANGE_BASE}/{period}/{encoded}"
+
+
+def sum_downloads_from_range_payload(payload: object) -> int:
+    """Sum daily ``downloads`` values from an npm ``/downloads/range/`` JSON body.
+
+    Raises:
+        ValueError: If the payload is not a well-formed range response.
+    """
+    if not isinstance(payload, dict):
+        msg = "npm API response must be a JSON object"
+        raise ValueError(msg)
+    if "error" in payload:
+        err = payload.get("error")
+        msg = f"npm API error: {err!s}"
+        raise ValueError(msg)
+    raw_rows = payload.get("downloads")
+    if not isinstance(raw_rows, list):
+        msg = "npm API response missing 'downloads' array"
+        raise ValueError(msg)
+    total = 0
+    for row in raw_rows:
+        if not isinstance(row, dict):
+            continue
+        n = row.get("downloads")
+        if isinstance(n, int):
+            total += n
+        elif isinstance(n, str) and n.isdigit():
+            total += int(n)
+    return total
+
+
+def fetch_last_week_downloads(
+    client: httpx.Client,
+    package: str,
+    *,
+    period: str = DEFAULT_PERIOD,
+) -> dict[str, Any]:
+    """GET npm range stats for ``package`` and return a small result object."""
+    url = _downloads_url(package, period)
+    response = client.get(url)
+    response.raise_for_status()
+    payload: object = response.json()
+    count = sum_downloads_from_range_payload(payload)
+    return {
+        "package": package,
+        "period": period,
+        "downloads": count,
+    }
+
+
+def collect_npm_weekly(
+    packages: tuple[str, ...],
+    *,
+    period: str = DEFAULT_PERIOD,
+    timeout: float = REQUEST_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Collect last-week download totals for all ``packages``."""
+    collected_at = datetime.now(UTC).replace(microsecond=0).isoformat()
+    results: dict[str, dict[str, Any]] = {}
+    with httpx.Client(timeout=timeout) as client:
+        for pkg in packages:
+            results[pkg] = fetch_last_week_downloads(client, pkg, period=period)
+    return {
+        "source": "npm_downloads_api",
+        "period": period,
+        "collected_at": collected_at,
+        "packages": results,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Collect last-week npm download counts for @asap-protocol/* packages."
+    )
+    parser.add_argument(
+        "--period",
+        default=DEFAULT_PERIOD,
+        help=f'Downloads range period (default: "{DEFAULT_PERIOD}")',
+    )
+    parser.add_argument(
+        "--package",
+        action="append",
+        dest="packages",
+        metavar="NAME",
+        help=("npm package name (repeatable). Defaults to @asap-protocol/client when omitted."),
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Write JSON to this path instead of stdout",
+    )
+    args = parser.parse_args(argv)
+    pkgs: tuple[str, ...] = tuple(args.packages) if args.packages else DEFAULT_PACKAGES
+
+    report = collect_npm_weekly(pkgs, period=args.period)
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/telemetry/collect_pypi.py
+++ b/scripts/telemetry/collect_pypi.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Fetch PyPI download aggregates for a package via `pypistats` (PyPI Stats public API).
+
+Mirrors ``pypistats recent <package>`` — **last_day**, **last_week**, **last_month** —
+and emits JSON for weekly aggregation.
+
+Requires the project optional extra ``telemetry`` (install: ``uv sync --extra telemetry``
+or ``uv sync --all-extras``).
+
+API: https://pypistats.org/api
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pypistats
+
+DEFAULT_PYPI_PACKAGE = "asap-protocol"
+_RECENT_KEYS = ("last_day", "last_week", "last_month")
+
+
+def normalize_recent_counts(data: object) -> dict[str, int]:
+    """Validate ``pypistats`` /recent ``data`` object and return integer counts.
+
+    Raises:
+        ValueError: If the payload is missing required keys or has invalid types.
+    """
+    if not isinstance(data, dict):
+        msg = "pypistats recent 'data' must be a JSON object"
+        raise ValueError(msg)
+    out: dict[str, int] = {}
+    for key in _RECENT_KEYS:
+        if key not in data:
+            msg = f"pypistats recent data missing key {key!r}"
+            raise ValueError(msg)
+        val = data[key]
+        if isinstance(val, bool) or not isinstance(val, int | float | str):
+            msg = f"pypistats recent {key!r} must be numeric"
+            raise ValueError(msg)
+        if isinstance(val, str):
+            stripped = val.replace(",", "").strip()
+            if not stripped.isdigit():
+                msg = f"pypistats recent {key!r} is not an integer string"
+                raise ValueError(msg)
+            out[key] = int(stripped)
+        else:
+            out[key] = int(val)
+    return out
+
+
+def fetch_pypi_recent(package: str) -> dict[str, Any]:
+    """Call ``pypistats.recent`` and return a minimal report dict for one package."""
+    raw = pypistats.recent(package, format="json")
+    if isinstance(raw, str) and not raw.strip().startswith("{"):
+        msg = f"pypistats API: {raw}"
+        raise ValueError(msg)
+    payload: object = json.loads(raw) if isinstance(raw, str) else raw
+    if not isinstance(payload, dict):
+        msg = "pypistats JSON response must be an object"
+        raise ValueError(msg)
+    name = payload.get("package")
+    if name != package:
+        msg = f"pypistats package mismatch: expected {package!r}, got {name!r}"
+        raise ValueError(msg)
+    counts = normalize_recent_counts(payload.get("data"))
+    return {
+        "package": package,
+        "downloads": counts,
+    }
+
+
+def collect_pypi_recent(
+    packages: tuple[str, ...],
+) -> dict[str, Any]:
+    """Collect recent download windows for each PyPI ``packages`` name."""
+    collected_at = datetime.now(UTC).replace(microsecond=0).isoformat()
+    results: dict[str, dict[str, Any]] = {}
+    for pkg in packages:
+        results[pkg] = fetch_pypi_recent(pkg)
+    return {
+        "source": "pypistats_recent",
+        "collected_at": collected_at,
+        "packages": results,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Collect PyPI download aggregates (pypistats recent) for telemetry."
+    )
+    parser.add_argument(
+        "--package",
+        action="append",
+        dest="packages",
+        metavar="NAME",
+        help=("PyPI project name (repeatable). Defaults to asap-protocol when omitted."),
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Write JSON to this path instead of stdout",
+    )
+    args = parser.parse_args(argv)
+    pkgs: tuple[str, ...] = tuple(args.packages) if args.packages else (DEFAULT_PYPI_PACKAGE,)
+
+    report = collect_pypi_recent(pkgs)
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/telemetry/collect_registry.py
+++ b/scripts/telemetry/collect_registry.py
@@ -23,6 +23,8 @@ from urllib.parse import urlparse
 
 import httpx
 
+from scripts.lib.safe_url import is_safe_http_url
+
 DEFAULT_REGISTRY_URL = (
     "https://raw.githubusercontent.com/adriannoes/asap-protocol/main/registry.json"
 )
@@ -55,18 +57,27 @@ def detect_registry_format(raw: object) -> str:
 
 
 def fetch_registry_json(url: str, client: httpx.Client | None = None) -> object:
-    """GET JSON from ``url`` (``http`` or ``https`` only)."""
+    """GET JSON from ``url`` (HTTPS only; SSRF-safe; redirects disabled)."""
     parsed = urlparse(url)
-    if parsed.scheme not in ("https", "http"):
-        msg = f"unsupported URL scheme for registry fetch: {parsed.scheme!r}"
+    if parsed.scheme != "https":
+        msg = "registry fetch requires https://"
+        raise ValueError(msg)
+    if not parsed.netloc:
+        msg = "registry URL must include a host"
+        raise ValueError(msg)
+    if not is_safe_http_url(url):
+        msg = f"blocked registry URL: {url}"
         raise ValueError(msg)
     close_client = client is None
     http = client or httpx.Client(
         timeout=REQUEST_TIMEOUT_SECONDS,
-        follow_redirects=True,
+        follow_redirects=False,
     )
     try:
         response = http.get(url)
+        if response.is_redirect:
+            msg = "registry URL must not redirect (use the final HTTPS URL)"
+            raise ValueError(msg)
         response.raise_for_status()
         return response.json()
     finally:

--- a/scripts/telemetry/collect_registry.py
+++ b/scripts/telemetry/collect_registry.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Count agents in the public `registry.json` mirror and optionally diff vs a prior snapshot.
+
+Loads the Lite Registry JSON (root ``agents`` array or a bare array of entries) from a
+HTTPS URL (default: GitHub raw mirror) or a local path, matching
+``jq '.agents | length'`` for the wrapped format.
+
+``--previous`` may point to either:
+
+- output from an earlier run of this script (uses ``agent_count``), or
+- a saved copy of ``registry.json`` (agents are counted the same way).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+DEFAULT_REGISTRY_URL = (
+    "https://raw.githubusercontent.com/adriannoes/asap-protocol/main/registry.json"
+)
+REQUEST_TIMEOUT_SECONDS = 30.0
+
+
+def count_registry_agents(raw: object) -> int:
+    """Return the number of agent entries (array root or ``.agents`` list).
+
+    Raises:
+        ValueError: If JSON root is not a supported registry shape.
+    """
+    if isinstance(raw, list):
+        return len(raw)
+    if isinstance(raw, dict):
+        agents = raw.get("agents")
+        if isinstance(agents, list):
+            return len(agents)
+    msg = "registry must be a JSON array or an object with an 'agents' array"
+    raise ValueError(msg)
+
+
+def detect_registry_format(raw: object) -> str:
+    """Return ``lite_registry`` or ``array`` for telemetry metadata."""
+    if isinstance(raw, list):
+        return "array"
+    if isinstance(raw, dict) and isinstance(raw.get("agents"), list):
+        return "lite_registry"
+    raise ValueError("unsupported registry shape")
+
+
+def fetch_registry_json(url: str, client: httpx.Client | None = None) -> object:
+    """GET JSON from ``url`` (``http`` or ``https`` only)."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("https", "http"):
+        msg = f"unsupported URL scheme for registry fetch: {parsed.scheme!r}"
+        raise ValueError(msg)
+    close_client = client is None
+    http = client or httpx.Client(
+        timeout=REQUEST_TIMEOUT_SECONDS,
+        follow_redirects=True,
+    )
+    try:
+        response = http.get(url)
+        response.raise_for_status()
+        return response.json()
+    finally:
+        if close_client:
+            http.close()
+
+
+def resolve_previous_agent_count(raw: object) -> int:
+    """Resolve count from prior telemetry JSON or a registry document."""
+    if isinstance(raw, dict):
+        previous = raw.get("agent_count")
+        if isinstance(previous, int):
+            return previous
+    return count_registry_agents(raw)
+
+
+def load_previous_count(path: Path) -> int:
+    """Load and resolve agent count from a previous snapshot file."""
+    prev_raw: object = json.loads(path.read_text(encoding="utf-8"))
+    return resolve_previous_agent_count(prev_raw)
+
+
+def collect_registry_snapshot(
+    raw: object,
+    *,
+    registry_ref: str,
+    previous_count: int | None,
+) -> dict[str, Any]:
+    """Build telemetry dict for one registry fetch."""
+    collected_at = datetime.now(UTC).replace(microsecond=0).isoformat()
+    count = count_registry_agents(raw)
+    fmt = detect_registry_format(raw)
+    growth: int | None = None if previous_count is None else count - previous_count
+    return {
+        "source": "registry_mirror",
+        "registry_ref": registry_ref,
+        "format": fmt,
+        "collected_at": collected_at,
+        "agent_count": count,
+        "previous_agent_count": previous_count,
+        "growth": growth,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Count agents in registry.json mirror and optionally diff vs a prior file."
+    )
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_REGISTRY_URL,
+        help="HTTPS URL of registry.json (ignored when --registry-path is set).",
+    )
+    parser.add_argument(
+        "--registry-path",
+        type=Path,
+        default=None,
+        help="Read registry JSON from this local path instead of --url.",
+    )
+    parser.add_argument(
+        "--previous",
+        type=Path,
+        default=None,
+        help=(
+            "Optional prior snapshot: earlier collector output (agent_count) or "
+            "saved registry.json."
+        ),
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Write JSON to this path instead of stdout",
+    )
+    args = parser.parse_args(argv)
+
+    previous_count: int | None = None
+    if args.previous is not None:
+        if not args.previous.is_file():
+            print(f"Previous snapshot not found: {args.previous}", file=sys.stderr)
+            return 1
+        try:
+            previous_count = load_previous_count(args.previous)
+        except (json.JSONDecodeError, ValueError, OSError) as exc:
+            print(f"Failed to read previous snapshot: {exc}", file=sys.stderr)
+            return 1
+
+    registry_ref: str
+    try:
+        if args.registry_path is not None:
+            if not args.registry_path.is_file():
+                print(f"Registry file not found: {args.registry_path}", file=sys.stderr)
+                return 1
+            registry_ref = str(args.registry_path.resolve())
+            raw: object = json.loads(args.registry_path.read_text(encoding="utf-8"))
+        else:
+            registry_ref = args.url
+            raw = fetch_registry_json(args.url)
+    except httpx.HTTPStatusError as exc:
+        print(
+            f"HTTP {exc.response.status_code} fetching registry: {exc.request.url!s}",
+            file=sys.stderr,
+        )
+        return 1
+    except (httpx.HTTPError, json.JSONDecodeError, ValueError, OSError) as exc:
+        print(f"Registry load failed: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        report = collect_registry_snapshot(
+            raw,
+            registry_ref=registry_ref,
+            previous_count=previous_count,
+        )
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_aggregate.py
+++ b/tests/scripts/test_aggregate.py
@@ -2,13 +2,37 @@
 
 from __future__ import annotations
 
+import json
+import socket
+from collections.abc import Iterator
 from datetime import date
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from scripts.telemetry import aggregate as aggregate_mod
+
+
+def _fake_public_getaddrinfo(
+    host: str,
+    port: object,
+    family: int = 0,
+    sock_type: int = 0,
+    proto: int = 0,
+    flags: int = 0,
+) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+    _ = (host, port, family, sock_type, proto, flags)
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+
+@pytest.fixture(autouse=True)
+def _patch_safe_url_dns() -> Iterator[None]:
+    """Keep URL-safety tests deterministic without real DNS lookups."""
+    with patch("scripts.lib.safe_url.socket.getaddrinfo", _fake_public_getaddrinfo):
+        yield
 
 
 def test_validate_snapshot_accepts_minimal_shape() -> None:
@@ -16,8 +40,11 @@ def test_validate_snapshot_accepts_minimal_shape() -> None:
         "snapshot_version": 1,
         "collected_at": "2026-05-16T12:00:00+00:00",
         "npm": {"@asap-protocol/client": 10},
-        "pypi": {"source": "x"},
-        "github": {"source": "github_rest_api"},
+        "pypi": {"packages": {}, "source": "stub"},
+        "github": {
+            "source": "github_rest_api",
+            "adapter_requests": {"by_framework": {}, "open_count": 0},
+        },
         "registry": {"agent_count": 1},
         "site": {"ctr_per_cta": {}},
         "adapter_requests": {},
@@ -35,6 +62,130 @@ def test_flatten_adapter_request_counts() -> None:
     out = aggregate_mod.flatten_adapter_request_counts(gh)
     assert out["mastra"] == 2
     assert out["_unparsed"] == 1
+
+
+def test_flatten_adapter_request_counts_skips_non_positive_unparsed() -> None:
+    gh: dict[str, Any] = {
+        "adapter_requests": {
+            "by_framework": {"acme": 1},
+            "unparsed_open_count": 0,
+        },
+    }
+    out = aggregate_mod.flatten_adapter_request_counts(gh)
+    assert out == {"acme": 1}
+    assert "_unparsed" not in out
+
+
+def test_flatten_adapter_request_counts_handles_missing_or_invalid_block() -> None:
+    assert aggregate_mod.flatten_adapter_request_counts({}) == {}
+    assert aggregate_mod.flatten_adapter_request_counts({"adapter_requests": "nope"}) == {}
+    gh: dict[str, Any] = {
+        "adapter_requests": {
+            "by_framework": "not-a-dict",
+            "unparsed_open_count": 3,
+        },
+    }
+    assert aggregate_mod.flatten_adapter_request_counts(gh) == {"_unparsed": 3}
+
+
+def test_build_npm_summary_filters_invalid_rows() -> None:
+    report: dict[str, Any] = {
+        "packages": {
+            "@a/good": {"downloads": 10},
+            "@b/bad-body": "x",
+            "@c/no-dl": {},
+            "not-dict": 1,
+        }
+    }
+    assert aggregate_mod.build_npm_summary(report) == {"@a/good": 10}
+    assert aggregate_mod.build_npm_summary({}) == {}
+    assert aggregate_mod.build_npm_summary({"packages": "no"}) == {}
+
+
+def test_list_snapshot_files_skips_latest_and_unmatched_names(tmp_path: Path) -> None:
+    (tmp_path / "snapshot-2026-05-01.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "snapshot-latest.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "snapshot-notadate.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "snapshot-2026-05-10.json").write_text("{}", encoding="utf-8")
+    rows = aggregate_mod.list_snapshot_files(tmp_path)
+    dates = [d for d, _ in rows]
+    assert dates == [date(2026, 5, 1), date(2026, 5, 10)]
+    assert all(p.is_absolute() for _, p in rows)
+
+
+def test_resolve_previous_snapshot_path() -> None:
+    base = Path("/tmp/ignored")
+    p1 = base / "a.json"
+    p2 = base / "b.json"
+    hist = [(date(2026, 5, 1), p1), (date(2026, 5, 8), p2)]
+    with patch.object(aggregate_mod, "list_snapshot_files", return_value=hist):
+        assert aggregate_mod.resolve_previous_snapshot_path(Path("."), date(2026, 5, 8)) == p1
+        assert aggregate_mod.resolve_previous_snapshot_path(Path("."), date(2026, 5, 1)) is None
+
+
+def test_registry_count_from_snapshot(tmp_path: Path) -> None:
+    good = tmp_path / "good.json"
+    good.write_text(
+        json.dumps({"registry": {"agent_count": 7}}),
+        encoding="utf-8",
+    )
+    assert aggregate_mod.registry_count_from_snapshot(good) == 7
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("{", encoding="utf-8")
+    assert aggregate_mod.registry_count_from_snapshot(bad_json) is None
+    odd = tmp_path / "odd.json"
+    odd.write_text(json.dumps({"registry": []}), encoding="utf-8")
+    assert aggregate_mod.registry_count_from_snapshot(odd) is None
+
+
+def test_fetch_site_ctr_success_and_degraded_payloads() -> None:
+    ok = httpx.Response(
+        200,
+        json={"site": {"ctr_per_cta": {"x": {"clicks": 1, "views": 10}}}},
+        request=httpx.Request("GET", "https://example.com/api/telemetry"),
+    )
+    mock_ok = MagicMock()
+    mock_ok.__enter__.return_value.get.return_value = ok
+    mock_ok.__exit__.return_value = None
+    with patch.object(aggregate_mod.httpx, "Client", return_value=mock_ok):
+        got = aggregate_mod.fetch_site_ctr("https://example.com/api/telemetry", "s")
+    assert got["ctr_per_cta"]["x"]["clicks"] == 1
+
+    bad_json = httpx.Response(
+        200,
+        content=b"not-json",
+        request=httpx.Request("GET", "https://example.com/api/telemetry"),
+    )
+    mock_bad = MagicMock()
+    mock_bad.__enter__.return_value.get.return_value = bad_json
+    mock_bad.__exit__.return_value = None
+    with patch.object(aggregate_mod.httpx, "Client", return_value=mock_bad):
+        degraded = aggregate_mod.fetch_site_ctr("https://example.com/api/telemetry", "s")
+    assert degraded.get("fetch_error") is True
+
+    not_dict = httpx.Response(
+        200,
+        json=["a"],
+        request=httpx.Request("GET", "https://example.com/api/telemetry"),
+    )
+    mock_nd = MagicMock()
+    mock_nd.__enter__.return_value.get.return_value = not_dict
+    mock_nd.__exit__.return_value = None
+    with patch.object(aggregate_mod.httpx, "Client", return_value=mock_nd):
+        degraded2 = aggregate_mod.fetch_site_ctr("https://example.com/api/telemetry", "s")
+    assert degraded2.get("fetch_error") is True
+
+    missing_site = httpx.Response(
+        200,
+        json={"foo": 1},
+        request=httpx.Request("GET", "https://example.com/api/telemetry"),
+    )
+    mock_ms = MagicMock()
+    mock_ms.__enter__.return_value.get.return_value = missing_site
+    mock_ms.__exit__.return_value = None
+    with patch.object(aggregate_mod.httpx, "Client", return_value=mock_ms):
+        degraded3 = aggregate_mod.fetch_site_ctr("https://example.com/api/telemetry", "s")
+    assert degraded3.get("fetch_error") is True
 
 
 def test_render_dashboard_adapter_section_sorted() -> None:
@@ -84,9 +235,152 @@ def test_main_writes_files(
     monkeypatch.setattr(aggregate_mod, "update_latest_symlink", lambda *_a, **_k: None)
 
     code = aggregate_mod.main(
-        ["--output-dir", str(tmp_path), "--date", "2026-05-16"],
+        [
+            "--output-dir",
+            str(tmp_path),
+            "--date",
+            "2026-05-16",
+            "--allow-github-skip",
+        ],
     )
     assert code == 0
     written = (tmp_path / "snapshot-2026-05-16.json").read_text(encoding="utf-8")
     assert "adapter_requests" in written
     assert (tmp_path / "dashboard.md").is_file()
+
+
+def test_validate_site_endpoint_requires_https() -> None:
+    with pytest.raises(ValueError, match="https"):
+        aggregate_mod.validate_site_endpoint("http://example.com/api/telemetry")
+    with pytest.raises(ValueError, match="host"):
+        aggregate_mod.validate_site_endpoint("https://")
+
+
+def test_validate_site_endpoint_blocks_private_and_metadata_hosts() -> None:
+    with pytest.raises(ValueError, match="public HTTPS URL"):
+        aggregate_mod.validate_site_endpoint("https://localhost/api/telemetry")
+    with pytest.raises(ValueError, match="public HTTPS URL"):
+        aggregate_mod.validate_site_endpoint("https://169.254.169.254/latest/meta-data/")
+
+
+def test_fetch_site_ctr_rejects_redirect() -> None:
+    req = httpx.Request("GET", "https://example.com/api/telemetry")
+    redirect = httpx.Response(302, headers={"Location": "https://other.example/"}, request=req)
+    mock_client = MagicMock()
+    mock_client.__enter__.return_value.get.return_value = redirect
+    mock_client.__exit__.return_value = None
+    with (
+        patch.object(aggregate_mod.httpx, "Client", return_value=mock_client),
+        pytest.raises(ValueError, match="redirect"),
+    ):
+        aggregate_mod.fetch_site_ctr("https://example.com/api/telemetry", "secret")
+
+
+def test_strict_missing_github_token_exits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TELEMETRY_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(
+        aggregate_mod,
+        "collect_npm_weekly",
+        lambda *_a, **_k: {"packages": {"@asap-protocol/client": {"downloads": 1}}},
+    )
+    monkeypatch.setattr(
+        aggregate_mod,
+        "collect_pypi_recent",
+        lambda *_a, **_k: {"packages": {}, "source": "stub"},
+    )
+    rc = aggregate_mod.main(["--output-dir", str(tmp_path), "--date", "2026-05-16"])
+    assert rc == 1
+
+
+def test_strict_github_http_error_is_fatal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEMETRY_GITHUB_TOKEN", "tok")
+
+    def _stub_npm(*_a: object, **_k: object) -> dict[str, Any]:
+        return {"packages": {"@asap-protocol/client": {"downloads": 1}}}
+
+    def _stub_pypi(*_a: object, **_k: object) -> dict[str, Any]:
+        return {"packages": {}, "source": "stub"}
+
+    def _boom(
+        _owner: str,
+        _repo: str,
+        *,
+        token: str,
+        client: httpx.Client | None = None,
+    ) -> dict[str, Any]:
+        assert token == "tok"
+        req = httpx.Request("GET", "https://api.github.com/repos/o/r")
+        resp = httpx.Response(403, request=req)
+        raise httpx.HTTPStatusError("Forbidden", request=req, response=resp)
+
+    monkeypatch.setattr(aggregate_mod, "collect_npm_weekly", _stub_npm)
+    monkeypatch.setattr(aggregate_mod, "collect_pypi_recent", _stub_pypi)
+    monkeypatch.setattr(aggregate_mod, "collect_github_signals", _boom)
+    rc = aggregate_mod.main(["--output-dir", str(tmp_path), "--date", "2026-05-16"])
+    assert rc == 1
+
+
+def test_allow_github_skip_survives_github_http_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TELEMETRY_GITHUB_TOKEN", "tok")
+
+    monkeypatch.setattr(
+        aggregate_mod,
+        "collect_npm_weekly",
+        lambda *_a, **_k: {"packages": {"@asap-protocol/client": {"downloads": 1}}},
+    )
+    monkeypatch.setattr(
+        aggregate_mod,
+        "collect_pypi_recent",
+        lambda *_a, **_k: {"packages": {}, "source": "stub"},
+    )
+
+    def _boom(
+        _owner: str,
+        _repo: str,
+        *,
+        token: str,
+        client: httpx.Client | None = None,
+    ) -> dict[str, Any]:
+        assert token == "tok"
+        req = httpx.Request("GET", "https://api.github.com/")
+        resp = httpx.Response(403, request=req)
+        raise httpx.HTTPStatusError("Forbidden", request=req, response=resp)
+
+    monkeypatch.setattr(aggregate_mod, "collect_github_signals", _boom)
+
+    def _fake_fetch(_url: str) -> dict[str, Any]:
+        return {"agents": [{"id": "a"}]}
+
+    monkeypatch.setattr(aggregate_mod, "fetch_registry_json", _fake_fetch)
+    monkeypatch.setattr(aggregate_mod, "update_latest_symlink", lambda *_a, **_k: None)
+
+    rc = aggregate_mod.main(
+        [
+            "--output-dir",
+            str(tmp_path),
+            "--date",
+            "2026-05-16",
+            "--allow-github-skip",
+        ],
+    )
+    assert rc == 0
+    snap_path = tmp_path / "snapshot-2026-05-16.json"
+    text = snap_path.read_text(encoding="utf-8")
+    assert '"skipped": true' in text
+    assert "Forbidden" not in text
+    assert "https://api.github.com" not in text
+    assert "GitHub telemetry failed; see CI logs." in text
+
+
+def test_render_dashboard_includes_data_quality_warnings() -> None:
+    snap: dict[str, Any] = {
+        "adapter_requests": {},
+        "github": {"skipped": True, "reason": "403 Forbidden"},
+        "site": {"ctr_per_cta": {}, "fetch_error": True},
+    }
+    md = aggregate_mod.render_dashboard(snap, [], weeks=12)
+    assert "## Data quality warnings" in md

--- a/tests/scripts/test_aggregate.py
+++ b/tests/scripts/test_aggregate.py
@@ -1,0 +1,92 @@
+"""Tests for scripts/telemetry/aggregate.py."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.telemetry import aggregate as aggregate_mod
+
+
+def test_validate_snapshot_accepts_minimal_shape() -> None:
+    sample: dict[str, Any] = {
+        "snapshot_version": 1,
+        "collected_at": "2026-05-16T12:00:00+00:00",
+        "npm": {"@asap-protocol/client": 10},
+        "pypi": {"source": "x"},
+        "github": {"source": "github_rest_api"},
+        "registry": {"agent_count": 1},
+        "site": {"ctr_per_cta": {}},
+        "adapter_requests": {},
+    }
+    aggregate_mod.validate_snapshot(sample)
+
+
+def test_flatten_adapter_request_counts() -> None:
+    gh: dict[str, Any] = {
+        "adapter_requests": {
+            "by_framework": {"mastra": 2, "langgraph": 1},
+            "unparsed_open_count": 1,
+        },
+    }
+    out = aggregate_mod.flatten_adapter_request_counts(gh)
+    assert out["mastra"] == 2
+    assert out["_unparsed"] == 1
+
+
+def test_render_dashboard_adapter_section_sorted() -> None:
+    snap: dict[str, Any] = {
+        "adapter_requests": {"mastra": 2, "x": 5, "_unparsed": 1},
+    }
+    hist = [(date(2026, 5, 16), Path("snapshot-2026-05-16.json"))]
+    md = aggregate_mod.render_dashboard(snap, hist, weeks=12)
+    assert "## Adapter requests" in md
+    # x has higher count than mastra; _unparsed last
+    x_pos = md.index("| `x` |")
+    m_pos = md.index("| `mastra` |")
+    u_pos = md.index("| `_unparsed` |")
+    assert x_pos < m_pos < u_pos
+
+
+def test_main_writes_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        aggregate_mod,
+        "collect_npm_weekly",
+        lambda *_a, **_k: {
+            "packages": {"@asap-protocol/client": {"downloads": 42}},
+        },
+    )
+    monkeypatch.setattr(
+        aggregate_mod,
+        "collect_pypi_recent",
+        lambda *_a, **_k: {"packages": {}, "source": "stub"},
+    )
+    monkeypatch.setattr(
+        aggregate_mod,
+        "collect_github_or_placeholder",
+        lambda *_a, **_k: {
+            "source": "github_rest_api",
+            "adapter_requests": {"by_framework": {"acme": 1}, "open_count": 1},
+            "repo": {"stargazers_count": 3},
+        },
+    )
+
+    def _fake_fetch(_url: str) -> dict[str, Any]:
+        return {"agents": [{"id": "a"}]}
+
+    monkeypatch.setattr(aggregate_mod, "fetch_registry_json", _fake_fetch)
+    monkeypatch.setattr(aggregate_mod, "update_latest_symlink", lambda *_a, **_k: None)
+
+    code = aggregate_mod.main(
+        ["--output-dir", str(tmp_path), "--date", "2026-05-16"],
+    )
+    assert code == 0
+    written = (tmp_path / "snapshot-2026-05-16.json").read_text(encoding="utf-8")
+    assert "adapter_requests" in written
+    assert (tmp_path / "dashboard.md").is_file()

--- a/tests/scripts/test_collect_github.py
+++ b/tests/scripts/test_collect_github.py
@@ -1,0 +1,168 @@
+"""Tests for scripts/telemetry/collect_github.py."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from scripts.telemetry.collect_github import (
+    collect_github_signals,
+    fetch_popular_referrers,
+    fetch_repo_summary,
+    fetch_traffic_clones,
+    main,
+    parse_framework_from_issue_body,
+    slug_framework_label,
+    summarize_adapter_requests,
+)
+
+
+def _json_response(data: object, status: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status,
+        json=data,
+        request=httpx.Request("GET", "https://api.github.com/test"),
+    )
+
+
+class TestFetchRepoSummary:
+    def test_parses_counts(self) -> None:
+        payload = {
+            "stargazers_count": 10,
+            "forks_count": 3,
+            "open_issues_count": 2,
+            "watchers_count": 10,
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/repos/o/r"
+            return _json_response(payload)
+
+        transport = httpx.MockTransport(handler)
+        with httpx.Client(base_url="https://api.github.com", transport=transport) as client:
+            out = fetch_repo_summary(client, "o", "r")
+        assert out == payload
+
+    def test_raises_on_invalid_shape(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return _json_response({"stargazers_count": "x"})
+
+        transport = httpx.MockTransport(handler)
+        with (
+            httpx.Client(base_url="https://api.github.com", transport=transport) as client,
+            pytest.raises(ValueError, match="stargazers_count"),
+        ):
+            fetch_repo_summary(client, "o", "r")
+
+
+class TestFetchTrafficClones:
+    def test_parses_clone_payload(self) -> None:
+        payload = {
+            "count": 100,
+            "uniques": 40,
+            "clones": [{"timestamp": "2026-05-10T00:00:00Z", "count": 5, "uniques": 3}],
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/repos/o/r/traffic/clones"
+            return _json_response(payload)
+
+        transport = httpx.MockTransport(handler)
+        with httpx.Client(base_url="https://api.github.com", transport=transport) as client:
+            out = fetch_traffic_clones(client, "o", "r")
+        assert out["count"] == 100
+        assert out["uniques"] == 40
+        assert len(out["clones"]) == 1
+
+
+class TestFetchPopularReferrers:
+    def test_filters_well_formed_rows(self) -> None:
+        payload: list[dict[str, Any]] = [
+            {"referrer": "Google", "views": 9, "uniques": 4},
+            {"bad": True},
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/repos/o/r/traffic/popular/referrers"
+            return _json_response(payload)
+
+        transport = httpx.MockTransport(handler)
+        with httpx.Client(base_url="https://api.github.com", transport=transport) as client:
+            out = fetch_popular_referrers(client, "o", "r")
+        assert out == [{"referrer": "Google", "views": 9, "uniques": 4}]
+
+
+class TestCollectGithubSignals:
+    def test_joins_all_endpoints(self) -> None:
+        repo_payload = {
+            "stargazers_count": 1,
+            "forks_count": 2,
+            "open_issues_count": 3,
+            "watchers_count": 1,
+        }
+        clone_payload = {"count": 7, "uniques": 5, "clones": []}
+        ref_payload = [{"referrer": "X", "views": 1, "uniques": 1}]
+        issues_payload: list[dict[str, Any]] = [
+            {
+                "number": 1,
+                "title": "Add Mastra",
+                "body": "### Framework name\n\nMastra\n",
+            },
+        ]
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path == "/repos/acme/widget":
+                return _json_response(repo_payload)
+            if path == "/repos/acme/widget/traffic/clones":
+                return _json_response(clone_payload)
+            if path == "/repos/acme/widget/traffic/popular/referrers":
+                return _json_response(ref_payload)
+            if path == "/repos/acme/widget/issues":
+                return _json_response(issues_payload)
+            return _json_response({"message": "unexpected"}, status=404)
+
+        transport = httpx.MockTransport(handler)
+        with httpx.Client(base_url="https://api.github.com", transport=transport) as client:
+            report = collect_github_signals("acme", "widget", token="", client=client)
+        assert report["source"] == "github_rest_api"
+        assert report["repository"] == "acme/widget"
+        assert report["repo"] == repo_payload
+        assert report["traffic_clones"]["count"] == 7
+        assert report["traffic_referrers"] == ref_payload
+        assert report["adapter_requests"]["by_framework"]["mastra"] == 1
+
+
+class TestAdapterRequestParsing:
+    def test_parse_framework_heading(self) -> None:
+        body = "### Framework name\n\nOpenAI Agents SDK\n\n### Use case\n\ndemo"
+        assert parse_framework_from_issue_body(body) == "OpenAI Agents SDK"
+
+    def test_parse_framework_line(self) -> None:
+        body = "Some intro\n\nFramework: LangGraph\n"
+        assert parse_framework_from_issue_body(body) == "LangGraph"
+
+    def test_slug_framework_label(self) -> None:
+        assert slug_framework_label("OpenAI Agents SDK") == "openai-agents-sdk"
+
+    def test_summarize_groups_and_unparsed(self) -> None:
+        issues: list[dict[str, Any]] = [
+            {"body": "### Framework\n\nMastra"},
+            {"body": "no framework here"},
+            {"body": "Framework: mastra"},
+        ]
+        summary = summarize_adapter_requests(issues)
+        assert summary["open_count"] == 3
+        assert summary["by_framework"]["mastra"] == 2
+        assert summary["unparsed_open_count"] == 1
+
+
+class TestCollectGithubMain:
+    def test_main_rejects_missing_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        assert main(["--owner", "a", "--repo", "b"]) == 1

--- a/tests/scripts/test_collect_npm.py
+++ b/tests/scripts/test_collect_npm.py
@@ -1,0 +1,117 @@
+"""Tests for scripts/telemetry/collect_npm.py."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from scripts.telemetry.collect_npm import (
+    _downloads_url,
+    collect_npm_weekly,
+    fetch_last_week_downloads,
+    sum_downloads_from_range_payload,
+)
+
+
+class TestDownloadsUrl:
+    def test_encodes_scoped_package(self) -> None:
+        assert _downloads_url("@asap-protocol/client", "last-week") == (
+            "https://api.npmjs.org/downloads/range/last-week/%40asap-protocol%2Fclient"
+        )
+
+
+class TestSumDownloadsFromRangePayload:
+    def test_sums_daily_rows(self) -> None:
+        payload = {
+            "downloads": [
+                {"day": "2026-05-10", "downloads": 10},
+                {"day": "2026-05-11", "downloads": 5},
+            ]
+        }
+        assert sum_downloads_from_range_payload(payload) == 15
+
+    def test_rejects_non_object(self) -> None:
+        with pytest.raises(ValueError, match="JSON object"):
+            sum_downloads_from_range_payload([])
+
+    def test_rejects_api_error_field(self) -> None:
+        with pytest.raises(ValueError, match="not found"):
+            sum_downloads_from_range_payload({"error": "not found"})
+
+    def test_rejects_missing_downloads(self) -> None:
+        with pytest.raises(ValueError, match="downloads"):
+            sum_downloads_from_range_payload({"start": "x"})
+
+
+class TestFetchLastWeekDownloads:
+    def test_parses_success_body(self) -> None:
+        body = {
+            "downloads": [
+                {"day": "2026-05-10", "downloads": 3},
+                {"day": "2026-05-11", "downloads": 7},
+            ]
+        }
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = body
+        mock_resp.raise_for_status = MagicMock()
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_resp
+
+        out = fetch_last_week_downloads(mock_client, "@asap-protocol/client")
+        assert out["package"] == "@asap-protocol/client"
+        assert out["period"] == "last-week"
+        assert out["downloads"] == 10
+        mock_client.get.assert_called_once()
+        called_url = mock_client.get.call_args[0][0]
+        assert "%40asap-protocol%2Fclient" in called_url
+
+    def test_propagates_http_errors(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404",
+            request=MagicMock(),
+            response=MagicMock(),
+        )
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_resp
+        with pytest.raises(httpx.HTTPStatusError):
+            fetch_last_week_downloads(mock_client, "@asap-protocol/client")
+
+
+class TestCollectNpmWeekly:
+    @patch("scripts.telemetry.collect_npm.httpx.Client")
+    def test_collects_multiple_packages(self, mock_client_cls: MagicMock) -> None:
+        def _response_for_url(url: str) -> MagicMock:
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            if "foo" in url:
+                mock_resp.json.return_value = {"downloads": [{"day": "2026-05-10", "downloads": 2}]}
+            else:
+                mock_resp.json.return_value = {
+                    "downloads": [{"day": "2026-05-10", "downloads": 40}]
+                }
+            return mock_resp
+
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.__exit__.return_value = None
+        mock_client.get.side_effect = lambda url: _response_for_url(url)
+        mock_client_cls.return_value = mock_client
+
+        report = collect_npm_weekly(
+            ("@asap-protocol/client", "@asap-protocol/foo"),
+            period="last-week",
+        )
+        assert report["source"] == "npm_downloads_api"
+        assert report["period"] == "last-week"
+        assert "collected_at" in report
+        pkgs = report["packages"]
+        assert pkgs["@asap-protocol/client"]["downloads"] == 40
+        assert pkgs["@asap-protocol/foo"]["downloads"] == 2
+
+        assert mock_client.get.call_count == 2
+        raw = json.dumps(report)
+        assert '"@asap-protocol/client"' in raw

--- a/tests/scripts/test_collect_pypi.py
+++ b/tests/scripts/test_collect_pypi.py
@@ -1,0 +1,92 @@
+"""Tests for scripts/telemetry/collect_pypi.py."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from scripts.telemetry.collect_pypi import (
+    collect_pypi_recent,
+    fetch_pypi_recent,
+    normalize_recent_counts,
+)
+
+
+class TestNormalizeRecentCounts:
+    def test_parses_ints(self) -> None:
+        data = {"last_day": 1, "last_week": 10, "last_month": 100}
+        assert normalize_recent_counts(data) == data
+
+    def test_parses_numeric_strings(self) -> None:
+        data = {"last_day": "5", "last_week": "50", "last_month": "500"}
+        assert normalize_recent_counts(data) == {
+            "last_day": 5,
+            "last_week": 50,
+            "last_month": 500,
+        }
+
+    def test_rejects_missing_key(self) -> None:
+        with pytest.raises(ValueError, match="last_week"):
+            normalize_recent_counts({"last_day": 1, "last_month": 2})
+
+    def test_rejects_non_object(self) -> None:
+        with pytest.raises(ValueError, match="JSON object"):
+            normalize_recent_counts([])
+
+
+class TestFetchPypiRecent:
+    @patch("scripts.telemetry.collect_pypi.pypistats.recent")
+    def test_parses_json_envelope(
+        self,
+        mock_recent: object,
+    ) -> None:
+        mock_recent.return_value = json.dumps(
+            {
+                "package": "asap-protocol",
+                "data": {"last_day": 2, "last_week": 20, "last_month": 200},
+            }
+        )
+        out = fetch_pypi_recent("asap-protocol")
+        assert out["package"] == "asap-protocol"
+        assert out["downloads"] == {
+            "last_day": 2,
+            "last_week": 20,
+            "last_month": 200,
+        }
+
+    @patch("scripts.telemetry.collect_pypi.pypistats.recent")
+    def test_raises_on_no_data_message(self, mock_recent: object) -> None:
+        mock_recent.return_value = "No data found for https://pypi.org/project/x/"
+        with pytest.raises(ValueError, match="pypistats API"):
+            fetch_pypi_recent("x")
+
+    @patch("scripts.telemetry.collect_pypi.pypistats.recent")
+    def test_raises_on_package_mismatch(self, mock_recent: object) -> None:
+        mock_recent.return_value = json.dumps(
+            {"package": "other", "data": {"last_day": 1, "last_week": 2, "last_month": 3}}
+        )
+        with pytest.raises(ValueError, match="mismatch"):
+            fetch_pypi_recent("asap-protocol")
+
+
+class TestCollectPypiRecent:
+    @patch("scripts.telemetry.collect_pypi.pypistats.recent")
+    def test_collects_multiple_packages(self, mock_recent: object) -> None:
+        def _side_effect(pkg: str, **_kwargs: object) -> str:
+            if pkg == "asap-protocol":
+                counts = {"last_day": 1, "last_week": 10, "last_month": 100}
+            else:
+                counts = {"last_day": 0, "last_week": 3, "last_month": 30}
+            return json.dumps({"package": pkg, "data": counts})
+
+        mock_recent.side_effect = _side_effect
+
+        report = collect_pypi_recent(("asap-protocol", "asap-cli"))
+        assert report["source"] == "pypistats_recent"
+        assert "collected_at" in report
+        pkgs = report["packages"]
+        assert pkgs["asap-protocol"]["downloads"]["last_week"] == 10
+        assert pkgs["asap-cli"]["downloads"]["last_week"] == 3
+        assert mock_recent.call_count == 2

--- a/tests/scripts/test_collect_registry.py
+++ b/tests/scripts/test_collect_registry.py
@@ -57,9 +57,37 @@ class TestLoadPreviousCount:
 
 
 class TestFetchRegistryJson:
-    def test_https_only(self) -> None:
-        with pytest.raises(ValueError, match="scheme"):
+    def test_rejects_non_https_scheme(self) -> None:
+        with pytest.raises(ValueError, match="https"):
             fetch_registry_json("file:///etc/passwd")
+
+    def test_rejects_http_scheme(self) -> None:
+        with pytest.raises(ValueError, match="https"):
+            fetch_registry_json("http://example.com/registry.json")
+
+    def test_rejects_missing_host(self) -> None:
+        with pytest.raises(ValueError, match="host"):
+            fetch_registry_json("https:///registry.json")
+
+    def test_rejects_localhost(self) -> None:
+        with pytest.raises(ValueError, match="blocked"):
+            fetch_registry_json("https://localhost/registry.json")
+
+    def test_rejects_redirect_response(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.host == "example.com"
+            return httpx.Response(
+                302,
+                headers={"Location": "https://example.com/foo"},
+                request=request,
+            )
+
+        transport = httpx.MockTransport(handler)
+        with (
+            httpx.Client(transport=transport) as client,
+            pytest.raises(ValueError, match="redirect"),
+        ):
+            fetch_registry_json("https://example.com/registry.json", client=client)
 
     def test_gets_json(self) -> None:
         payload: dict[str, object] = {"agents": []}
@@ -133,4 +161,42 @@ class TestMainCli:
                 str(tmp_path / "nope.json"),
             ]
         )
+        assert rc == 1
+
+    def test_invalid_previous_json_errors(self, tmp_path: Path) -> None:
+        reg = tmp_path / "registry.json"
+        reg.write_text(json.dumps({"agents": []}), encoding="utf-8")
+        prev = tmp_path / "bad-prev.json"
+        prev.write_text("{", encoding="utf-8")
+        rc = main(
+            [
+                "--registry-path",
+                str(reg),
+                "--previous",
+                str(prev),
+            ]
+        )
+        assert rc == 1
+
+    def test_missing_registry_path_errors(self, tmp_path: Path) -> None:
+        rc = main(
+            [
+                "--registry-path",
+                str(tmp_path / "missing.json"),
+            ]
+        )
+        assert rc == 1
+
+    def test_http_status_error_from_url_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(url: str, client: httpx.Client | None = None) -> object:
+            _ = (url, client)
+            req = httpx.Request("GET", "https://example.com/registry.json")
+            resp = httpx.Response(500, request=req)
+            raise httpx.HTTPStatusError("server error", request=req, response=resp)
+
+        monkeypatch.setattr(
+            "scripts.telemetry.collect_registry.fetch_registry_json",
+            _boom,
+        )
+        rc = main(["--url", "https://example.com/registry.json"])
         assert rc == 1

--- a/tests/scripts/test_collect_registry.py
+++ b/tests/scripts/test_collect_registry.py
@@ -1,0 +1,136 @@
+"""Tests for scripts/telemetry/collect_registry.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from scripts.telemetry.collect_registry import (
+    collect_registry_snapshot,
+    count_registry_agents,
+    detect_registry_format,
+    fetch_registry_json,
+    load_previous_count,
+    main,
+    resolve_previous_agent_count,
+)
+
+
+class TestCountRegistryAgents:
+    def test_counts_lite_registry(self) -> None:
+        raw = {"version": "1", "agents": [{"id": "a"}, {"id": "b"}]}
+        assert count_registry_agents(raw) == 2
+
+    def test_counts_array_root(self) -> None:
+        assert count_registry_agents([{"id": "x"}]) == 1
+
+    def test_rejects_bad_root(self) -> None:
+        with pytest.raises(ValueError, match="array"):
+            count_registry_agents({"no_agents": []})
+
+
+class TestDetectRegistryFormat:
+    def test_lite_registry(self) -> None:
+        assert detect_registry_format({"agents": []}) == "lite_registry"
+
+    def test_array(self) -> None:
+        assert detect_registry_format([]) == "array"
+
+
+class TestResolvePreviousAgentCount:
+    def test_from_telemetry_json(self) -> None:
+        assert resolve_previous_agent_count({"agent_count": 42}) == 42
+
+    def test_from_registry_wrapper(self) -> None:
+        raw = {"agents": [{"id": "1"}, {"id": "2"}]}
+        assert resolve_previous_agent_count(raw) == 2
+
+
+class TestLoadPreviousCount:
+    def test_reads_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "prev.json"
+        p.write_text(json.dumps({"agent_count": 5}), encoding="utf-8")
+        assert load_previous_count(p) == 5
+
+
+class TestFetchRegistryJson:
+    def test_https_only(self) -> None:
+        with pytest.raises(ValueError, match="scheme"):
+            fetch_registry_json("file:///etc/passwd")
+
+    def test_gets_json(self) -> None:
+        payload: dict[str, object] = {"agents": []}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.host == "example.com"
+            return httpx.Response(200, json=payload)
+
+        transport = httpx.MockTransport(handler)
+        with httpx.Client(transport=transport) as client:
+            out = fetch_registry_json("https://example.com/registry.json", client=client)
+        assert out == payload
+
+
+class TestCollectRegistrySnapshot:
+    def test_growth_when_previous_set(self) -> None:
+        raw: dict[str, object] = {"agents": [{}] * 4}
+        report = collect_registry_snapshot(
+            raw,
+            registry_ref="https://example/r.json",
+            previous_count=2,
+        )
+        assert report["agent_count"] == 4
+        assert report["growth"] == 2
+        assert report["previous_agent_count"] == 2
+
+    def test_growth_none_without_previous(self) -> None:
+        raw: dict[str, object] = {"agents": [{}]}
+        report = collect_registry_snapshot(
+            raw,
+            registry_ref="local",
+            previous_count=None,
+        )
+        assert report["growth"] is None
+        assert report["previous_agent_count"] is None
+
+
+class TestMainCli:
+    def test_local_registry_and_previous(self, tmp_path: Path) -> None:
+        reg = tmp_path / "registry.json"
+        reg.write_text(
+            json.dumps({"agents": [{"id": "a"}, {"id": "b"}]}),
+            encoding="utf-8",
+        )
+        prev = tmp_path / "prev.json"
+        prev.write_text(json.dumps({"agent_count": 1}), encoding="utf-8")
+        out = tmp_path / "out.json"
+        rc = main(
+            [
+                "--registry-path",
+                str(reg),
+                "--previous",
+                str(prev),
+                "-o",
+                str(out),
+            ]
+        )
+        assert rc == 0
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data["agent_count"] == 2
+        assert data["growth"] == 1
+
+    def test_missing_previous_errors(self, tmp_path: Path) -> None:
+        reg = tmp_path / "registry.json"
+        reg.write_text(json.dumps({"agents": []}), encoding="utf-8")
+        rc = main(
+            [
+                "--registry-path",
+                str(reg),
+                "--previous",
+                str(tmp_path / "nope.json"),
+            ]
+        )
+        assert rc == 1

--- a/tests/scripts/test_process_registration.py
+++ b/tests/scripts/test_process_registration.py
@@ -191,7 +191,7 @@ class TestProcessRegistrationRun:
     @pytest.fixture(autouse=True)
     def _patch_dns(self) -> None:
         """Mock getaddrinfo so test URLs resolve to public IP."""
-        with patch("scripts.process_registration.socket.getaddrinfo", _fake_getaddrinfo_public):
+        with patch("scripts.lib.safe_url.socket.getaddrinfo", _fake_getaddrinfo_public):
             yield
 
     def test_valid_issue_writes_registry_and_valid_result(

--- a/tests/scripts/test_safe_url.py
+++ b/tests/scripts/test_safe_url.py
@@ -1,0 +1,79 @@
+"""Tests for scripts.lib.safe_url."""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+from scripts.lib.safe_url import is_safe_http_url
+
+
+def _fake_public_getaddrinfo(
+    host: str,
+    port: object,
+    family: int = 0,
+    sock_type: int = 0,
+    proto: int = 0,
+    flags: int = 0,
+) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+    _ = (host, port, family, sock_type, proto, flags)
+    return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+
+class TestIsSafeHttpUrl:
+    def test_allows_http_for_issueops_compatible_urls(self) -> None:
+        """IssueOps may fetch HTTP manifests; SSRF checks target host/IP, not TLS."""
+        with patch("scripts.lib.safe_url.socket.getaddrinfo", _fake_public_getaddrinfo):
+            assert is_safe_http_url("http://example.com/path") is True
+
+    def test_blocks_localhost_hostname(self) -> None:
+        assert is_safe_http_url("https://localhost/registry.json") is False
+
+    def test_blocks_metadata_ip(self) -> None:
+        assert is_safe_http_url("https://169.254.169.254/latest/meta-data/") is False
+
+    @patch("scripts.lib.safe_url.socket.getaddrinfo", _fake_public_getaddrinfo)
+    def test_allows_https_public_example(self) -> None:
+        assert is_safe_http_url("https://example.com/registry.json") is True
+
+    def test_blocks_non_http_scheme(self) -> None:
+        with patch("scripts.lib.safe_url.socket.getaddrinfo", _fake_public_getaddrinfo):
+            assert is_safe_http_url("ftp://example.com/file") is False
+
+    def test_blocks_literal_private_ip_hostname(self) -> None:
+        assert is_safe_http_url("https://10.0.0.1/") is False
+
+    def test_public_ip_hostname_uses_dns_resolution_path(self) -> None:
+        """Literal public IPs skip blocked-host set but still resolve via getaddrinfo."""
+        with patch("scripts.lib.safe_url.socket.getaddrinfo", _fake_public_getaddrinfo):
+            assert is_safe_http_url("https://93.184.216.34/path") is True
+
+    def test_blocks_when_dns_resolves_to_private_ip(self) -> None:
+        def _private(
+            host: str,
+            port: object,
+            family: int = 0,
+            sock_type: int = 0,
+            proto: int = 0,
+            flags: int = 0,
+        ) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+            _ = (host, port, family, sock_type, proto, flags)
+            return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("192.168.1.10", 0))]
+
+        with patch("scripts.lib.safe_url.socket.getaddrinfo", _private):
+            assert is_safe_http_url("https://example.com/") is False
+
+    def test_blocks_when_dns_resolution_fails(self) -> None:
+        def _fail(
+            host: str,
+            port: object,
+            family: int = 0,
+            sock_type: int = 0,
+            proto: int = 0,
+            flags: int = 0,
+        ) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+            _ = (host, port, family, sock_type, proto, flags)
+            raise socket.gaierror("nxdomain")
+
+        with patch("scripts.lib.safe_url.socket.getaddrinfo", _fail):
+            assert is_safe_http_url("https://example.com/") is False

--- a/uv.lock
+++ b/uv.lock
@@ -288,6 +288,9 @@ redis = [
 smolagents = [
     { name = "smolagents" },
 ]
+telemetry = [
+    { name = "pypistats" },
+]
 webauthn = [
     { name = "webauthn" },
 ]
@@ -337,6 +340,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5,<3" },
     { name = "pydantic-ai", marker = "extra == 'pydanticai'", specifier = ">=0.2" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21" },
+    { name = "pypistats", marker = "extra == 'telemetry'", specifier = ">=1.11.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.1" },
@@ -355,7 +359,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=12.0" },
     { name = "zeroconf", marker = "extra == 'dns-sd'", specifier = ">=0.80" },
 ]
-provides-extras = ["dev", "docs", "dns-sd", "redis", "webauthn", "mcp", "langchain", "crewai", "llamaindex", "smolagents", "pydanticai", "openclaw", "openapi"]
+provides-extras = ["dev", "docs", "dns-sd", "redis", "webauthn", "mcp", "langchain", "crewai", "llamaindex", "smolagents", "pydanticai", "openclaw", "openapi", "telemetry"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -757,6 +761,15 @@ wheels = [
 ]
 
 [[package]]
+name = "chardet"
+version = "6.0.0.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/42/fb9436c103a881a377e34b9f58d77b5f503461c702ff654ebe86151bcfe9/chardet-6.0.0.post1.tar.gz", hash = "sha256:6b78048c3c97c7b2ed1fbad7a18f76f5a6547f7d34dbab536cc13887c9a92fa4", size = 12521798, upload-time = "2026-02-22T15:09:17.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/42/5de54f632c2de53cd3415b3703383d5fff43a94cbc0567ef362515261a21/chardet-6.0.0.post1-py3-none-any.whl", hash = "sha256:c894a36800549adf7bb5f2af47033281b75fdfcd2aa0f0243be0ad22a52e2dcb", size = 627245, upload-time = "2026-02-22T15:09:15.876Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1081,6 +1094,19 @@ wheels = [
 ]
 
 [[package]]
+name = "dataproperty"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mbstrdecoder" },
+    { name = "typepy", extra = ["datetime"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/6f/a801320bb388d965be9c370ec753cc33120e6cbe0069fa05644f05821975/dataproperty-1.1.1.tar.gz", hash = "sha256:a83af82a234edda5378a36fb092bc90dd554646c5e58202a310acf468ae81bc8", size = 42954, upload-time = "2026-05-09T10:33:42.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/41/eab7fe313820578b341a2a1d6aeeedd2c38ec1e3f3d51e57e2735b5beac0/dataproperty-1.1.1-py3-none-any.whl", hash = "sha256:cf026aa002dbd6c57c619ec6741ffd61ae7bf2f20481951d8af2dff44480340e", size = 27691, upload-time = "2026-05-09T10:33:40.468Z" },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1153,6 +1179,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "dominate"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/f3/1c8088ff19a0fcd9c3234802a0ee47006ea64bd8852f1019194f0e3583ff/dominate-2.9.1.tar.gz", hash = "sha256:558284687d9b8aae1904e3d6051ad132dd4a8c0cf551b37ea4e7e42a31d19dc4", size = 37715, upload-time = "2023-12-24T20:45:19.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/19/0380af745f151a1648657bbcef0fb49ac28bf09083d94498163ffd9b32dc/dominate-2.9.1-py2.py3-none-any.whl", hash = "sha256:cb7b6b79d33b15ae0a6e87856b984879927c7c2ebb29522df4c75b28ffd9b989", size = 29976, upload-time = "2023-12-24T20:45:17.154Z" },
 ]
 
 [[package]]
@@ -2557,6 +2592,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mbstrdecoder"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/9c/dd6e38d747a62ead27f9abef32f4ca4311d4e40ac28e76bcc9ffb5dd0329/mbstrdecoder-1.1.5.tar.gz", hash = "sha256:8cbfba26938befd8a35e3cc06ca0632f61320b7b2be7df32550b895e1725b1ce", size = 14529, upload-time = "2026-05-05T04:17:58.23Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/eb/711270faab7b7df702339a2c68b31fd3ed4fffc68b0e99e5bdf49b1e87e4/mbstrdecoder-1.1.5-py3-none-any.whl", hash = "sha256:4a50fe113d4abecfd86e8f716b2e413cce03d63af83ec3c7cdbe81dec0e519ed", size = 7966, upload-time = "2026-05-05T04:17:56.78Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3440,6 +3487,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathvalidate"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
+]
+
+[[package]]
 name = "pdfminer-six"
 version = "20251230"
 source = { registry = "https://pypi.org/simple" }
@@ -3623,6 +3679,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/20/60ae67bb9d82f00427946218d49e2e7e80fb41c15dc5019482289ec9ce8d/posthog-5.4.0.tar.gz", hash = "sha256:701669261b8d07cdde0276e5bc096b87f9e200e3b9589c5ebff14df658c5893c", size = 88076, upload-time = "2025-06-20T23:19:23.485Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/98/e480cab9a08d1c09b1c59a93dade92c1bb7544826684ff2acbfd10fcfbd4/posthog-5.4.0-py3-none-any.whl", hash = "sha256:284dfa302f64353484420b52d4ad81ff5c2c2d1d607c4e2db602ac72761831bd", size = 105364, upload-time = "2025-06-20T23:19:22.001Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
 ]
 
 [[package]]
@@ -4233,12 +4301,52 @@ wheels = [
 ]
 
 [[package]]
+name = "pypistats"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "prettytable" },
+    { name = "pytablewriter", extra = ["html"] },
+    { name = "python-slugify" },
+    { name = "termcolor" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/9b/b4b4a8d9053fa83312ce4258c122e7c26b97b239e0c717b473d561f78e45/pypistats-1.13.0.tar.gz", hash = "sha256:0e0bf01f844cbd8ca57b6658a30f6f3a586c25d65c738907d991d813b3097591", size = 125762, upload-time = "2026-01-26T18:58:40.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/5f/3732c2790050a73d337d25440accc72a88af21cc50c5a932300e02911d8e/pypistats-1.13.0-py3-none-any.whl", hash = "sha256:eac5d387745b94592ee171eb69827505e052e8619f0f54c8ad0dd9b2fd1fb9f8", size = 15522, upload-time = "2026-01-26T18:58:39.73Z" },
+]
+
+[[package]]
 name = "pyproject-hooks"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pytablewriter"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dataproperty" },
+    { name = "mbstrdecoder" },
+    { name = "pathvalidate" },
+    { name = "setuptools" },
+    { name = "tabledata" },
+    { name = "tcolorpy" },
+    { name = "typepy", extra = ["datetime"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/a1/617730f290f04d347103ab40bf67d317df6691b14746f6e1ea039fb57062/pytablewriter-1.2.1.tar.gz", hash = "sha256:7bd0f4f397e070e3b8a34edcf1b9257ccbb18305493d8350a5dbc9957fced959", size = 619241, upload-time = "2025-01-01T15:37:00.04Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/4c/c199512f01c845dfe5a7840ab3aae6c60463b5dc2a775be72502dfd9170a/pytablewriter-1.2.1-py3-none-any.whl", hash = "sha256:e906ff7ff5151d70a5f66e0f7b75642a7f2dce8d893c265b79cc9cf6bc04ddb4", size = 91083, upload-time = "2025-01-01T15:36:55.63Z" },
+]
+
+[package.optional-dependencies]
+html = [
+    { name = "dominate" },
 ]
 
 [[package]]
@@ -4352,6 +4460,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
 name = "python-socketio"
 version = "5.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4377,6 +4497,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/40/7e/0d6c82b5ccc71e7c833aed43d9e8468e1f2ff0be1b3f657a6fcafbb8433d/python_ulid-3.1.0.tar.gz", hash = "sha256:ff0410a598bc5f6b01b602851a3296ede6f91389f913a5d5f8c496003836f636", size = 93175, upload-time = "2025-08-18T16:09:26.305Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/a0/4ed6632b70a52de845df056654162acdebaf97c20e3212c559ac43e7216e/python_ulid-3.1.0-py3-none-any.whl", hash = "sha256:e2cdc979c8c877029b4b7a38a6fba3bc4578e4f109a308419ff4d3ccf0a46619", size = 11577, upload-time = "2025-08-18T16:09:25.047Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
 ]
 
 [[package]]
@@ -4955,6 +5084,28 @@ wheels = [
 ]
 
 [[package]]
+name = "tabledata"
+version = "1.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dataproperty" },
+    { name = "typepy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/65/2f54f0dedd775dde48e300023d20e13ad329a51e33dcadb6d47b4dc95768/tabledata-1.3.5.tar.gz", hash = "sha256:98c64d0ad6b520846b41000fb3f5b2f42fa7ca2675c2c669e5ccab6b93082a36", size = 25396, upload-time = "2026-05-11T12:03:26.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/86/37fa0e1437089f08b8b1b8c8ad93f6b57e9427753f002914299323300a9e/tabledata-1.3.5-py3-none-any.whl", hash = "sha256:a1e57afc4767b51bef551114c0df31f205d712dbb75e3caf9be7834a79f23136", size = 11919, upload-time = "2026-05-11T12:03:24.907Z" },
+]
+
+[[package]]
+name = "tcolorpy"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/cc/44f2d81d8f9093aad81c3467a5bf5718d2b5f786e887b6e4adcfc17ec6b9/tcolorpy-0.1.7.tar.gz", hash = "sha256:0fbf6bf238890bbc2e32662aa25736769a29bf6d880328f310c910a327632614", size = 299437, upload-time = "2024-12-29T15:24:23.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a2/ed023f2edd1e011b4d99b6727bce8253842d66c3fbf9ed0a26fc09a92571/tcolorpy-0.1.7-py3-none-any.whl", hash = "sha256:26a59d52027e175a37e0aba72efc99dda43f074db71f55b316d3de37d3251378", size = 8096, upload-time = "2024-12-29T15:24:21.33Z" },
+]
+
+[[package]]
 name = "temporalio"
 version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4980,6 +5131,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]
@@ -5112,6 +5281,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typepy"
+version = "1.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mbstrdecoder" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/9f/ae119b0e0fd0fe8dcb0e1eeebfeb62f37fdc0b467267cff15cdb746ba38b/typepy-1.3.5.tar.gz", hash = "sha256:a1c5f54c41860f89bab175f512b11e8c9a57cfe7b8b3d5ae5d52d828b756b6dd", size = 39883, upload-time = "2026-05-04T14:04:32.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/71/75cf08c49b64a9419f1f2cef9be072ac34f6b784da2851489470b7c7ba15/typepy-1.3.5-py3-none-any.whl", hash = "sha256:de361b59609c7503efc2edbe9d7a4e053ae71307bf90ae1678ec4d6bcd807922", size = 31530, upload-time = "2026-05-04T14:04:31.46Z" },
+]
+
+[package.optional-dependencies]
+datetime = [
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds **`scripts/telemetry/`** collectors (npm, PyPI, GitHub, registry) plus **`aggregate.py`** for snapshot + markdown dashboard wiring (private output ignored from git).
- **`apps/web`**: Bearer-protected **`/api/telemetry`**, **`data-cta`** on homepage links, env placeholders in **`apps/web/.env.example`** (`TELEMETRY_TOKEN`, optional `TELEMETRY_SITE_METRICS_JSON` documented in-code for Vercel Analytics limitations).
- **CI**: **`.github/workflows/telemetry-weekly.yml`** (`workflow_dispatch` + weekly schedule); **`.github/ISSUE_TEMPLATE/adapter-request.yml`** for promotion-gate feedback.
- **Docs**: **`PRIVACY.md`**, **`docs/maintainers/telemetry.md`**, README link; **`apps/example-agent/uv.lock`** aligned with root workspace metadata.

## Local verification (CI-aligned)

Ran on this branch before opening the PR:

- [x] `python3 scripts/lint_no_transport_growth.py` — OK
- [x] `uv run ruff check .` + `uv run ruff format --check .` — OK
- [x] `uv run mypy src/ scripts/ tests/` — OK
- [x] `uv run mkdocs build` — OK
- [x] `PYTHONPATH=src:. uv run pytest -n auto -q` — **3306 passed**, 5 skipped
- [x] `PYTHONPATH` incl. asap-compliance — `pytest asap-compliance/tests/` — **54 passed**
- [x] **`apps/web`**: `npm ci`, `npm run lint`, `npx tsc --noEmit`, `npm test` — **122 passed**

## Test plan (post-merge)

- [ ] Confirm **GitHub** label **`adapter-request`** exists (or matches template expectation).
- [ ] After deploy: set **`TELEMETRY_TOKEN`** (and optionally **`TELEMETRY_SITE_METRICS_JSON`**) per `docs/maintainers/telemetry.md`; smoke `GET /api/telemetry` with bearer.
- [ ] Optional: trigger **`telemetry-weekly`** via **workflow_dispatch** and confirm artifact contains snapshot/dashboard output.