### PR TITLE
feat(openai-agents): add @asap-protocol/openai-agents adapter and reference app

### DIFF
--- a/.github/workflows/openai-agents-ci.yml
+++ b/.github/workflows/openai-agents-ci.yml
@@ -1,0 +1,99 @@
+name: OpenAI Agents adapter CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/typescript/openai-agents/**"
+      - "packages/typescript/client/**"
+      - "apps/example-openai-agents/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/openai-agents-ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/typescript/openai-agents/**"
+      - "packages/typescript/client/**"
+      - "apps/example-openai-agents/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/openai-agents-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  package-quality-and-test:
+    # Matrix: **@openai/agents** `latest` vs baseline pin **0.11.4**.
+    name: (${{ matrix.openai-agents }} @openai/agents) lint, typecheck, test, treeshake
+    concurrency:
+      group: openai-agents-ci-${{ github.workflow }}-${{ github.ref }}-${{ matrix.openai-agents }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        openai-agents: ["latest", "0.11.4"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+        with:
+          version: 9.15.4
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Set @openai/agents devDependency for matrix
+        shell: bash
+        env:
+          OPENAI_AGENTS_SPEC: ${{ matrix.openai-agents }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require("fs");
+          const pkgPath = "packages/typescript/openai-agents/package.json";
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          const version = process.env.OPENAI_AGENTS_SPEC.trim();
+          if (!version) {
+            throw new Error("OPENAI_AGENTS_SPEC missing");
+          }
+          pkg.devDependencies = pkg.devDependencies ?? {};
+          pkg.devDependencies["@openai/agents"] = version === "latest" ? "latest" : version;
+          fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+          NODE
+
+      - name: Install dependencies (openai-agents slice)
+        run: pnpm install --no-frozen-lockfile --filter "@asap-protocol/openai-agents..." --filter example-openai-agents
+
+      - uses: actions/cache@v4
+        id: client-dist
+        with:
+          path: packages/typescript/client/dist
+          key: ${{ runner.os }}-asap-ts-client-${{ hashFiles('packages/typescript/client/src/**', 'packages/typescript/client/package.json', 'packages/typescript/client/tsconfig.build.json') }}
+
+      - name: Build @asap-protocol/client
+        if: steps.client-dist.outputs.cache-hit != 'true'
+        run: pnpm --filter @asap-protocol/client run build
+
+      - name: Lint
+        run: pnpm --filter @asap-protocol/openai-agents run lint
+
+      - name: Typecheck
+        run: pnpm --filter @asap-protocol/openai-agents run typecheck
+
+      - name: Test with coverage (≥85% statements)
+        run: pnpm --filter @asap-protocol/openai-agents test
+
+      - name: Tree-shake check (agadoo)
+        run: pnpm --filter @asap-protocol/openai-agents run check:treeshake
+
+      - name: example-openai-agents lint + typecheck
+        run: |
+          pnpm --filter example-openai-agents run lint
+          pnpm --filter example-openai-agents run typecheck

--- a/.github/workflows/openai-agents-ci.yml
+++ b/.github/workflows/openai-agents-ci.yml
@@ -68,6 +68,9 @@ jobs:
           fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
           NODE
 
+      # Matrix jobs rewrite devDependencies["@openai/agents"] to `latest` or a pin, so this
+      # install uses --no-frozen-lockfile only for the adapter slice. The committed pnpm-lock.yaml
+      # at repo root remains authoritative for normal local/CI installs outside this matrix.
       - name: Install dependencies (openai-agents slice)
         run: pnpm install --no-frozen-lockfile --filter "@asap-protocol/openai-agents..." --filter example-openai-agents
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ pip install asap-protocol
 
 **npm** Mastra (**[`@asap-protocol/mastra`](https://www.npmjs.com/package/@asap-protocol/mastra)** when published — today also via monorepo `workspace:*`) bridges ASAP capabilities onto **`@mastra/core`** tools alongside the TypeScript SDK; docs live under [`docs/integrations/mastra.md`](docs/integrations/mastra.md) and runnable UI under [`apps/example-mastra/README.md`](apps/example-mastra/README.md).
 
+**npm** OpenAI Agents SDK (**[`@asap-protocol/openai-agents`](https://www.npmjs.com/package/@asap-protocol/openai-agents)** when published — workspace **`packages/typescript/openai-agents`**) exposes ASAP capabilities as **`@openai/agents`** `tool()` definitions — **not** the legacy Chat Completions helper [`adapters/openai`](packages/typescript/client/src/adapters/openai.ts); see [`docs/integrations/openai-agents.md`](docs/integrations/openai-agents.md) and CLI demo [`apps/example-openai-agents/README.md`](apps/example-openai-agents/README.md).
+
 ```bash
 npm install @asap-protocol/client
 # reproducible pin (same as latest today):

--- a/apps/example-mastra/.env.example
+++ b/apps/example-mastra/.env.example
@@ -20,6 +20,6 @@ NEXT_PUBLIC_ASAP_PROVIDER_URL=http://127.0.0.1:8080
 # Comma-separated capability URNs offered to the Mastra tools.
 NEXT_PUBLIC_ASAP_CAPABILITIES=urn:asap:cap:echo
 
-# Used by LAB1-004 compliance script (`pnpm run compliance` from apps/example-mastra`).
+# Used by `pnpm run compliance` in apps/example-mastra (`asap compliance-check` against this URL).
 # Prefer https:// for anything beyond loopback; plaintext leaks metadata on the wire.
 ASAP_PROVIDER_URL=http://127.0.0.1:8080

--- a/apps/example-mastra/README.md
+++ b/apps/example-mastra/README.md
@@ -54,7 +54,7 @@ pnpm --filter example-mastra dev -- --port 3001
 
 **Purpose:** avoids `EADDRINUSE` when both dev servers run on the same machine.
 
-## Compliance (LAB1-004)
+## Compliance
 
 With **`uv`** installed and **`ASAP_PROVIDER_URL`** set (**HTTPS** recommended for staged endpoints):
 

--- a/apps/example-mastra/scripts/compliance.ts
+++ b/apps/example-mastra/scripts/compliance.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * LAB1-004: Runs `asap compliance-check` against the ASAP gateway URL wired for this demo.
+ * Runs `asap compliance-check` against `ASAP_PROVIDER_URL` (repo root, `--exit-on-fail`).
  *
  * Expects `uv` on PATH and ASAP checked out locally (Compliance Harness bundled with asap-protocol).
  * Configure `ASAP_PROVIDER_URL` in `.env` or the environment — see `.env.example`.

--- a/apps/example-openai-agents/.env.example
+++ b/apps/example-openai-agents/.env.example
@@ -1,0 +1,5 @@
+OPENAI_API_KEY=
+# Default matches apps/example-agent-style gateways on loopback (Compliance Harness demos).
+ASAP_PROVIDER_URL=http://127.0.0.1:8080/
+# Comma-separated URNs or short capability ids understood by your gateway (demo default).
+ASAP_CAPABILITIES=urn:asap:cap:demo_echo

--- a/apps/example-openai-agents/README.md
+++ b/apps/example-openai-agents/README.md
@@ -1,0 +1,51 @@
+# OpenAI Agents SDK · ASAP example (`example-openai-agents`)
+
+Minimal **Node** demo that runs an OpenAI **`Agent`** from **`@openai/agents`** with ASAP capability **`tool()`** instances from **`@asap-protocol/openai-agents`**.
+
+## Prerequisites
+
+- **pnpm** at the repository root (workspace install).
+- **`OPENAI_API_KEY`** with access to **`gpt-4o-mini`** (or edit `src/index.ts`).
+- **`uv`** plus Python deps when running **`pnpm run compliance`**.
+- An ASAP HTTP gateway exposing **`GET /asap/capability/describe`** and **`POST /asap/capability/execute`** for your capability ids.
+
+## Quickstart
+
+**1.** Install workspaces from the repo root:
+
+```bash
+pnpm install
+```
+
+**Purpose:** links `@asap-protocol/client`, `@asap-protocol/openai-agents`, and pulls **`@openai/agents`**.
+
+**2.** Start an ASAP gateway reachable at **`127.0.0.1:8080`** (same convention as **`apps/example-mastra`** — often your Python transport demo).
+
+**3.** Configure and run:
+
+```bash
+cp apps/example-openai-agents/.env.example apps/example-openai-agents/.env
+# Fill OPENAI_API_KEY (and optionally ASAP_PROVIDER_URL / ASAP_CAPABILITIES).
+
+pnpm --filter example-openai-agents start
+```
+
+**Purpose:** prints assistant output after the model resolves capability tools against your gateway.
+
+### Alternative PetStore-backed gateway
+
+PetStore integrations live under **`examples/openapi_petstore/`**. Point **`ASAP_PROVIDER_URL`** at whichever HTTPS gateway fronts those capabilities.
+
+### Custom prompt (optional)
+
+```bash
+pnpm --filter example-openai-agents exec tsx src/index.ts Ask the ASAP provider to echo "ping".
+```
+
+## Compliance
+
+```bash
+pnpm --filter example-openai-agents run compliance
+```
+
+**Purpose:** runs **`asap compliance-check --exit-on-fail --url …`** from the repo root against **`ASAP_PROVIDER_URL`**.

--- a/apps/example-openai-agents/eslint.config.js
+++ b/apps/example-openai-agents/eslint.config.js
@@ -1,0 +1,26 @@
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    ignores: ["node_modules/**"],
+  },
+  {
+    files: ["src/**/*.ts", "scripts/**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "no-console": "off",
+    },
+  },
+);

--- a/apps/example-openai-agents/package.json
+++ b/apps/example-openai-agents/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "example-openai-agents",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "lint": "eslint .",
+    "typecheck": "pnpm --filter @asap-protocol/client run build && pnpm --filter @asap-protocol/openai-agents run build && tsc --noEmit",
+    "compliance": "tsx scripts/compliance.ts"
+  },
+  "dependencies": {
+    "@asap-protocol/client": "workspace:*",
+    "@asap-protocol/openai-agents": "workspace:*",
+    "@openai/agents": "^0.11.4",
+    "dotenv": "^16.6.1",
+    "zod": "^4.4.2"
+  },
+  "devDependencies": {
+    "@eslint/js": "9.18.0",
+    "@types/node": "^20.19.0",
+    "eslint": "9.18.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.8.3",
+    "typescript-eslint": "8.59.1"
+  }
+}

--- a/apps/example-openai-agents/scripts/compliance.ts
+++ b/apps/example-openai-agents/scripts/compliance.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Runs `asap compliance-check` against `ASAP_PROVIDER_URL` (repo root, `--exit-on-fail`).
+ */
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../../..");
+
+const url = process.env.ASAP_PROVIDER_URL?.trim();
+
+if (!url) {
+  console.error("Missing ASAP_PROVIDER_URL — set it to your gateway base URL (e.g. https://petstore-gateway.example)");
+  process.exit(1);
+}
+
+try {
+  void new URL(url);
+} catch {
+  console.error(`Invalid ASAP_PROVIDER_URL — not a valid absolute URL: ${url}`);
+  process.exit(1);
+}
+
+const result = spawnSync("uv", ["run", "asap", "compliance-check", "--url", url, "--exit-on-fail"], {
+  cwd: repoRoot,
+  stdio: "inherit",
+});
+
+process.exit(typeof result.status === "number" ? result.status : 1);

--- a/apps/example-openai-agents/src/index.ts
+++ b/apps/example-openai-agents/src/index.ts
@@ -1,0 +1,61 @@
+import "dotenv/config";
+
+import { Agent, run, setDefaultOpenAIKey } from "@openai/agents";
+
+import type { AsapExecuteClient } from "@asap-protocol/client";
+import { asapToolsForOpenAIAgents } from "@asap-protocol/openai-agents";
+
+function requiredEnv(name: string): string {
+  const v = process.env[name]?.trim();
+  if (!v) {
+    throw new Error(`Missing ${name} — copy apps/example-openai-agents/.env.example and fill values`);
+  }
+  return v;
+}
+
+async function main(): Promise<void> {
+  const apiKey = requiredEnv("OPENAI_API_KEY");
+  const providerHref =
+    process.env.ASAP_PROVIDER_URL?.trim() && process.env.ASAP_PROVIDER_URL.trim().length > 0
+      ? process.env.ASAP_PROVIDER_URL.trim()
+      : "http://127.0.0.1:8080/";
+  const capsRaw =
+    process.env.ASAP_CAPABILITIES?.trim() && process.env.ASAP_CAPABILITIES.trim().length > 0
+      ? process.env.ASAP_CAPABILITIES.trim()
+      : "urn:asap:cap:demo_echo";
+
+  const capabilities = capsRaw.split(",").map((s) => s.trim()).filter(Boolean);
+
+  const provider = new URL(providerHref);
+  const client: AsapExecuteClient = {
+    provider,
+    capabilities,
+  };
+
+  setDefaultOpenAIKey(apiKey);
+
+  const tools = await asapToolsForOpenAIAgents(client);
+  const agent = new Agent({
+    name: "example-openai-agents",
+    instructions: [
+      "You call ASAP capability tools to satisfy the user.",
+      `Configured capabilities (comma-separated): ${capabilities.join(", ")}.`,
+      "Prefer the echo capability when asked for a ping.",
+    ].join(" "),
+    model: "gpt-4o-mini",
+    tools: [...tools],
+  });
+
+  const prompt =
+    process.argv.slice(2).join(" ").trim() ||
+    "Use an ASAP capability tool to echo the short phrase `hello-from-openai-agents`.";
+
+  const result = await run(agent, prompt);
+  // CLI demo output
+  console.log(result.finalOutput ?? "(no text output)");
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/apps/example-openai-agents/tsconfig.json
+++ b/apps/example-openai-agents/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*.ts", "scripts/**/*.ts", "eslint.config.js"]
+}

--- a/apps/web/public/icons/openai-agents.svg
+++ b/apps/web/public/icons/openai-agents.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6" stroke="#71717a" stroke-width="1.5"/>
+  <circle cx="16" cy="14" r="5" stroke="#a1a1aa" stroke-width="1.5"/>
+  <path d="M10 26c2-4 10-4 12 0" stroke="#a1a1aa" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/apps/web/src/app/developer-experience/page.tsx
+++ b/apps/web/src/app/developer-experience/page.tsx
@@ -153,9 +153,9 @@ export default function DeveloperExperiencePage() {
                             { name: 'OpenClaw', icon: 'openclaw', desc: 'Interoperable chat-based agent patterns.' },
                             { name: 'Vercel AI SDK', icon: 'vercel', desc: 'Bridge ASAP agents into Next.js/React apps with native tool-calling support.' },
                             {
-                                name: 'Mastra',
-                                icon: 'mastra',
-                                desc: 'Mount ASAP capabilities as Mastra Agent tools (@asap-protocol/mastra + @mastra/core).',
+                                name: 'OpenAI Agents',
+                                icon: 'openai-agents',
+                                desc: 'ASAP capability tools for the OpenAI Agents SDK (`@asap-protocol/openai-agents`; separate from the Chat Completions adapter in `@asap-protocol/client`).',
                             },
                         ].map((fw) => (
                             <div key={fw.name} className="p-5 rounded-lg border border-zinc-800 bg-zinc-900/20 hover:bg-zinc-900/40 transition-all group">

--- a/apps/web/src/components/agents/data-table.tsx
+++ b/apps/web/src/components/agents/data-table.tsx
@@ -80,7 +80,7 @@ export function DataTable<TData, TValue>({
         }
     };
 
-    // eslint-disable-next-line react-hooks/incompatible-library
+    /* eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table: rule flags useReactTable with controlled filter/sort state (library pattern). */
     const table = useReactTable({
         data,
         columns,

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 - **Transport Agnostic**: Clean separation between protocol logic and transport capability (HTTP JSON-RPC, WebSocket, SSE)
 - **Observability**: First-class tracking with correlation IDs and trace IDs
 - **Security & authorization (v2.2+, WebAuthn real in v2.2.1)**: Per-runtime Host/Agent JWTs, capability grants with constraints, approval flows, opt-in WebAuthn (`asap-protocol[webauthn]`) for browser-controlled and high-risk capability registration — see [Security](security.md) and [Migration](migration.md)
-- **Adoption tools (v2.3.0)**: [OpenAPI adapter](adapters/openapi.md), TypeScript client ([`packages/typescript/client`](https://github.com/adriannoes/asap-protocol/tree/main/packages/typescript/client)), Mastra adapter ([`integrations/mastra.md`](integrations/mastra.md) · `@asap-protocol/mastra`), [Auto-registration](registry/auto-registration.md), [Capability escalation](capabilities/escalation.md), [ASAP HTTP challenge](transport/asap-challenge.md)
+- **Adoption tools (v2.3.0)**: [OpenAPI adapter](adapters/openapi.md), TypeScript client ([`packages/typescript/client`](https://github.com/adriannoes/asap-protocol/tree/main/packages/typescript/client)), Mastra adapter ([`integrations/mastra.md`](integrations/mastra.md) · `@asap-protocol/mastra`), OpenAI Agents SDK adapter ([`integrations/openai-agents.md`](integrations/openai-agents.md) · `@asap-protocol/openai-agents`), [Auto-registration](registry/auto-registration.md), [Capability escalation](capabilities/escalation.md), [ASAP HTTP challenge](transport/asap-challenge.md)
 
 ## Installation
 
@@ -93,7 +93,7 @@ See [CLI reference](cli.md) (all commands, exit codes, `compliance-check`, `audi
 
 - [OpenAPI adapter](adapters/openapi.md) — derive ASAP skills and an upstream proxy from OpenAPI 3.x (`asap.adapters.openapi`)
 - [TypeScript client SDK](sdks/typescript.md) — `@asap-protocol/client` on npm (browser + Node; optional LLM adapters)
-- [Mastra integration](integrations/mastra.md) — `@asap-protocol/mastra`: ASAP capabilities as Mastra tools (`@mastra/core` ^1.5)
+- [OpenAI Agents SDK adapter](integrations/openai-agents.md) — `@asap-protocol/openai-agents`: ASAP capabilities as `@openai/agents` tools + handoff-oriented remote agent helper (`@openai/agents`, distinct from `@asap-protocol/client/adapters/openai`)
 - [CLI reference](cli.md) — all `asap` commands, including `compliance-check`, `audit export`, and exit codes
 - [Audit log](audit.md) — hash chain model, export formats, tamper checks
 - [API Reference](api-reference.md)

--- a/docs/integrations/openai-agents.md
+++ b/docs/integrations/openai-agents.md
@@ -1,0 +1,145 @@
+# OpenAI Agents SDK integration (`@asap-protocol/openai-agents`)
+
+Expose ASAP **capabilities** as [**OpenAI Agents SDK**](https://openai.github.io/openai-agents-js/) **`tool()`** definitions backed by **`@asap-protocol/client`**, optionally wrap an **`Agent`** you attach as a **handoff** target against an ASAP gateway, and bridge ASAP **`task_stream`** payloads into incremental assistant **text deltas**.
+
+!!! warning "Not `@asap-protocol/client/adapters/openai`"
+
+    `@asap-protocol/client/adapters/openai` generates **static `ChatCompletionTool[]`** for the raw OpenAI **Chat Completions HTTP API** (`openai` npm package).
+
+    **`@asap-protocol/openai-agents`** targets **`@openai/agents`** (`Agent`, `tool()`, handoffs, `run()`). Different runtime — **both coexist**.
+
+## Requirements
+
+| Runtime / tool | Version |
+|----------------|---------|
+| Node.js | **≥ 18** |
+| `@openai/agents` | **`^0.11.0`** (CI exercises **`latest`** + pinned **`0.11.4`**) |
+| `@asap-protocol/client` | **`^2.3.0`** |
+| `zod` | **`^3.25.76`** or **`^4.1.x`** (`@openai/agents` currently peers on **`zod ^4`** — prefer **v4** locally if npm warns) |
+
+## Installation
+
+Published (when available):
+
+```bash
+npm install @asap-protocol/openai-agents @asap-protocol/client @openai/agents zod
+```
+
+Workspace / monorepo:
+
+```json
+{
+  "dependencies": {
+    "@asap-protocol/openai-agents": "workspace:*",
+    "@asap-protocol/client": "workspace:*",
+    "@openai/agents": "^0.11.4",
+    "zod": "^4.4.2"
+  }
+}
+```
+
+Configure **`AsapExecuteClient`** (`provider`, **`capabilities[]`**, optional JWT / fetch) exactly like other adapters — see [TypeScript client](../sdks/typescript.md).
+
+### Public exports (`@asap-protocol/openai-agents`)
+
+| Export | Role |
+|--------|------|
+| `asapToolsForOpenAIAgents(client)` | `async` — build **`tool()`** instances (calls **`describeCapability`** unless **`inputSchemas`** are pre-supplied) |
+| `asapToolsForOpenAIAgentsSync(client)` | Same tools **without** describe round-trips when **`inputSchemas`** are provided |
+| `asapAsRemoteAgent(client, providerUrl, options?)` | Returns an OpenAI **`Agent`** wired with ASAP tools; captures draft **`task.request`** metadata on **`agent_start`** (handoffs included) |
+| `draftTaskRequestEnvelopeForRemoteAgent({ mode, providerUrl, turnInput })` | Stable envelope-shaped draft carrying **`extensions.asap_agent_mode`** (`delegated` \| `autonomous`) |
+| `zodFromJsonSchema(schema)` | Shared JSON Schema → Zod helper for offline validation / tooling |
+| `asapStreamToOpenAIAgentsTextStream(source)` | Map ASAP **`task_stream`** envelopes → UTF-8 chunks |
+| `asapStreamToOpenAIAgentsRunStreamChunks(source)` | Same chunks wrapped as **`{ type: "text_delta", text }`** |
+| ASAP RPC error re-exports + **`ApprovalRequiredError`**, **`CapabilityNotGrantedError`** | Approval / escalation symmetry with Mastra adapter |
+
+## Basic capability tools
+
+```typescript
+import { Agent, run, setDefaultOpenAIKey } from "@openai/agents";
+import type { AsapExecuteClient } from "@asap-protocol/client";
+import { asapToolsForOpenAIAgents } from "@asap-protocol/openai-agents";
+
+declare const client: AsapExecuteClient;
+
+setDefaultOpenAIKey(process.env.OPENAI_API_KEY!);
+
+const tools = await asapToolsForOpenAIAgents(client);
+const agent = new Agent({
+  name: "asap-demo",
+  instructions: "Use ASAP capability tools when they help answer the user.",
+  model: "gpt-4o-mini",
+  tools: [...tools],
+});
+
+await run(agent, "Echo hello via ASAP capabilities.");
+```
+
+Each tool **`execute`** path calls **`executeCapability(provider, capabilityId, args, { fetch, agentJwt })`** — **not** a method on `client`.
+
+!!! tip "`invokeFunctionTool` and typed errors"
+
+    OpenAI Agents wraps tool failures unless **`errorFunction` is disabled**. This adapter sets **`errorFunction: null`** so **`ApprovalRequiredError`**, **`CapabilityNotGrantedError`**, and ASAP **`RecoverableError`** propagate to host code (`packages/typescript/openai-agents` tests rely on **`invokeFunctionTool`** for unary execution).
+
+### Schema modes
+
+When describe JSON Schema lists **`properties`**, parameters compile to **strict Zod objects** (`strict: true`) — matching SDK requirements.
+
+Fallback **open-object** schemas compile to **JSON Schema parameters** (`strict: false`). Rare ASAP schemas still route through permissive records — mirror Mastra limitations.
+
+## Handoffs (`asapAsRemoteAgent`)
+
+```typescript
+import { asapAsRemoteAgent } from "@asap-protocol/openai-agents";
+import type { AsapExecuteClient } from "@asap-protocol/client";
+
+declare const client: AsapExecuteClient;
+
+const specialist = await asapAsRemoteAgent(client, client.provider, {
+  mode: "delegated",
+});
+
+// Pass `specialist` via Agent `handoffs: [...]` from your orchestrator agent.
+```
+
+On **`agent_start`**, **`RunContext.context.lastAsapHandoffEnvelope`** receives **`draftTaskRequestEnvelopeForRemoteAgent`** output (`extensions.asap_agent_mode`, serialized turn input payload).
+
+## Capability escalation (`capability_not_granted`)
+
+Provide **`requestCapability`** identical to Mastra:
+
+```typescript
+await asapToolsForOpenAIAgents(client, {
+  async requestCapability(required) {
+    await fetch(`/approval/${required}`, { method: "POST" });
+  },
+});
+```
+
+Thrown **`CapabilityNotGrantedError`** exposes **`.requestCapability()`** so orchestrators can retry after grants.
+
+## Streaming
+
+Combine **`createAsapStreamClient`** / **`streamTaskStreamEnvelopes`** (`@asap-protocol/client/streaming`) with:
+
+```typescript
+import { asapStreamToOpenAIAgentsRunStreamChunks } from "@asap-protocol/openai-agents";
+
+for await (const delta of asapStreamToOpenAIAgentsRunStreamChunks(streamClient.stream(envelope))) {
+  process.stdout.write(delta.text);
+}
+```
+
+This mirrors Mastra **`asapStreamToMastraTextStream`** but emits **`OpenAIAgentsStreamTextDelta`** records you can merge into UI streams.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| **`Strict mode is required for Zod parameters`** | Upgrade **`@openai/agents`** ≥ **0.11** — older helpers assumed looser typing. Empty capability schemas automatically downgrade to JSON-schema tools. |
+| Tool calls succeed but HTTP hits wrong host | **`asapAsRemoteAgent`** merges **`providerUrl`** into **`client.provider`** — verify trailing slashes / TLS. |
+| Streaming stalls | Confirm SSE **`Accept: text/event-stream`** gateway compatibility (`streamTaskStreamEnvelopes`). |
+
+Runnable CLI demo: [`apps/example-openai-agents/README.md`](https://github.com/adriannoes/asap-protocol/tree/main/apps/example-openai-agents).
+
+Compliance Harness: `pnpm --filter example-openai-agents run compliance`.

--- a/docs/integrations/openai-agents.md
+++ b/docs/integrations/openai-agents.md
@@ -15,7 +15,7 @@ Expose ASAP **capabilities** as [**OpenAI Agents SDK**](https://openai.github.io
 | Node.js | **≥ 18** |
 | `@openai/agents` | **`^0.11.0`** (CI exercises **`latest`** + pinned **`0.11.4`**) |
 | `@asap-protocol/client` | **`^2.3.0`** |
-| `zod` | **`^3.25.76`** or **`^4.1.x`** (`@openai/agents` currently peers on **`zod ^4`** — prefer **v4** locally if npm warns) |
+| `zod` | **`^4.1.8`** (matches `@openai/agents` peer; Zod 3 is not supported by this package) |
 
 ## Installation
 
@@ -46,12 +46,17 @@ Configure **`AsapExecuteClient`** (`provider`, **`capabilities[]`**, optional JW
 |--------|------|
 | `asapToolsForOpenAIAgents(client)` | `async` — build **`tool()`** instances (calls **`describeCapability`** unless **`inputSchemas`** are pre-supplied) |
 | `asapToolsForOpenAIAgentsSync(client)` | Same tools **without** describe round-trips when **`inputSchemas`** are provided |
-| `asapAsRemoteAgent(client, providerUrl, options?)` | Returns an OpenAI **`Agent`** wired with ASAP tools; captures draft **`task.request`** metadata on **`agent_start`** (handoffs included) |
+| `asapAsRemoteAgent(client, providerUrl, options?)` | Returns an OpenAI **`Agent`** wired with ASAP tools; on **`agent_start`** POSTs a real **`task.request`** via JSON-RPC **`asap.send`** and stores the draft on **`RunContext.context.lastAsapHandoffEnvelope`** |
+| `sendAsapEnvelope(provider, envelope, options?)` | Lower-level **`POST /asap`** helper used by handoffs (JSON-RPC **`asap.send`**) |
 | `draftTaskRequestEnvelopeForRemoteAgent({ mode, providerUrl, turnInput })` | Stable envelope-shaped draft carrying **`extensions.asap_agent_mode`** (`delegated` \| `autonomous`) |
 | `zodFromJsonSchema(schema)` | Shared JSON Schema → Zod helper for offline validation / tooling |
 | `asapStreamToOpenAIAgentsTextStream(source)` | Map ASAP **`task_stream`** envelopes → UTF-8 chunks |
 | `asapStreamToOpenAIAgentsRunStreamChunks(source)` | Same chunks wrapped as **`{ type: "text_delta", text }`** |
 | ASAP RPC error re-exports + **`ApprovalRequiredError`**, **`CapabilityNotGrantedError`** | Approval / escalation symmetry with Mastra adapter |
+
+!!! warning "Pre-1.0 `@openai/agents` API drift"
+
+    **`@openai/agents` is pre-1.0.** Minor/patch releases may change `Agent` constructor options, `tool()` parameter shapes, or default tool error handling. CI exercises **`latest`** and pinned **`0.11.4`**; pin your app dependency and re-run compliance after upgrades.
 
 ## Basic capability tools
 
@@ -102,7 +107,12 @@ const specialist = await asapAsRemoteAgent(client, client.provider, {
 // Pass `specialist` via Agent `handoffs: [...]` from your orchestrator agent.
 ```
 
-On **`agent_start`**, **`RunContext.context.lastAsapHandoffEnvelope`** receives **`draftTaskRequestEnvelopeForRemoteAgent`** output (`extensions.asap_agent_mode`, serialized turn input payload).
+On **`agent_start`**, the adapter:
+
+1. Sets **`RunContext.context.lastAsapHandoffEnvelope`** from **`draftTaskRequestEnvelopeForRemoteAgent`** (`extensions.asap_agent_mode`, serialized turn input).
+2. **POSTs** that envelope to **`providerUrl`** via JSON-RPC **`asap.send`** at **`/asap`** (same wire shape as the Python **`ASAPClient.send`**).
+
+**Agent JWT scope:** **`client.agentJwt`** is only forwarded when **`providerUrl`** matches **`client.provider`** (same origin **and** pathname). For cross-provider handoffs, pass **`remoteAgentJwt`** in options — otherwise **`asapAsRemoteAgent`** throws before any HTTP call.
 
 ## Capability escalation (`capability_not_granted`)
 
@@ -111,10 +121,17 @@ Provide **`requestCapability`** identical to Mastra:
 ```typescript
 await asapToolsForOpenAIAgents(client, {
   async requestCapability(required) {
-    await fetch(`/approval/${required}`, { method: "POST" });
+    await fetch(`/approval/${encodeURIComponent(required)}`, {
+      method: "POST",
+      // Protect approval endpoints with session auth and CSRF tokens as required by your service.
+    });
   },
 });
 ```
+
+!!! note "Approval endpoint security"
+
+    **`requestCapability`** runs in your host process — encode capability IDs in URLs (`encodeURIComponent`) and ensure approval routes require authenticated sessions and CSRF protection where applicable.
 
 Thrown **`CapabilityNotGrantedError`** exposes **`.requestCapability()`** so orchestrators can retry after grants.
 
@@ -138,6 +155,7 @@ This mirrors Mastra **`asapStreamToMastraTextStream`** but emits **`OpenAIAgents
 |---------|-----|
 | **`Strict mode is required for Zod parameters`** | Upgrade **`@openai/agents`** ≥ **0.11** — older helpers assumed looser typing. Empty capability schemas automatically downgrade to JSON-schema tools. |
 | Tool calls succeed but HTTP hits wrong host | **`asapAsRemoteAgent`** merges **`providerUrl`** into **`client.provider`** — verify trailing slashes / TLS. |
+| **`client.agentJwt is scoped to …`** on handoff | **`providerUrl`** differs from **`client.provider`** — supply **`remoteAgentJwt`** scoped to the remote gateway. |
 | Streaming stalls | Confirm SSE **`Accept: text/event-stream`** gateway compatibility (`streamTaskStreamEnvelopes`). |
 
 Runnable CLI demo: [`apps/example-openai-agents/README.md`](https://github.com/adriannoes/asap-protocol/tree/main/apps/example-openai-agents).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - TypeScript client: sdks/typescript.md
   - Integrations:
       - Mastra: integrations/mastra.md
+      - OpenAI Agents SDK: integrations/openai-agents.md
   - Tutorials:
       - Building Your First Agent: tutorials/first-agent.md
       - Stateful Workflows: tutorials/stateful-workflows.md

--- a/packages/typescript/client/src/adapters/shared.ts
+++ b/packages/typescript/client/src/adapters/shared.ts
@@ -1,6 +1,4 @@
-/**
- * Shared helpers for ASAP → LLM SDK adapters (tasks 6.1–6.3).
- */
+/** Shared helpers for wiring ASAP capabilities into LLM/agent SDK tool surfaces. */
 
 import type { CapabilityFetch } from "../capabilities.js";
 

--- a/packages/typescript/client/src/index.ts
+++ b/packages/typescript/client/src/index.ts
@@ -1,6 +1,4 @@
-/**
- * Public API for @asap-protocol/client (expanded in later sprint tasks).
- */
+/** TypeScript client for ASAP Protocol (JSON-RPC over HTTP). */
 export const SDK_NAME = "@asap-protocol/client" as const;
 
 export {
@@ -120,6 +118,9 @@ export type {
   TaskUpdatePayload,
 } from "./types/envelope.js";
 export { isKnownPayloadType, narrowEnvelope } from "./types/envelope.js";
+
+/** Adapter authoring surface (also available from `@asap-protocol/client/adapters/shared`). */
+export type { AsapCapabilityList, AsapExecuteClient } from "./adapters/shared.js";
 
 export type { Storage, WebStorageLike } from "./storage-local.js";
 export { MemoryStorage, LocalStorage } from "./storage-local.js";

--- a/packages/typescript/client/test/ed25519-fallback.test.ts
+++ b/packages/typescript/client/test/ed25519-fallback.test.ts
@@ -1,6 +1,6 @@
 import { decodeProtectedHeader, importJWK, jwtVerify } from "jose";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resetEd25519KeygenProbeForTests } from "../src/ed25519-keypair.js";
+import { generateEd25519KeyPair, resetEd25519KeygenProbeForTests } from "../src/ed25519-keypair.js";
 import { createAgent, createHost } from "../src/identity.js";
 import { MemoryStorage } from "../src/storage-local.js";
 
@@ -71,5 +71,18 @@ describe("Ed25519 keygen (task 2.2)", () => {
     await createHost({ storage: new MemoryStorage() });
     await createHost({ storage: new MemoryStorage() });
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("when subtle path was cached as working but generateKey later fails, uses noble fallback", async () => {
+    const realPair = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
+    const spy = vi
+      .spyOn(crypto.subtle, "generateKey")
+      .mockResolvedValueOnce(realPair as CryptoKeyPair)
+      .mockRejectedValueOnce(new Error("transient subtle failure"));
+    const first = await generateEd25519KeyPair();
+    const second = await generateEd25519KeyPair();
+    expect(first.privateKey.algorithm.name).toBe("Ed25519");
+    expect(second.privateKey.algorithm.name).toBe("Ed25519");
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/typescript/client/test/envelope-from-wire.test.ts
+++ b/packages/typescript/client/test/envelope-from-wire.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { envelopeFromWireJson } from "../src/streaming.js";
+
+describe("envelopeFromWireJson", () => {
+  it("rejects non-object wire JSON", () => {
+    expect(() => envelopeFromWireJson(null)).toThrow(/must be an object/u);
+  });
+
+  it("normalizes non-string timestamp to empty string", () => {
+    const env = envelopeFromWireJson({
+      id: "e1",
+      asap_version: "2.2",
+      timestamp: 99,
+      sender: "a",
+      recipient: "b",
+      payload_type: "TaskStream",
+      payload: { final: true },
+    });
+    expect(env.timestamp).toBe("");
+  });
+
+  it("maps extensions null and omits invalid extension shapes", () => {
+    const withNull = envelopeFromWireJson({
+      id: "e1",
+      asap_version: "2.2",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      sender: "a",
+      recipient: "b",
+      payload_type: "x",
+      payload: {},
+      extensions: null,
+    });
+    expect(withNull.extensions).toBeNull();
+
+    const withNumber = envelopeFromWireJson({
+      id: "e2",
+      asap_version: "2.2",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      sender: "a",
+      recipient: "b",
+      payload_type: "x",
+      payload: {},
+      extensions: 42,
+    });
+    expect(withNumber.extensions).toBeUndefined();
+  });
+});

--- a/packages/typescript/client/test/errors-rpc.test.ts
+++ b/packages/typescript/client/test/errors-rpc.test.ts
@@ -53,4 +53,29 @@ describe("errors RPC taxonomy (TS-011)", () => {
     });
     expect(err).toBeInstanceOf(RemoteRecoverableRPCError);
   });
+
+  it("pop remote meta filters alternative_agents and maps fallback_action", () => {
+    const err = RemoteFatalRPCError.fromJsonRpc(RPC_REMOTE_GENERIC, "try others", {
+      alternative_agents: ["urn:a:ok", 42, "urn:b:ok"],
+      fallback_action: "retry_later",
+    });
+    expect(err.alternativeAgents).toEqual(["urn:a:ok", "urn:b:ok"]);
+    expect(err.fallbackAction).toBe("retry_later");
+  });
+
+  it("pop remote meta applies asap taxonomy from data.code when present", () => {
+    const err = RemoteFatalRPCError.fromJsonRpc(RPC_REMOTE_GENERIC, "typed", {
+      code: "asap:capabilities/unsupported",
+      detail: "x",
+    });
+    expect(err.taxonomyCode).toBe("asap:capabilities/unsupported");
+    expect((err.details as { detail?: string }).detail).toBe("x");
+  });
+
+  it("omits alternativeAgents when every entry is non-string", () => {
+    const err = RemoteFatalRPCError.fromJsonRpc(RPC_REMOTE_GENERIC, "none", {
+      alternative_agents: [1, {}, null],
+    });
+    expect(err.alternativeAgents).toBeUndefined();
+  });
 });

--- a/packages/typescript/client/test/streaming.test.ts
+++ b/packages/typescript/client/test/streaming.test.ts
@@ -118,6 +118,37 @@ describe("streaming (TS-010, task 4.2)", () => {
     expect(chunks[0]?.payload.final).toBe(true);
   });
 
+  it("parses SSE split across multiple stream chunks", async () => {
+    const wire = JSON.stringify(taskStreamEnvelope({ id: "s1", final: true, chunk: "done" }));
+    const payload = `data: ${wire}\n\n`;
+    const enc = new TextEncoder();
+    const cut = 7;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(enc.encode(payload.slice(0, cut)));
+        controller.enqueue(enc.encode(payload.slice(cut)));
+        controller.close();
+      },
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(stream, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+    );
+    const client = createAsapStreamClient({
+      baseUrl: "https://provider.example",
+      fetch: fetchMock as typeof fetch,
+    });
+    const chunks: EnvelopeFor<"TaskStream">[] = [];
+    for await (const env of client.stream(taskRequestEnvelope())) {
+      chunks.push(env);
+    }
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.payload.final).toBe(true);
+  });
+
   it("stops iteration when AbortSignal aborts (ReadableStream cancellation)", async () => {
     const wire1 = JSON.stringify(taskStreamEnvelope({ id: "s1", final: false, chunk: "x" }));
 

--- a/packages/typescript/client/test/transport-retry.test.ts
+++ b/packages/typescript/client/test/transport-retry.test.ts
@@ -85,6 +85,22 @@ describe("transport retry (TS-011)", () => {
     expect(op).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry RemoteRecoverableRPCError without retryAfterMs when no fallback backoff", async () => {
+    const err = new RemoteRecoverableRPCError({
+      wireJsonRpcCode: RPC_THREAD_POOL_EXHAUSTED,
+      message: "no hint",
+    });
+    const op = vi.fn().mockRejectedValue(err);
+    await expect(
+      callWithRecoverableRetry(op, {
+        sleep: vi.fn(async () => {
+          /* noop */
+        }),
+      }),
+    ).rejects.toBe(err);
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
   it("retries RecoverableError without retryAfterMs when fallbackBackoffMs is set", async () => {
     let calls = 0;
     const op = vi.fn().mockImplementation(async () => {
@@ -121,5 +137,43 @@ describe("transport retry (TS-011)", () => {
       sleep,
     });
     expect(sleep).toHaveBeenLastCalledWith(60_000);
+  });
+
+  it("retries RemoteRecoverableRPCError without retryAfterMs when fallbackBackoffMs is set", async () => {
+    let calls = 0;
+    const op = vi.fn().mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new RemoteRecoverableRPCError({
+          wireJsonRpcCode: RPC_THREAD_POOL_EXHAUSTED,
+          message: "no hint",
+        });
+      }
+      return { ok: true as const };
+    });
+    const sleep = vi.fn(async () => {
+      /* noop */
+    });
+    const result = await callWithRecoverableRetry(op, { fallbackBackoffMs: 200, sleep });
+    expect(result).toEqual({ ok: true });
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(200);
+  });
+
+  it("uses default sleep when sleep is not injected", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const op = vi.fn().mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new RecoverableError({ code: "HINTED", retryAfterMs: 0 });
+      }
+      return { ok: true as const };
+    });
+    const p = callWithRecoverableRetry(op, { maxRetries: 5 });
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toEqual({ ok: true });
+    expect(op).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 });

--- a/packages/typescript/mastra/src/asap-to-mastra-tool.ts
+++ b/packages/typescript/mastra/src/asap-to-mastra-tool.ts
@@ -27,9 +27,9 @@ function isRecord(x: unknown): x is Record<string, unknown> {
 }
 
 /**
- * Wraps a {@link CapabilityFetch} to map select provider **403** JSON error payloads into typed errors.
+ * Wraps a {@link CapabilityFetch} to map select provider HTTP 403 JSON error payloads into typed errors.
  *
- * **Unary JSON only:** non-403 responses are returned as-is so bodies are not buffered. Do not use this
+ * Unary JSON only: non-403 responses are returned as-is so bodies are not buffered. Do not use this
  * wrapper for SSE or other streaming responses; the contract assumes small JSON payloads suitable for
  * `describeCapability` / `executeCapability`.
  */

--- a/packages/typescript/mastra/src/index.ts
+++ b/packages/typescript/mastra/src/index.ts
@@ -1,6 +1,4 @@
-/**
- * Public API for @asap-protocol/mastra (implemented in sprint tasks 2.x–4.x).
- */
+/** Mastra integration: ASAP capabilities as Mastra `createTool` definitions. */
 
 export {
   asapToolsForMastra,

--- a/packages/typescript/mastra/test/asap-to-mastra-tool.test.ts
+++ b/packages/typescript/mastra/test/asap-to-mastra-tool.test.ts
@@ -185,6 +185,41 @@ describe("asapToolsForMastra", () => {
     await expect(tool.execute?.({})).rejects.toThrow(/constraint violated/i);
   });
 
+  it("skips describeCapability when inputSchemas already defines the capability", async () => {
+    vi.spyOn(asapClient, "executeCapability").mockResolvedValue({ ok: true });
+    describeCapabilityMock.mockResolvedValue({ name: "demo_echo", description: "unused" });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+    };
+    await asapToolsForMastra(client, {
+      inputSchemas: {
+        "urn:asap:cap:demo_echo": {
+          type: "object",
+          properties: { message: { type: "string" } },
+        },
+      },
+      outputSchemas: {
+        "urn:asap:cap:demo_echo": { type: "object", additionalProperties: true },
+      },
+    });
+    expect(describeCapabilityMock).not.toHaveBeenCalled();
+  });
+
+  it("builds tools when describeCapability fails", async () => {
+    describeCapabilityMock.mockRejectedValue(new Error("describe unavailable"));
+    const spy = vi.spyOn(asapClient, "executeCapability").mockResolvedValue({ ok: true });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+    };
+    const tools = await asapToolsForMastra(client);
+    expect(tools).toHaveLength(1);
+    const tool = tools[0] as { execute?: (input: unknown) => Promise<unknown> };
+    await tool.execute?.({});
+    expect(spy).toHaveBeenCalled();
+  });
+
   it("exposes asapToolsForMastraSync for pre-supplied schemas", () => {
     const client = {
       provider: new URL("http://localhost:8080/"),

--- a/packages/typescript/mastra/test/errors.test.ts
+++ b/packages/typescript/mastra/test/errors.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ApprovalRequiredError, CapabilityNotGrantedError } from "../src/errors.js";
+
+describe("adapter errors", () => {
+  it("parses approval_url from non-array object detail", () => {
+    const err = new ApprovalRequiredError("needs sign-off", {
+      approval_url: "https://example/approve",
+    });
+    expect(err.detail).toEqual({ approval_url: "https://example/approve" });
+  });
+
+  it("ignores approval detail when data is not a plain object", () => {
+    const err = new ApprovalRequiredError("x", []);
+    expect(err.detail).toBeUndefined();
+  });
+
+  it("invokes requestCapability hook when provided", async () => {
+    const hook = vi.fn().mockResolvedValue(undefined);
+    const err = new CapabilityNotGrantedError("cap:read", hook, "custom");
+    expect(err.message).toBe("custom");
+    await err.requestCapability();
+    expect(hook).toHaveBeenCalledWith("cap:read");
+  });
+});

--- a/packages/typescript/openai-agents/.npmrc
+++ b/packages/typescript/openai-agents/.npmrc
@@ -1,0 +1,1 @@
+access=public

--- a/packages/typescript/openai-agents/README.md
+++ b/packages/typescript/openai-agents/README.md
@@ -1,0 +1,49 @@
+# `@asap-protocol/openai-agents`
+
+## ⚠️ This is **not** `@asap-protocol/client/adapters/openai`
+
+[`@asap-protocol/client/adapters/openai`](https://github.com/adriannoes/asap-protocol/tree/main/packages/typescript/client/src/adapters/openai.ts) exposes **`asapToolsForOpenAI`**, producing **static `ChatCompletionTool[]`** for the **OpenAI Chat Completions API** (`openai` npm package, no Agents runtime).
+
+**`@asap-protocol/openai-agents`** integrates with the **`@openai/agents` SDK** (`Agent`, `tool()`, handoffs, `run()`). Different consumer and lifecycle — **both packages coexist**.
+
+## Overview
+
+Maps ASAP **capabilities** to OpenAI Agents **`tool()`** definitions (using **`executeCapability`** from **`@asap-protocol/client`**), optionally wraps an **`Agent`** intended as a **handoff** target against an ASAP gateway, and bridges ASAP **`task_stream`** payloads into incremental **text deltas**.
+
+## Peer dependencies
+
+| Package | Range |
+|---------|-------|
+| `@asap-protocol/client` | `^2.3.0` |
+| `@openai/agents` | `^0.11.0` (patch drift tolerated; CI pins **`0.11.4`** + **`latest`**) |
+| `zod` | `^3.25.76` **or** `^4.1.8` |
+
+Node **≥ 18**.
+
+## Usage
+
+See [`docs/integrations/openai-agents.md`](../../../docs/integrations/openai-agents.md) and [`apps/example-openai-agents/`](../../../apps/example-openai-agents/).
+
+```typescript
+import { Agent, run, setDefaultOpenAIKey } from "@openai/agents";
+import type { AsapExecuteClient } from "@asap-protocol/client";
+import { asapToolsForOpenAIAgents } from "@asap-protocol/openai-agents";
+
+declare const client: AsapExecuteClient;
+
+setDefaultOpenAIKey(process.env.OPENAI_API_KEY ?? "");
+
+const tools = await asapToolsForOpenAIAgents(client);
+const agent = new Agent({
+  name: "demo",
+  instructions: "Use ASAP tools when helpful.",
+  model: "gpt-4o-mini",
+  tools: [...tools],
+});
+
+await run(agent, "Echo hello via ASAP.");
+```
+
+## Status
+
+Pre-release **`0.0.0`** workspace package until publish workflow promotes a semver tag.

--- a/packages/typescript/openai-agents/README.md
+++ b/packages/typescript/openai-agents/README.md
@@ -16,9 +16,13 @@ Maps ASAP **capabilities** to OpenAI Agents **`tool()`** definitions (using **`e
 |---------|-------|
 | `@asap-protocol/client` | `^2.3.0` |
 | `@openai/agents` | `^0.11.0` (patch drift tolerated; CI pins **`0.11.4`** + **`latest`**) |
-| `zod` | `^3.25.76` **or** `^4.1.8` |
+| `zod` | `^4.1.8` (aligned with `@openai/agents`; Zod 3 is not supported) |
 
 Node **≥ 18**.
+
+!!! warning "Pre-1.0 `@openai/agents` API drift"
+
+    **`@openai/agents` is pre-1.0.** Minor/patch releases may change `Agent` constructor options, `tool()` parameter shapes, or default tool error handling. Pin your dependency and re-run tests after upgrades; CI exercises **`latest`** and **`0.11.4`**.
 
 ## Usage
 

--- a/packages/typescript/openai-agents/eslint.config.js
+++ b/packages/typescript/openai-agents/eslint.config.js
@@ -1,0 +1,27 @@
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    ignores: ["dist/**", ".tshy/**", "coverage/**"],
+  },
+  {
+    files: ["src/**/*.ts", "test/**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-empty-object-type": "off",
+      "@typescript-eslint/triple-slash-reference": "off",
+    },
+  },
+);

--- a/packages/typescript/openai-agents/package.json
+++ b/packages/typescript/openai-agents/package.json
@@ -17,7 +17,7 @@
   "peerDependencies": {
     "@asap-protocol/client": "^2.3.0",
     "@openai/agents": "^0.11.0",
-    "zod": "^3.25.76 || ^4.1.8"
+    "zod": "^4.1.8"
   },
   "dependencies": {},
   "files": [

--- a/packages/typescript/openai-agents/package.json
+++ b/packages/typescript/openai-agents/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@asap-protocol/openai-agents",
+  "version": "0.0.0",
+  "description": "ASAP Protocol capabilities as OpenAI Agents SDK tools (@openai/agents)",
+  "type": "module",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adriannoes/asap-protocol"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "peerDependencies": {
+    "@asap-protocol/client": "^2.3.0",
+    "@openai/agents": "^0.11.0",
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "dependencies": {},
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tshy",
+    "test": "vitest run --coverage",
+    "test:no-coverage": "vitest run",
+    "lint": "eslint .",
+    "check:treeshake": "pnpm run build && agadoo ./dist/esm/index.js",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "devDependencies": {
+    "@asap-protocol/client": "workspace:*",
+    "@eslint/js": "9.18.0",
+    "@openai/agents": "^0.11.4",
+    "@types/node": "^20.19.0",
+    "@vitest/coverage-v8": "4.1.5",
+    "agadoo": "3.0.0",
+    "eslint": "9.18.0",
+    "tshy": "^3.3.2",
+    "typescript": "^5.8.3",
+    "typescript-eslint": "8.59.1",
+    "vitest": "^4.1.1",
+    "zod": "^4.4.2"
+  },
+  "tshy": {
+    "project": "./tsconfig.build.json",
+    "exports": {
+      ".": "./src/index.ts"
+    }
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    }
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
+}

--- a/packages/typescript/openai-agents/src/asap-as-remote-agent.ts
+++ b/packages/typescript/openai-agents/src/asap-as-remote-agent.ts
@@ -6,6 +6,7 @@ import {
   type AsapToolsForOpenAIAgentsOptions,
   asapToolsForOpenAIAgents,
 } from "./asap-to-openai-tool.js";
+import { sendAsapEnvelope } from "./send-asap-envelope.js";
 
 export type AsapRemoteAgentMode = "delegated" | "autonomous";
 
@@ -22,6 +23,11 @@ export interface AsapAsRemoteAgentOptions {
   readonly handoffDescription?: string;
   readonly model?: string;
   readonly toolsOptions?: AsapToolsForOpenAIAgentsOptions;
+  /**
+   * Agent JWT scoped to `providerUrl` when it differs from `client.provider`.
+   * Required for cross-provider handoffs when `client.agentJwt` is set.
+   */
+  readonly remoteAgentJwt?: string;
 }
 
 function serializeTurnInput(turnInput: string | AgentInputItem[] | undefined): string {
@@ -36,6 +42,13 @@ function serializeTurnInput(turnInput: string | AgentInputItem[] | undefined): s
   } catch {
     return "";
   }
+}
+
+/**
+ * Returns whether two provider URLs refer to the same ASAP host path (origin + pathname).
+ */
+export function sameProviderOrigin(a: URL, b: URL): boolean {
+  return a.origin === b.origin && a.pathname === b.pathname;
 }
 
 /**
@@ -82,11 +95,43 @@ function resolveProvider(providerUrl: string | URL): URL {
   return typeof providerUrl === "string" ? new URL(providerUrl) : providerUrl;
 }
 
+function resolveHandoffJwt(
+  client: AsapExecuteClient,
+  providerUrl: URL,
+  options?: AsapAsRemoteAgentOptions,
+): string | undefined {
+  if (options?.remoteAgentJwt !== undefined) {
+    return options.remoteAgentJwt;
+  }
+  if (client.agentJwt !== undefined && !sameProviderOrigin(client.provider, providerUrl)) {
+    throw new Error(
+      `client.agentJwt is scoped to ${client.provider.href}; pass remoteAgentJwt when providerUrl (${providerUrl.href}) differs`,
+    );
+  }
+  return client.agentJwt;
+}
+
+function buildMergedClient(
+  client: AsapExecuteClient,
+  resolvedProvider: URL,
+  handoffJwt: string | undefined,
+): AsapExecuteClient {
+  const merged: AsapExecuteClient = {
+    ...client,
+    provider: resolvedProvider,
+  };
+  if (handoffJwt !== undefined) {
+    return { ...merged, agentJwt: handoffJwt };
+  }
+  const { agentJwt: _omit, ...withoutJwt } = merged;
+  return withoutJwt;
+}
+
 /**
  * Returns an OpenAI Agents {@link Agent} backed by ASAP capability tools on `providerUrl`.
  *
  * Subscribes to `agent_start` so {@link AsapRemoteRunContext.lastAsapHandoffEnvelope} captures draft envelope metadata
- * (including {@link AsapAsRemoteAgentOptions.mode}) whenever this agent begins a turn—including after an SDK handoff.
+ * and POSTs a real `task.request` via JSON-RPC `asap.send` whenever this agent begins a turn—including after an SDK handoff.
  */
 export async function asapAsRemoteAgent(
   client: AsapExecuteClient,
@@ -95,10 +140,8 @@ export async function asapAsRemoteAgent(
 ): Promise<Agent<AsapRemoteRunContext>> {
   const mode = options?.mode ?? "delegated";
   const resolvedProvider = resolveProvider(providerUrl);
-  const mergedClient: AsapExecuteClient = {
-    ...client,
-    provider: resolvedProvider,
-  };
+  const handoffJwt = resolveHandoffJwt(client, resolvedProvider, options);
+  const mergedClient = buildMergedClient(client, resolvedProvider, handoffJwt);
 
   const tools = await asapToolsForOpenAIAgents(mergedClient, options?.toolsOptions);
 
@@ -113,10 +156,15 @@ export async function asapAsRemoteAgent(
   });
 
   agent.on("agent_start", (runContext, _self, turnInput) => {
-    runContext.context.lastAsapHandoffEnvelope = draftTaskRequestEnvelopeForRemoteAgent({
+    const draft = draftTaskRequestEnvelopeForRemoteAgent({
       mode,
       providerUrl: resolvedProvider,
       turnInput,
+    });
+    runContext.context.lastAsapHandoffEnvelope = draft;
+    void sendAsapEnvelope(resolvedProvider, draft, {
+      fetch: mergedClient.fetch,
+      agentJwt: mergedClient.agentJwt,
     });
   });
 

--- a/packages/typescript/openai-agents/src/asap-as-remote-agent.ts
+++ b/packages/typescript/openai-agents/src/asap-as-remote-agent.ts
@@ -1,0 +1,124 @@
+import { Agent, type AgentInputItem } from "@openai/agents";
+
+import type { AsapExecuteClient } from "@asap-protocol/client/adapters/shared";
+
+import {
+  type AsapToolsForOpenAIAgentsOptions,
+  asapToolsForOpenAIAgents,
+} from "./asap-to-openai-tool.js";
+
+export type AsapRemoteAgentMode = "delegated" | "autonomous";
+
+/** Mutable bag carried through {@link RunContext} when using {@link asapAsRemoteAgent}. */
+export interface AsapRemoteRunContext {
+  /** Latest draft ASAP envelope captured when this agent starts (including after an SDK handoff). */
+  lastAsapHandoffEnvelope?: Record<string, unknown>;
+}
+
+export interface AsapAsRemoteAgentOptions {
+  readonly mode?: AsapRemoteAgentMode;
+  readonly name?: string;
+  readonly instructions?: string | undefined;
+  readonly handoffDescription?: string;
+  readonly model?: string;
+  readonly toolsOptions?: AsapToolsForOpenAIAgentsOptions;
+}
+
+function serializeTurnInput(turnInput: string | AgentInputItem[] | undefined): string {
+  if (turnInput === undefined) {
+    return "";
+  }
+  if (typeof turnInput === "string") {
+    return turnInput;
+  }
+  try {
+    return JSON.stringify(turnInput);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Draft `task.request`-style envelope metadata used when delegating from OpenAI Agents handoffs to ASAP.
+ *
+ * The gateway still performs authorization and routing; this object mirrors how adapters attach agent mode.
+ */
+export function draftTaskRequestEnvelopeForRemoteAgent(params: {
+  readonly mode: AsapRemoteAgentMode;
+  readonly providerUrl: URL;
+  readonly turnInput?: string | AgentInputItem[];
+}): Record<string, unknown> {
+  const delegatedInput = serializeTurnInput(params.turnInput);
+  return {
+    asap_version: "2.2",
+    sender: "urn:asap:agent:openai-agents-adapter",
+    recipient: params.providerUrl.href,
+    payload_type: "task.request",
+    payload: {
+      conversation_id: "openai-agents-handoff",
+      skill_id: "asap-remote-handoff",
+      input: {
+        query: delegatedInput,
+        asap_agent_mode: params.mode,
+      },
+    },
+    extensions: {
+      asap_agent_mode: params.mode,
+    },
+  };
+}
+
+function defaultInstructions(mode: AsapRemoteAgentMode, capabilities: readonly string[]): string {
+  const list = capabilities.length > 0 ? capabilities.join(", ") : "(none configured)";
+  return [
+    "You are an ASAP-backed specialist agent invoked via OpenAI Agents SDK handoffs.",
+    `Operate in ${mode} mode with respect to host policy.`,
+    `Use the ASAP capability tools wired for this agent (deterministic keys). Capability URNs: ${list}.`,
+    "Pass structured JSON arguments that satisfy each capability schema.",
+  ].join(" ");
+}
+
+function resolveProvider(providerUrl: string | URL): URL {
+  return typeof providerUrl === "string" ? new URL(providerUrl) : providerUrl;
+}
+
+/**
+ * Returns an OpenAI Agents {@link Agent} backed by ASAP capability tools on `providerUrl`.
+ *
+ * Subscribes to `agent_start` so {@link AsapRemoteRunContext.lastAsapHandoffEnvelope} captures draft envelope metadata
+ * (including {@link AsapAsRemoteAgentOptions.mode}) whenever this agent begins a turn—including after an SDK handoff.
+ */
+export async function asapAsRemoteAgent(
+  client: AsapExecuteClient,
+  providerUrl: string | URL,
+  options?: AsapAsRemoteAgentOptions,
+): Promise<Agent<AsapRemoteRunContext>> {
+  const mode = options?.mode ?? "delegated";
+  const resolvedProvider = resolveProvider(providerUrl);
+  const mergedClient: AsapExecuteClient = {
+    ...client,
+    provider: resolvedProvider,
+  };
+
+  const tools = await asapToolsForOpenAIAgents(mergedClient, options?.toolsOptions);
+
+  const agent = new Agent<AsapRemoteRunContext>({
+    name: options?.name ?? `asap-remote-${resolvedProvider.hostname}`,
+    instructions: options?.instructions ?? defaultInstructions(mode, mergedClient.capabilities),
+    handoffDescription:
+      options?.handoffDescription ??
+      `Delegates to ASAP capabilities at ${resolvedProvider.href} (${mode} mode).`,
+    model: options?.model ?? "gpt-4o-mini",
+    tools: [...tools],
+  });
+
+  agent.on("agent_start", (runContext, _self, turnInput) => {
+    runContext.context.lastAsapHandoffEnvelope = draftTaskRequestEnvelopeForRemoteAgent({
+      mode,
+      providerUrl: resolvedProvider,
+      turnInput,
+    });
+  });
+
+  return agent;
+}

--- a/packages/typescript/openai-agents/src/asap-to-openai-tool.ts
+++ b/packages/typescript/openai-agents/src/asap-to-openai-tool.ts
@@ -44,6 +44,34 @@ export interface AsapToolsForOpenAIAgentsOptions {
   readonly requestCapability?: (requiredCapability: string) => void | Promise<void>;
   readonly inputSchemas?: Readonly<Record<string, unknown>>;
   readonly outputSchemas?: Readonly<Record<string, unknown>>;
+  /**
+   * Called when {@link describeCapability} fails for a capability. The error is rethrown unless
+   * {@link allowPermissiveDescribeFallback} is `true`.
+   */
+  readonly onDescribeError?: (capabilityId: string, error: unknown) => void;
+  /**
+   * When `true`, failed describe calls fall back to generic tool metadata instead of failing
+   * tool construction. Defaults to `false`.
+   */
+  readonly allowPermissiveDescribeFallback?: boolean;
+  /** Passed to {@link describeCapability} and {@link executeCapability} fetch calls. */
+  readonly signal?: AbortSignal;
+}
+
+const DESCRIBE_CONCURRENCY = 5;
+
+async function mapInBatches<T, R>(
+  items: readonly T[],
+  batchSize: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const batchResults = await Promise.all(batch.map(fn));
+    results.push(...batchResults);
+  }
+  return results;
 }
 
 function isRecord(x: unknown): x is Record<string, unknown> {
@@ -109,8 +137,17 @@ function buildTools(
   options: AsapToolsForOpenAIAgentsOptions | undefined,
 ): ReturnType<typeof tool>[] {
   const tools: ReturnType<typeof tool>[] = [];
+  const seenToolNames = new Map<string, string>();
   for (const capabilityId of client.capabilities) {
     const id = capabilityToolKey(capabilityId);
+    const existingCapabilityId = seenToolNames.get(id);
+    if (existingCapabilityId !== undefined && existingCapabilityId !== capabilityId) {
+      throw new Error(
+        `OpenAI Agents tool name collision: "${id}" maps to both "${existingCapabilityId}" and "${capabilityId}". ` +
+          "Use distinct capability identifiers or provide inputSchemas to skip describe.",
+      );
+    }
+    seenToolNames.set(id, capabilityId);
     const described = describedByCapability.get(capabilityId);
     const inputJson = jsonSchemaForCapabilityInput(
       options?.inputSchemas?.[capabilityId] ?? described?.input_schema,
@@ -123,6 +160,7 @@ function buildTools(
       return executeCapability(client.provider, capabilityId, ctx, {
         agentJwt: client.agentJwt,
         fetch: fetchFn,
+        signal: options?.signal,
       });
     };
 
@@ -173,26 +211,36 @@ export async function asapToolsForOpenAIAgents(
     | undefined
   >();
 
+  const toDescribe = client.capabilities.filter(
+    (capabilityId) => options?.inputSchemas?.[capabilityId] === undefined,
+  );
   for (const capabilityId of client.capabilities) {
     if (options?.inputSchemas?.[capabilityId] !== undefined) {
       describedByCapability.set(capabilityId, undefined);
-      continue;
     }
-    const described = await describeCapability(client.provider, capabilityId, {
-      fetch: fetchFn,
-      agentJwt: client.agentJwt,
-    }).catch(() => undefined);
+  }
 
-    if (described === undefined) {
-      describedByCapability.set(capabilityId, undefined);
-    } else {
+  await mapInBatches(toDescribe, DESCRIBE_CONCURRENCY, async (capabilityId) => {
+    try {
+      const described = await describeCapability(client.provider, capabilityId, {
+        fetch: fetchFn,
+        agentJwt: client.agentJwt,
+        signal: options?.signal,
+      });
       describedByCapability.set(capabilityId, {
         description: described.description,
         input_schema: described.input_schema,
         output_schema: described.output_schema,
       });
+    } catch (error: unknown) {
+      options?.onDescribeError?.(capabilityId, error);
+      if (options?.allowPermissiveDescribeFallback === true) {
+        describedByCapability.set(capabilityId, undefined);
+        return;
+      }
+      throw error;
     }
-  }
+  });
 
   return buildTools(client, fetchFn, describedByCapability, options);
 }

--- a/packages/typescript/openai-agents/src/asap-to-openai-tool.ts
+++ b/packages/typescript/openai-agents/src/asap-to-openai-tool.ts
@@ -1,0 +1,222 @@
+import { tool } from "@openai/agents";
+import { describeCapability, executeCapability, type CapabilityFetch } from "@asap-protocol/client";
+import {
+  capabilityToolKey,
+  jsonSchemaForCapabilityInput,
+  type AsapExecuteClient,
+} from "@asap-protocol/client/adapters/shared";
+import type { ZodObject } from "zod";
+import { z } from "zod";
+
+import { ApprovalRequiredError, CapabilityNotGrantedError } from "./errors.js";
+import { zodFromJsonSchema } from "./schema-bridge.js";
+
+/** JSON Schema object accepted by `tool({ strict: false })` (SDK types are not exported from `@openai/agents`). */
+type OpenAIAgentsNonStrictToolParameters = Extract<Parameters<typeof tool>[0], { strict: false }>["parameters"];
+
+type BuiltToolParameters =
+  | { readonly mode: "zod"; readonly schema: ZodObject<Record<string, z.ZodTypeAny>> }
+  | { readonly mode: "json"; readonly schema: Record<string, unknown> };
+
+function buildToolParameters(inputJson: Record<string, unknown>): BuiltToolParameters {
+  const props = inputJson.properties;
+  const hasProps =
+    inputJson.type === "object" &&
+    typeof props === "object" &&
+    props !== null &&
+    !Array.isArray(props) &&
+    Object.keys(props).length > 0;
+
+  if (hasProps) {
+    const zSch = zodFromJsonSchema(inputJson);
+    if (zSch instanceof z.ZodObject) {
+      return { mode: "zod", schema: zSch.strict() };
+    }
+  }
+
+  return { mode: "json", schema: inputJson };
+}
+
+export interface AsapToolsForOpenAIAgentsOptions {
+  /**
+   * Invoked when the provider returns `403` with `error.code === "capability_not_granted"`.
+   */
+  readonly requestCapability?: (requiredCapability: string) => void | Promise<void>;
+  readonly inputSchemas?: Readonly<Record<string, unknown>>;
+  readonly outputSchemas?: Readonly<Record<string, unknown>>;
+}
+
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function wrapFetchWithCapabilityErrors(
+  base: CapabilityFetch | undefined,
+  options: AsapToolsForOpenAIAgentsOptions | undefined,
+): CapabilityFetch {
+  const impl = base ?? globalThis.fetch;
+  return async (input, init) => {
+    const res = await impl(input, init);
+    if (res.status !== 403) {
+      return res;
+    }
+    const text = await res.clone().text();
+    let parsed: unknown;
+    try {
+      parsed = text.length === 0 ? {} : JSON.parse(text);
+    } catch {
+      return new Response(text, { status: res.status, statusText: res.statusText, headers: res.headers });
+    }
+    if (!isRecord(parsed)) {
+      return new Response(text, { status: res.status, statusText: res.statusText, headers: res.headers });
+    }
+    if (parsed.error === "constraint_violated") {
+      return new Response(text, { status: res.status, statusText: res.statusText, headers: res.headers });
+    }
+    const errObj = parsed.error;
+    if (!isRecord(errObj)) {
+      return new Response(text, { status: res.status, statusText: res.statusText, headers: res.headers });
+    }
+    const code = errObj.code;
+    if (code === "capability_not_granted") {
+      const data = isRecord(errObj.data) ? errObj.data : undefined;
+      const required =
+        typeof data?.required_capability === "string" ? data.required_capability : "";
+      const msg = typeof errObj.message === "string" ? errObj.message : undefined;
+      throw new CapabilityNotGrantedError(required, options?.requestCapability, msg);
+    }
+    if (code === "approval_required") {
+      const msg =
+        typeof errObj.message === "string" ? errObj.message : "Capability execution requires approval";
+      throw new ApprovalRequiredError(msg, errObj.data);
+    }
+    return new Response(text, { status: res.status, statusText: res.statusText, headers: res.headers });
+  };
+}
+
+function buildTools(
+  client: AsapExecuteClient,
+  fetchFn: CapabilityFetch,
+  describedByCapability: ReadonlyMap<
+    string,
+    | {
+        readonly description: string;
+        readonly input_schema?: unknown;
+        readonly output_schema?: unknown;
+      }
+    | undefined
+  >,
+  options: AsapToolsForOpenAIAgentsOptions | undefined,
+): ReturnType<typeof tool>[] {
+  const tools: ReturnType<typeof tool>[] = [];
+  for (const capabilityId of client.capabilities) {
+    const id = capabilityToolKey(capabilityId);
+    const described = describedByCapability.get(capabilityId);
+    const inputJson = jsonSchemaForCapabilityInput(
+      options?.inputSchemas?.[capabilityId] ?? described?.input_schema,
+    );
+
+    const built = buildToolParameters(inputJson);
+
+    const exec = async (input: unknown): Promise<unknown> => {
+      const ctx = isRecord(input) ? input : {};
+      return executeCapability(client.provider, capabilityId, ctx, {
+        agentJwt: client.agentJwt,
+        fetch: fetchFn,
+      });
+    };
+
+    if (built.mode === "zod") {
+      tools.push(
+        tool({
+          name: id,
+          description: described?.description ?? `ASAP capability: ${capabilityId}`,
+          parameters: built.schema,
+          strict: true,
+          errorFunction: null,
+          execute: exec,
+        }),
+      );
+    } else {
+      tools.push(
+        tool({
+          name: id,
+          description: described?.description ?? `ASAP capability: ${capabilityId}`,
+          parameters: built.schema as OpenAIAgentsNonStrictToolParameters,
+          strict: false,
+          errorFunction: null,
+          execute: exec,
+        }),
+      );
+    }
+  }
+  return tools;
+}
+
+/**
+ * Build OpenAI Agents SDK {@link tool} instances for each ASAP capability on the client.
+ *
+ * Uses top-level {@link executeCapability} from `@asap-protocol/client` on each execution path.
+ */
+export async function asapToolsForOpenAIAgents(
+  client: AsapExecuteClient,
+  options?: AsapToolsForOpenAIAgentsOptions,
+): Promise<readonly ReturnType<typeof tool>[]> {
+  const fetchFn = wrapFetchWithCapabilityErrors(client.fetch, options);
+  const describedByCapability = new Map<
+    string,
+    | {
+        readonly description: string;
+        readonly input_schema?: unknown;
+        readonly output_schema?: unknown;
+      }
+    | undefined
+  >();
+
+  for (const capabilityId of client.capabilities) {
+    if (options?.inputSchemas?.[capabilityId] !== undefined) {
+      describedByCapability.set(capabilityId, undefined);
+      continue;
+    }
+    const described = await describeCapability(client.provider, capabilityId, {
+      fetch: fetchFn,
+      agentJwt: client.agentJwt,
+    }).catch(() => undefined);
+
+    if (described === undefined) {
+      describedByCapability.set(capabilityId, undefined);
+    } else {
+      describedByCapability.set(capabilityId, {
+        description: described.description,
+        input_schema: described.input_schema,
+        output_schema: described.output_schema,
+      });
+    }
+  }
+
+  return buildTools(client, fetchFn, describedByCapability, options);
+}
+
+/**
+ * Synchronous variant when {@link AsapToolsForOpenAIAgentsOptions.inputSchemas} / `outputSchemas`
+ * are already materialized (skips describe round-trips).
+ */
+export function asapToolsForOpenAIAgentsSync(
+  client: AsapExecuteClient,
+  options?: AsapToolsForOpenAIAgentsOptions,
+): readonly ReturnType<typeof tool>[] {
+  const fetchFn = wrapFetchWithCapabilityErrors(client.fetch, options);
+  const describedByCapability = new Map<
+    string,
+    | {
+        readonly description: string;
+        readonly input_schema?: unknown;
+        readonly output_schema?: unknown;
+      }
+    | undefined
+  >();
+  for (const capabilityId of client.capabilities) {
+    describedByCapability.set(capabilityId, undefined);
+  }
+  return buildTools(client, fetchFn, describedByCapability, options);
+}

--- a/packages/typescript/openai-agents/src/errors.ts
+++ b/packages/typescript/openai-agents/src/errors.ts
@@ -1,0 +1,70 @@
+export {
+  FatalError,
+  RecoverableError,
+  RemoteFatalRPCError,
+  RemoteRecoverableRPCError,
+} from "@asap-protocol/client";
+
+/**
+ * Structured `approval_required` payload (`error.data`) from an ASAP provider JSON body.
+ */
+export interface ApprovalRequiredDetail {
+  readonly reason?: string;
+  readonly approval_url?: string;
+}
+
+function approvalDetailFromUnknown(data: unknown): ApprovalRequiredDetail | undefined {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return undefined;
+  }
+  const rec = data as Record<string, unknown>;
+  const reason = rec.reason;
+  const approval_url = rec.approval_url;
+  const detail: { reason?: string; approval_url?: string } = {};
+  if (typeof reason === "string") {
+    detail.reason = reason;
+  }
+  if (typeof approval_url === "string") {
+    detail.approval_url = approval_url;
+  }
+  return Object.keys(detail).length > 0 ? (detail as ApprovalRequiredDetail) : undefined;
+}
+
+/**
+ * Raised when the provider indicates an approval step is required before the capability can run.
+ */
+export class ApprovalRequiredError extends Error {
+  override readonly name = "ApprovalRequiredError";
+
+  readonly detail?: ApprovalRequiredDetail;
+
+  constructor(message = "Capability execution requires approval", detail?: unknown) {
+    super(message);
+    this.detail = approvalDetailFromUnknown(detail);
+  }
+}
+
+/**
+ * Raised when the agent JWT is valid but the capability is not granted (HTTP 403 `capability_not_granted`).
+ */
+export class CapabilityNotGrantedError extends Error {
+  override readonly name = "CapabilityNotGrantedError";
+
+  readonly requiredCapability: string;
+
+  private readonly hook?: (capability: string) => void | Promise<void>;
+
+  constructor(
+    requiredCapability: string,
+    requestCapability?: (capability: string) => void | Promise<void>,
+    message?: string,
+  ) {
+    super(message ?? `Capability not granted: ${requiredCapability}`);
+    this.requiredCapability = requiredCapability;
+    this.hook = requestCapability;
+  }
+
+  requestCapability(): void | Promise<void> {
+    return this.hook?.(this.requiredCapability);
+  }
+}

--- a/packages/typescript/openai-agents/src/index.ts
+++ b/packages/typescript/openai-agents/src/index.ts
@@ -12,10 +12,16 @@ export {
 export {
   asapAsRemoteAgent,
   draftTaskRequestEnvelopeForRemoteAgent,
+  sameProviderOrigin,
   type AsapAsRemoteAgentOptions,
   type AsapRemoteAgentMode,
   type AsapRemoteRunContext,
 } from "./asap-as-remote-agent.js";
+export {
+  sendAsapEnvelope,
+  type SendAsapEnvelopeOptions,
+  type SendAsapFetch,
+} from "./send-asap-envelope.js";
 export { zodFromJsonSchema } from "./schema-bridge.js";
 export {
   asapStreamToOpenAIAgentsRunStreamChunks,

--- a/packages/typescript/openai-agents/src/index.ts
+++ b/packages/typescript/openai-agents/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * OpenAI Agents SDK (`@openai/agents`) integration: ASAP capabilities as `tool()` and related helpers.
+ *
+ * For static `ChatCompletionTool[]` against the Chat Completions HTTP API, use `@asap-protocol/client/adapters/openai` instead.
+ */
+
+export {
+  asapToolsForOpenAIAgents,
+  asapToolsForOpenAIAgentsSync,
+  type AsapToolsForOpenAIAgentsOptions,
+} from "./asap-to-openai-tool.js";
+export {
+  asapAsRemoteAgent,
+  draftTaskRequestEnvelopeForRemoteAgent,
+  type AsapAsRemoteAgentOptions,
+  type AsapRemoteAgentMode,
+  type AsapRemoteRunContext,
+} from "./asap-as-remote-agent.js";
+export { zodFromJsonSchema } from "./schema-bridge.js";
+export {
+  asapStreamToOpenAIAgentsRunStreamChunks,
+  asapStreamToOpenAIAgentsTextStream,
+  type OpenAIAgentsStreamTextDelta,
+} from "./streaming.js";
+export * from "./errors.js";

--- a/packages/typescript/openai-agents/src/schema-bridge.ts
+++ b/packages/typescript/openai-agents/src/schema-bridge.ts
@@ -1,5 +1,56 @@
 import { z, type ZodType } from "zod";
 
+type EnumLiteralKind = "string" | "number" | "boolean" | "null" | "unsupported";
+
+function enumLiteralKind(value: unknown): EnumLiteralKind {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return typeof value as "string" | "number" | "boolean";
+  }
+  return "unsupported";
+}
+
+function zodFromJsonSchemaEnum(enumValues: unknown[]): ZodType<unknown> {
+  if (enumValues.length === 0) {
+    throw new Error("JSON Schema enum must contain at least one value");
+  }
+
+  const kinds = new Set<EnumLiteralKind>();
+  for (const value of enumValues) {
+    kinds.add(enumLiteralKind(value));
+  }
+
+  if (kinds.has("unsupported")) {
+    throw new Error("JSON Schema enum supports only string, number, boolean, and null literals");
+  }
+
+  const nonNullKinds = [...kinds].filter((kind) => kind !== "null");
+  if (nonNullKinds.length > 1) {
+    throw new Error(
+      `JSON Schema enum with mixed primitive types is unsupported (found: ${[...kinds].join(", ")})`,
+    );
+  }
+
+  const literals = enumValues.map((value) => {
+    if (value === null) {
+      return z.null();
+    }
+    if (typeof value === "string") {
+      return z.literal(value);
+    }
+    if (typeof value === "number") {
+      return z.literal(value);
+    }
+    return z.literal(value as boolean);
+  });
+
+  return literals.length === 1
+    ? literals[0]!
+    : z.union(literals as unknown as [ZodType<unknown>, ZodType<unknown>, ...ZodType<unknown>[]]);
+}
+
 /**
  * Minimal JSON Schema → Zod bridge for adapter tool schemas (subset only).
  *
@@ -18,6 +69,9 @@ export function zodFromJsonSchema(schema: Record<string, unknown>): ZodType<unkn
       : branches.length === 1
         ? branches[0]!
         : z.union(branches as [ZodType<unknown>, ZodType<unknown>, ...ZodType<unknown>[]]);
+  }
+  if ("enum" in schema && Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return zodFromJsonSchemaEnum(schema.enum);
   }
   switch (schema.type) {
     case "object": {
@@ -52,8 +106,13 @@ export function zodFromJsonSchema(schema: Record<string, unknown>): ZodType<unkn
       return z.number();
     case "boolean":
       return z.boolean();
-    case "array":
+    case "array": {
+      const items = schema.items;
+      if (typeof items === "object" && items !== null && !Array.isArray(items)) {
+        return z.array(zodFromJsonSchema(items as Record<string, unknown>));
+      }
       return z.array(z.unknown());
+    }
     default:
       return z.record(z.string(), z.unknown());
   }

--- a/packages/typescript/openai-agents/src/schema-bridge.ts
+++ b/packages/typescript/openai-agents/src/schema-bridge.ts
@@ -1,0 +1,60 @@
+import { z, type ZodType } from "zod";
+
+/**
+ * Minimal JSON Schema → Zod bridge for adapter tool schemas (subset only).
+ *
+ * Lossy for `$ref` / complex `oneOf`; mirrors `@asap-protocol/mastra` / legacy Chat Completions adapter patterns.
+ */
+export function zodFromJsonSchema(schema: Record<string, unknown>): ZodType<unknown> {
+  if ("$ref" in schema) {
+    return z.record(z.string(), z.unknown());
+  }
+  if ("oneOf" in schema && Array.isArray(schema.oneOf)) {
+    const branches = schema.oneOf
+      .filter((s): s is Record<string, unknown> => typeof s === "object" && s !== null && !Array.isArray(s))
+      .map((s) => zodFromJsonSchema(s));
+    return branches.length === 0
+      ? z.unknown()
+      : branches.length === 1
+        ? branches[0]!
+        : z.union(branches as [ZodType<unknown>, ZodType<unknown>, ...ZodType<unknown>[]]);
+  }
+  switch (schema.type) {
+    case "object": {
+      const maybeProps = schema.properties;
+      if (
+        maybeProps !== undefined &&
+        typeof maybeProps === "object" &&
+        maybeProps !== null &&
+        !Array.isArray(maybeProps)
+      ) {
+        const propsRecord = maybeProps as Record<string, unknown>;
+        const required = new Set(
+          Array.isArray(schema.required) ? schema.required.filter((k): k is string => typeof k === "string") : [],
+        );
+        const shape: Record<string, ZodType<unknown>> = {};
+        for (const [key, val] of Object.entries(propsRecord)) {
+          if (typeof val === "object" && val !== null && !Array.isArray(val)) {
+            const child = zodFromJsonSchema(val as Record<string, unknown>);
+            shape[key] = required.has(key) ? child : child.optional();
+          }
+        }
+        if (Object.keys(shape).length > 0) {
+          return z.object(shape);
+        }
+      }
+      return z.record(z.string(), z.unknown());
+    }
+    case "string":
+      return z.string();
+    case "number":
+    case "integer":
+      return z.number();
+    case "boolean":
+      return z.boolean();
+    case "array":
+      return z.array(z.unknown());
+    default:
+      return z.record(z.string(), z.unknown());
+  }
+}

--- a/packages/typescript/openai-agents/src/send-asap-envelope.ts
+++ b/packages/typescript/openai-agents/src/send-asap-envelope.ts
@@ -1,0 +1,125 @@
+import { ASAP_SEND_METHOD, ASAP_VERSION_HEADER } from "@asap-protocol/client";
+
+const DEFAULT_ASAP_VERSION = "2.2";
+
+export type SendAsapFetch = typeof fetch;
+
+export interface SendAsapEnvelopeOptions {
+  readonly fetch?: SendAsapFetch;
+  readonly signal?: AbortSignal;
+  /** When set, sends `Authorization: Bearer <token>`. */
+  readonly agentJwt?: string;
+  /** Sent as `ASAP-Version` (default `2.2`). */
+  readonly asapVersion?: string;
+}
+
+/** Base URL with trailing slash for safe relative resolution of `asap/...` paths. */
+function providerBaseHref(provider: URL): string {
+  const href = provider.href;
+  return provider.pathname.endsWith("/") ? href : `${href}/`;
+}
+
+function asapSendHref(provider: URL): string {
+  return new URL("asap", providerBaseHref(provider)).href;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function jsonRpcErrorToError(error: unknown): Error {
+  if (!isRecord(error)) {
+    return new Error(String(error));
+  }
+  const message = typeof error.message === "string" ? error.message : JSON.stringify(error);
+  const err = new Error(message);
+  err.name = "JsonRpcError";
+  if (typeof error.code === "number") {
+    (err as Error & { code?: number }).code = error.code;
+  }
+  return err;
+}
+
+function parseJsonRpcResult(payload: unknown): unknown {
+  if (!isRecord(payload)) {
+    return payload;
+  }
+  if (payload.jsonrpc !== "2.0") {
+    return payload;
+  }
+  if (payload.error !== undefined && payload.error !== null) {
+    throw jsonRpcErrorToError(payload.error);
+  }
+  return payload.result;
+}
+
+function normalizeEnvelopeForSend(envelope: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...envelope,
+    id: typeof envelope.id === "string" ? envelope.id : crypto.randomUUID(),
+    timestamp: typeof envelope.timestamp === "string" ? envelope.timestamp : new Date().toISOString(),
+  };
+}
+
+function buildJsonRpcSendBody(envelope: Record<string, unknown>): { body: string; idempotencyKey: string } {
+  const requestId = crypto.randomUUID();
+  const idempotencyKey = crypto.randomUUID();
+  const jsonRpcRequest = {
+    jsonrpc: "2.0" as const,
+    method: ASAP_SEND_METHOD,
+    params: {
+      envelope,
+      idempotency_key: idempotencyKey,
+    },
+    id: requestId,
+  };
+  return { body: JSON.stringify(jsonRpcRequest), idempotencyKey };
+}
+
+/**
+ * POST a JSON-RPC `asap.send` request to the provider's `/asap` endpoint.
+ *
+ * @throws When HTTP status is not ok or the JSON-RPC response contains an error.
+ */
+export async function sendAsapEnvelope(
+  provider: URL,
+  envelope: Record<string, unknown>,
+  options?: SendAsapEnvelopeOptions,
+): Promise<unknown> {
+  const fetchFn = options?.fetch ?? globalThis.fetch.bind(globalThis);
+  const asapVersion = options?.asapVersion ?? DEFAULT_ASAP_VERSION;
+  const wireEnvelope = normalizeEnvelopeForSend(envelope);
+  const { body, idempotencyKey } = buildJsonRpcSendBody(wireEnvelope);
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    "X-Idempotency-Key": idempotencyKey,
+    [ASAP_VERSION_HEADER]: asapVersion,
+  };
+  if (options?.agentJwt !== undefined && options.agentJwt.length > 0) {
+    headers.Authorization = `Bearer ${options.agentJwt}`;
+  }
+
+  const response = await fetchFn(asapSendHref(provider), {
+    method: "POST",
+    headers,
+    body,
+    signal: options?.signal,
+  });
+
+  const text = await response.text();
+  let parsed: unknown;
+  try {
+    parsed = text.length === 0 ? {} : JSON.parse(text);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`asap.send: invalid JSON (${msg})`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`asap.send failed: HTTP ${String(response.status)} ${text.slice(0, 200)}`);
+  }
+
+  return parseJsonRpcResult(parsed);
+}

--- a/packages/typescript/openai-agents/src/streaming.ts
+++ b/packages/typescript/openai-agents/src/streaming.ts
@@ -1,0 +1,51 @@
+/**
+ * Bridge ASAP TaskStream-style payloads into UTF-8 text chunks suitable for OpenAI Agents streaming UX.
+ *
+ * Pair with `@asap-protocol/client` streaming helpers (`createAsapStreamClient`, `streamTaskStreamEnvelopes`).
+ */
+
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+/** Streaming text delta aligned with incremental assistant output (surface-only shape). */
+export interface OpenAIAgentsStreamTextDelta {
+  readonly type: "text_delta";
+  readonly text: string;
+}
+
+export async function* asapStreamToOpenAIAgentsTextStream(source: AsyncIterable<unknown>): AsyncIterable<string> {
+  const it = source[Symbol.asyncIterator]();
+  try {
+    while (true) {
+      const { value: event, done } = await it.next();
+      if (done) {
+        return;
+      }
+      if (!isRecord(event) || event.type !== "task_stream") {
+        continue;
+      }
+      const payload = event.payload;
+      if (!isRecord(payload)) {
+        continue;
+      }
+      const chunk = payload.chunk;
+      if (typeof chunk === "string") {
+        yield chunk;
+      }
+    }
+  } finally {
+    await it.return?.();
+  }
+}
+
+/**
+ * Same mapping as {@link asapStreamToOpenAIAgentsTextStream}, wrapped as `{ type: "text_delta" }` chunks.
+ */
+export async function* asapStreamToOpenAIAgentsRunStreamChunks(
+  source: AsyncIterable<unknown>,
+): AsyncIterable<OpenAIAgentsStreamTextDelta> {
+  for await (const text of asapStreamToOpenAIAgentsTextStream(source)) {
+    yield { type: "text_delta", text };
+  }
+}

--- a/packages/typescript/openai-agents/test/asap-as-remote-agent.test.ts
+++ b/packages/typescript/openai-agents/test/asap-as-remote-agent.test.ts
@@ -6,6 +6,7 @@ import { RunContext, invokeFunctionTool, type AgentInputItem, type FunctionTool 
 import {
   asapAsRemoteAgent,
   draftTaskRequestEnvelopeForRemoteAgent,
+  sameProviderOrigin,
   type AsapRemoteRunContext,
 } from "../src/asap-as-remote-agent.js";
 
@@ -53,6 +54,16 @@ describe("draftTaskRequestEnvelopeForRemoteAgent", () => {
   });
 });
 
+describe("sameProviderOrigin", () => {
+  it("matches origin and pathname", () => {
+    expect(sameProviderOrigin(new URL("https://a.example/"), new URL("https://a.example/"))).toBe(true);
+    expect(sameProviderOrigin(new URL("https://a.example/"), new URL("https://b.example/"))).toBe(false);
+    expect(
+      sameProviderOrigin(new URL("https://a.example/v1/"), new URL("https://a.example/v2/")),
+    ).toBe(false);
+  });
+});
+
 describe("asapAsRemoteAgent", () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -64,14 +75,63 @@ describe("asapAsRemoteAgent", () => {
     describeCapabilityMock.mockRejectedValue(new Error("describe not configured in this test"));
   });
 
+  it("rejects client.agentJwt when providerUrl differs before any fetch", async () => {
+    const fetchMock = vi.fn();
+    const client = {
+      provider: new URL("https://a.example/"),
+      capabilities: [],
+      agentJwt: "token",
+      fetch: fetchMock,
+    };
+
+    await expect(asapAsRemoteAgent(client, "https://b.example/")).rejects.toThrow(/remoteAgentJwt/);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(describeCapabilityMock).not.toHaveBeenCalled();
+  });
+
+  it("POSTs task.request via asap.send on agent_start", async () => {
+    describeCapabilityMock.mockResolvedValue({
+      name: "demo_echo",
+      description: "d",
+    });
+    const fetchMock = vi.fn(async () =>
+      Response.json({ jsonrpc: "2.0", result: { envelope: { id: "resp-1" } }, id: "rpc-1" }),
+    );
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+      fetch: fetchMock as typeof fetch,
+    };
+    const agent = await asapAsRemoteAgent(client, client.provider, { mode: "delegated" });
+
+    const bag: AsapRemoteRunContext = {};
+    const rc = new RunContext(bag);
+    agent.emit("agent_start", rc, agent, []);
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const firstCall = fetchMock.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const [url, init] = firstCall as unknown as [string | URL, RequestInit];
+    expect(String(url)).toContain("/asap");
+    const body = typeof init.body === "string" ? JSON.parse(init.body) : {};
+    expect(body.method).toBe("asap.send");
+    expect(body.params?.envelope?.payload_type).toBe("task.request");
+    expect(bag.lastAsapHandoffEnvelope?.payload_type).toBe("task.request");
+  });
+
   it("captures envelope draft with configured mode on agent_start", async () => {
     describeCapabilityMock.mockResolvedValue({
       name: "demo_echo",
       description: "d",
     });
+    const fetchMock = vi.fn(async () =>
+      Response.json({ jsonrpc: "2.0", result: {}, id: "rpc-1" }),
+    );
     const client = {
       provider: new URL("http://localhost:9999/"),
       capabilities: ["urn:asap:cap:demo_echo"],
+      fetch: fetchMock as typeof fetch,
     };
     const agent = await asapAsRemoteAgent(client, "http://localhost:8080/", { mode: "delegated" });
 

--- a/packages/typescript/openai-agents/test/asap-as-remote-agent.test.ts
+++ b/packages/typescript/openai-agents/test/asap-as-remote-agent.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as asapClient from "@asap-protocol/client";
+import { capabilityToolKey } from "@asap-protocol/client/adapters/shared";
+import { RunContext, invokeFunctionTool, type AgentInputItem, type FunctionTool } from "@openai/agents";
+import {
+  asapAsRemoteAgent,
+  draftTaskRequestEnvelopeForRemoteAgent,
+  type AsapRemoteRunContext,
+} from "../src/asap-as-remote-agent.js";
+
+const describeCapabilityMock = vi.fn();
+
+vi.mock("@asap-protocol/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@asap-protocol/client")>();
+  return {
+    ...actual,
+    describeCapability: (...args: unknown[]) => describeCapabilityMock(...args),
+  };
+});
+
+describe("draftTaskRequestEnvelopeForRemoteAgent", () => {
+  it("includes asap_agent_mode for delegated", () => {
+    const draft = draftTaskRequestEnvelopeForRemoteAgent({
+      mode: "delegated",
+      providerUrl: new URL("http://localhost:8080/"),
+      turnInput: "hello",
+    });
+    expect(draft.extensions).toEqual({ asap_agent_mode: "delegated" });
+    expect((draft.payload as Record<string, unknown>).input).toMatchObject({
+      asap_agent_mode: "delegated",
+      query: "hello",
+    });
+  });
+
+  it("records autonomous mode separately", () => {
+    const draft = draftTaskRequestEnvelopeForRemoteAgent({
+      mode: "autonomous",
+      providerUrl: new URL("https://gw.example/"),
+    });
+    expect(draft.extensions).toEqual({ asap_agent_mode: "autonomous" });
+  });
+
+  it("uses empty query when turn input cannot be JSON-serialized", () => {
+    const circular: unknown[] = [];
+    circular.push(circular);
+    const draft = draftTaskRequestEnvelopeForRemoteAgent({
+      mode: "delegated",
+      providerUrl: new URL("http://localhost:8080/"),
+      turnInput: circular as AgentInputItem[],
+    });
+    expect((draft.payload as { input?: { query?: string } }).input?.query).toBe("");
+  });
+});
+
+describe("asapAsRemoteAgent", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    describeCapabilityMock.mockReset();
+    describeCapabilityMock.mockRejectedValue(new Error("describe not configured in this test"));
+  });
+
+  it("captures envelope draft with configured mode on agent_start", async () => {
+    describeCapabilityMock.mockResolvedValue({
+      name: "demo_echo",
+      description: "d",
+    });
+    const client = {
+      provider: new URL("http://localhost:9999/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+    };
+    const agent = await asapAsRemoteAgent(client, "http://localhost:8080/", { mode: "delegated" });
+
+    const bag: AsapRemoteRunContext = {};
+    const rc = new RunContext(bag);
+    agent.emit("agent_start", rc, agent, []);
+
+    expect(bag.lastAsapHandoffEnvelope?.extensions).toEqual({ asap_agent_mode: "delegated" });
+    expect((bag.lastAsapHandoffEnvelope?.recipient as string | undefined) ?? "").toContain("8080");
+  });
+
+  it("installs ASAP tools keyed like capabilityToolKey", async () => {
+    describeCapabilityMock.mockResolvedValue({ name: "demo_echo", description: "Echo" });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+    };
+    const agent = await asapAsRemoteAgent(client, client.provider);
+    const enabled = await agent.getAllTools(new RunContext<AsapRemoteRunContext>({}));
+    const names = enabled.map((t) => (t as { name?: string }).name).filter(Boolean);
+    expect(names).toContain(capabilityToolKey("urn:asap:cap:demo_echo"));
+  });
+
+  it("relays executeCapability through bundled tools", async () => {
+    describeCapabilityMock.mockResolvedValue({ name: "demo_echo", description: "d" });
+    const spy = vi.spyOn(asapClient, "executeCapability").mockResolvedValue({ ok: true });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+      agentJwt: "jwt-handoff",
+    };
+    const agent = await asapAsRemoteAgent(client, client.provider);
+    const enabled = await agent.getAllTools(new RunContext<AsapRemoteRunContext>({}));
+    await invokeFunctionTool({
+      tool: enabled[0] as FunctionTool,
+      runContext: new RunContext({}),
+      input: JSON.stringify({ message: "ping" }),
+    });
+    expect(spy).toHaveBeenCalledWith(
+      client.provider,
+      "urn:asap:cap:demo_echo",
+      { message: "ping" },
+      expect.objectContaining({ agentJwt: "jwt-handoff" }),
+    );
+  });
+});

--- a/packages/typescript/openai-agents/test/asap-to-openai-tool.test.ts
+++ b/packages/typescript/openai-agents/test/asap-to-openai-tool.test.ts
@@ -253,14 +253,23 @@ describe("asapToolsForOpenAIAgents", () => {
     expect(describeCapabilityMock).not.toHaveBeenCalled();
   });
 
-  it("builds tools when describeCapability fails", async () => {
+  it("rejects when describeCapability fails by default", async () => {
+    describeCapabilityMock.mockRejectedValue(new Error("describe unavailable"));
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+    };
+    await expect(asapToolsForOpenAIAgents(client)).rejects.toThrow("describe unavailable");
+  });
+
+  it("builds tools when describeCapability fails with allowPermissiveDescribeFallback", async () => {
     describeCapabilityMock.mockRejectedValue(new Error("describe unavailable"));
     const spy = vi.spyOn(asapClient, "executeCapability").mockResolvedValue({ ok: true });
     const client = {
       provider: new URL("http://localhost:8080/"),
       capabilities: ["urn:asap:cap:demo_echo"],
     };
-    const tools = await asapToolsForOpenAIAgents(client);
+    const tools = await asapToolsForOpenAIAgents(client, { allowPermissiveDescribeFallback: true });
     expect(tools).toHaveLength(1);
     await invokeFunctionTool({
       tool: tools[0]!,
@@ -268,6 +277,44 @@ describe("asapToolsForOpenAIAgents", () => {
       input: JSON.stringify({}),
     });
     expect(spy).toHaveBeenCalled();
+  });
+
+  it("invokes onDescribeError when describeCapability fails", async () => {
+    const describeError = new Error("describe unavailable");
+    describeCapabilityMock.mockRejectedValue(describeError);
+    const onDescribeError = vi.fn();
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+    };
+    await expect(
+      asapToolsForOpenAIAgents(client, { onDescribeError }),
+    ).rejects.toThrow("describe unavailable");
+    expect(onDescribeError).toHaveBeenCalledWith("urn:asap:cap:demo_echo", describeError);
+  });
+
+  it("throws on tool name collision between capabilities", async () => {
+    describeCapabilityMock.mockResolvedValue({ name: "file", description: "d" });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:file/read", "urn:asap:cap:file_read"],
+    };
+    await expect(asapToolsForOpenAIAgents(client)).rejects.toThrow(/tool name collision/u);
+  });
+
+  it("passes signal to describeCapability", async () => {
+    describeCapabilityMock.mockResolvedValue({ name: "demo_echo", description: "d" });
+    const signal = AbortSignal.timeout(30_000);
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+    };
+    await asapToolsForOpenAIAgents(client, { signal });
+    expect(describeCapabilityMock).toHaveBeenCalledWith(
+      client.provider,
+      "urn:asap:cap:demo_echo",
+      expect.objectContaining({ signal }),
+    );
   });
 
   it("supports asapToolsForOpenAIAgentsSync with inputSchemas", async () => {

--- a/packages/typescript/openai-agents/test/asap-to-openai-tool.test.ts
+++ b/packages/typescript/openai-agents/test/asap-to-openai-tool.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as asapClient from "@asap-protocol/client";
+import type { CapabilityFetch } from "@asap-protocol/client";
+import { capabilityToolKey } from "@asap-protocol/client/adapters/shared";
+import { RunContext, invokeFunctionTool } from "@openai/agents";
+import { ApprovalRequiredError, CapabilityNotGrantedError } from "../src/errors.js";
+import { asapToolsForOpenAIAgents, asapToolsForOpenAIAgentsSync } from "../src/asap-to-openai-tool.js";
+
+const describeCapabilityMock = vi.fn();
+
+vi.mock("@asap-protocol/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@asap-protocol/client")>();
+  return {
+    ...actual,
+    describeCapability: (...args: unknown[]) => describeCapabilityMock(...args),
+  };
+});
+
+function mockProvider403(code: string, extra: Record<string, unknown> = {}): CapabilityFetch {
+  return vi.fn(async () => {
+    return new Response(JSON.stringify({ error: { code, ...extra } }), { status: 403 });
+  }) as unknown as CapabilityFetch;
+}
+
+describe("asapToolsForOpenAIAgents", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    describeCapabilityMock.mockReset();
+    describeCapabilityMock.mockRejectedValue(new Error("describe not configured in this test"));
+  });
+
+  it("returns one OpenAI Agents tool per configured capability", async () => {
+    describeCapabilityMock.mockResolvedValue({
+      name: "demo_echo",
+      description: "d",
+    });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+    };
+    const tools = await asapToolsForOpenAIAgents(client);
+    expect(tools).toHaveLength(1);
+    const tool = tools[0] as { name?: string };
+    expect(tool.name).toBe(capabilityToolKey("urn:asap:cap:demo_echo"));
+  });
+
+  it("routes tool execution through executeCapability", async () => {
+    describeCapabilityMock.mockResolvedValue({
+      name: "demo_echo",
+      description: "d",
+    });
+    const spy = vi.spyOn(asapClient, "executeCapability").mockResolvedValue({ ok: true });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+      agentJwt: "jwt-test",
+    };
+    const tools = await asapToolsForOpenAIAgents(client);
+    expect(tools).toHaveLength(1);
+    await invokeFunctionTool({
+      tool: tools[0]!,
+      runContext: new RunContext({}),
+      input: JSON.stringify({ message: "ping" }),
+    });
+    expect(spy).toHaveBeenCalledWith(
+      client.provider,
+      "urn:asap:cap:demo_echo",
+      { message: "ping" },
+      expect.objectContaining({ agentJwt: "jwt-test" }),
+    );
+  });
+
+  it("validates LLM arguments with describe-derived JSON Schema → Zod", async () => {
+    vi.spyOn(asapClient, "executeCapability").mockResolvedValue({ ok: true });
+    describeCapabilityMock.mockResolvedValue({
+      name: "demo_echo",
+      description: "Echo capability",
+      input_schema: {
+        type: "object",
+        properties: { message: { type: "string" } },
+        required: ["message"],
+      },
+    });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+    };
+    const tools = await asapToolsForOpenAIAgents(client);
+    await expect(
+      invokeFunctionTool({
+        tool: tools[0]!,
+        runContext: new RunContext({}),
+        input: JSON.stringify({}),
+      }),
+    ).rejects.toThrow();
+
+    await invokeFunctionTool({
+      tool: tools[0]!,
+      runContext: new RunContext({}),
+      input: JSON.stringify({ message: "hi" }),
+    });
+  });
+
+  it("propagates ApprovalRequiredError on approval_required", async () => {
+    const fetchMock = mockProvider403("approval_required", {
+      message: "human approval pending",
+      data: { reason: "policy" },
+    });
+    describeCapabilityMock.mockResolvedValue({ name: "demo_echo", description: "d" });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+      fetch: fetchMock,
+    };
+    const tools = await asapToolsForOpenAIAgents(client);
+    let approvalErr: unknown;
+    try {
+      await invokeFunctionTool({
+        tool: tools[0]!,
+        runContext: new RunContext({}),
+        input: JSON.stringify({}),
+      });
+    } catch (e) {
+      approvalErr = e;
+    }
+    expect(approvalErr).toBeInstanceOf(ApprovalRequiredError);
+    expect((approvalErr as ApprovalRequiredError).detail).toEqual({ reason: "policy" });
+  });
+
+  it("throws CapabilityNotGrantedError with requestCapability hook", async () => {
+    const requestCapability = vi.fn();
+    const fetchMock = mockProvider403("capability_not_granted", {
+      message: "no grant",
+      data: { required_capability: "file:read" },
+      request_id: "req-1",
+    });
+    describeCapabilityMock.mockResolvedValue({ name: "file:read", description: "d" });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["file:read"],
+      fetch: fetchMock,
+    };
+    const tools = await asapToolsForOpenAIAgents(client, { requestCapability });
+    let err: unknown;
+    try {
+      await invokeFunctionTool({
+        tool: tools[0]!,
+        runContext: new RunContext({}),
+        input: JSON.stringify({}),
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CapabilityNotGrantedError);
+    await (err as CapabilityNotGrantedError).requestCapability();
+    expect(requestCapability).toHaveBeenCalledWith("file:read");
+  });
+
+  it("denies once then succeeds when provider grants capability", async () => {
+    let n = 0;
+    const fetchMock = vi.fn(async () => {
+      n += 1;
+      if (n === 1) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "capability_not_granted",
+              message: "retry later",
+              data: { required_capability: "urn:asap:cap:demo_echo" },
+            },
+          }),
+          { status: 403 },
+        );
+      }
+      return new Response(JSON.stringify({ jsonrpc: "2.0", result: { echoed: "ok" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as CapabilityFetch;
+
+    describeCapabilityMock.mockResolvedValue({ name: "demo_echo", description: "d" });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+      fetch: fetchMock,
+    };
+    const tools = await asapToolsForOpenAIAgents(client);
+    await expect(
+      invokeFunctionTool({
+        tool: tools[0]!,
+        runContext: new RunContext({}),
+        input: JSON.stringify({ message: "hi" }),
+      }),
+    ).rejects.toBeInstanceOf(CapabilityNotGrantedError);
+
+    await expect(
+      invokeFunctionTool({
+        tool: tools[0]!,
+        runContext: new RunContext({}),
+        input: JSON.stringify({ message: "hi" }),
+      }),
+    ).resolves.toEqual({ echoed: "ok" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not clone Response for successful executes", async () => {
+    describeCapabilityMock.mockResolvedValue({ name: "demo_echo", description: "d" });
+    let cloneSpy: ReturnType<typeof vi.spyOn> | undefined;
+    const fetchMock = vi.fn(async () => {
+      const body = JSON.stringify({ jsonrpc: "2.0", result: { ok: true } });
+      const res = new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+      cloneSpy = vi.spyOn(res, "clone");
+      return res;
+    });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+      fetch: fetchMock as unknown as CapabilityFetch,
+    };
+    const tools = await asapToolsForOpenAIAgents(client);
+    await invokeFunctionTool({
+      tool: tools[0]!,
+      runContext: new RunContext({}),
+      input: JSON.stringify({ message: "x" }),
+    });
+    expect(cloneSpy).toBeDefined();
+    expect(cloneSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips describeCapability when inputSchemas already defines the capability", async () => {
+    vi.spyOn(asapClient, "executeCapability").mockResolvedValue({ ok: true });
+    describeCapabilityMock.mockResolvedValue({ name: "demo_echo", description: "unused" });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+    };
+    await asapToolsForOpenAIAgents(client, {
+      inputSchemas: {
+        "urn:asap:cap:demo_echo": {
+          type: "object",
+          properties: { message: { type: "string" } },
+        },
+      },
+    });
+    expect(describeCapabilityMock).not.toHaveBeenCalled();
+  });
+
+  it("builds tools when describeCapability fails", async () => {
+    describeCapabilityMock.mockRejectedValue(new Error("describe unavailable"));
+    const spy = vi.spyOn(asapClient, "executeCapability").mockResolvedValue({ ok: true });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+    };
+    const tools = await asapToolsForOpenAIAgents(client);
+    expect(tools).toHaveLength(1);
+    await invokeFunctionTool({
+      tool: tools[0]!,
+      runContext: new RunContext({}),
+      input: JSON.stringify({}),
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("supports asapToolsForOpenAIAgentsSync with inputSchemas", async () => {
+    vi.spyOn(asapClient, "executeCapability").mockResolvedValue({ ok: true });
+    describeCapabilityMock.mockResolvedValue({ name: "demo_echo", description: "d" });
+    const client = {
+      provider: new URL("http://localhost:8080/"),
+      capabilities: ["urn:asap:cap:demo_echo"],
+    };
+    const tools = asapToolsForOpenAIAgentsSync(client, {
+      inputSchemas: {
+        "urn:asap:cap:demo_echo": {
+          type: "object",
+          properties: { message: { type: "string" } },
+          required: ["message"],
+        },
+      },
+    });
+    expect(describeCapabilityMock).not.toHaveBeenCalled();
+    await expect(
+      invokeFunctionTool({
+        tool: tools[0]!,
+        runContext: new RunContext({}),
+        input: JSON.stringify({}),
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/typescript/openai-agents/test/errors.test.ts
+++ b/packages/typescript/openai-agents/test/errors.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ApprovalRequiredError, CapabilityNotGrantedError } from "../src/errors.js";
+
+describe("adapter errors", () => {
+  it("parses approval_url from non-array object detail", () => {
+    const err = new ApprovalRequiredError("needs sign-off", {
+      approval_url: "https://example/approve",
+    });
+    expect(err.detail).toEqual({ approval_url: "https://example/approve" });
+  });
+
+  it("ignores approval detail when data is not a plain object", () => {
+    const err = new ApprovalRequiredError("x", []);
+    expect(err.detail).toBeUndefined();
+  });
+
+  it("invokes requestCapability hook when provided", async () => {
+    const hook = vi.fn().mockResolvedValue(undefined);
+    const err = new CapabilityNotGrantedError("cap:read", hook, "custom");
+    expect(err.message).toBe("custom");
+    await err.requestCapability();
+    expect(hook).toHaveBeenCalledWith("cap:read");
+  });
+});

--- a/packages/typescript/openai-agents/test/schema-bridge.test.ts
+++ b/packages/typescript/openai-agents/test/schema-bridge.test.ts
@@ -52,4 +52,59 @@ describe("zodFromJsonSchema", () => {
     const s = zodFromJsonSchema({ type: "object", properties: {} });
     expect(s.safeParse({ any: "thing" }).success).toBe(true);
   });
+
+  it("maps string enum schemas to literal unions and rejects invalid values", () => {
+    const s = zodFromJsonSchema({ type: "string", enum: ["read", "write"] });
+    expect(s.safeParse("read").success).toBe(true);
+    expect(s.safeParse("write").success).toBe(true);
+    expect(s.safeParse("delete").success).toBe(false);
+  });
+
+  it("maps enum constraints inside object properties", () => {
+    const s = zodFromJsonSchema({
+      type: "object",
+      properties: {
+        mode: { type: "string", enum: ["delegated", "autonomous"] },
+      },
+      required: ["mode"],
+    });
+    expect(s.safeParse({ mode: "delegated" }).success).toBe(true);
+    expect(s.safeParse({ mode: "invalid" }).success).toBe(false);
+  });
+
+  it("maps number and boolean enum literals", () => {
+    expect(zodFromJsonSchema({ enum: [1, 2] }).safeParse(1).success).toBe(true);
+    expect(zodFromJsonSchema({ enum: [1, 2] }).safeParse(3).success).toBe(false);
+    expect(zodFromJsonSchema({ enum: [true, false] }).safeParse(false).success).toBe(true);
+  });
+
+  it("maps null in enum literals alongside a single primitive type", () => {
+    const s = zodFromJsonSchema({ enum: ["none", null] });
+    expect(s.safeParse("none").success).toBe(true);
+    expect(s.safeParse(null).success).toBe(true);
+    expect(s.safeParse("other").success).toBe(false);
+  });
+
+  it("throws for mixed enum primitive types", () => {
+    expect(() => zodFromJsonSchema({ enum: ["read", 1] })).toThrow(/mixed primitive types/u);
+  });
+
+  it("throws for unsupported enum value types", () => {
+    expect(() => zodFromJsonSchema({ enum: [{ nested: true }] })).toThrow(
+      /supports only string, number, boolean, and null/u,
+    );
+  });
+
+  it("maps array items when items schema is an object", () => {
+    const s = zodFromJsonSchema({
+      type: "array",
+      items: {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      },
+    });
+    expect(s.safeParse([{ name: "a" }]).success).toBe(true);
+    expect(s.safeParse([{}]).success).toBe(false);
+  });
 });

--- a/packages/typescript/openai-agents/test/schema-bridge.test.ts
+++ b/packages/typescript/openai-agents/test/schema-bridge.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { zodFromJsonSchema } from "../src/schema-bridge.js";
+
+describe("zodFromJsonSchema", () => {
+  it("maps $ref to a permissive object schema", () => {
+    const s = zodFromJsonSchema({ $ref: "#/definitions/Foo" });
+    expect(s.safeParse({ a: 1 }).success).toBe(true);
+  });
+
+  it("maps oneOf to a Zod union", () => {
+    const s = zodFromJsonSchema({
+      oneOf: [{ type: "string" }, { type: "number" }],
+    });
+    expect(s.safeParse("x").success).toBe(true);
+    expect(s.safeParse(3).success).toBe(true);
+    expect(s.safeParse({}).success).toBe(false);
+  });
+
+  it("unwraps a single oneOf branch", () => {
+    const s = zodFromJsonSchema({ oneOf: [{ type: "string" }] });
+    expect(s.safeParse("one").success).toBe(true);
+  });
+
+  it("treats empty oneOf as unknown", () => {
+    const s = zodFromJsonSchema({ oneOf: [] });
+    expect(s.safeParse({ x: 1 }).success).toBe(true);
+  });
+
+  it("maps object properties with required keys", () => {
+    const s = zodFromJsonSchema({
+      type: "object",
+      properties: { message: { type: "string" } },
+      required: ["message"],
+    });
+    expect(s.safeParse({ message: "hi" }).success).toBe(true);
+    expect(s.safeParse({}).success).toBe(false);
+  });
+
+  it("maps integer, boolean, and array schemas", () => {
+    expect(zodFromJsonSchema({ type: "integer" }).safeParse(7).success).toBe(true);
+    expect(zodFromJsonSchema({ type: "boolean" }).safeParse(false).success).toBe(true);
+    expect(zodFromJsonSchema({ type: "array" }).safeParse([1, 2]).success).toBe(true);
+  });
+
+  it("falls back for schemas without a recognized type", () => {
+    const s = zodFromJsonSchema({ description: "no explicit type" });
+    expect(s.safeParse({ k: "v" }).success).toBe(true);
+  });
+
+  it("falls back to open record when object has empty properties", () => {
+    const s = zodFromJsonSchema({ type: "object", properties: {} });
+    expect(s.safeParse({ any: "thing" }).success).toBe(true);
+  });
+});

--- a/packages/typescript/openai-agents/test/streaming.test.ts
+++ b/packages/typescript/openai-agents/test/streaming.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  asapStreamToOpenAIAgentsRunStreamChunks,
+  asapStreamToOpenAIAgentsTextStream,
+} from "../src/streaming.js";
+
+describe("asapStreamToOpenAIAgentsTextStream", () => {
+  it("maps ASAP stream payloads into UTF-8 chunks", async () => {
+    async function* mockSource(): AsyncIterable<{ type: string; payload: { chunk: string } }> {
+      yield { type: "task_stream", payload: { chunk: "hello" } };
+      yield { type: "task_stream", payload: { chunk: " world" } };
+    }
+
+    const parts: string[] = [];
+    for await (const chunk of asapStreamToOpenAIAgentsTextStream(mockSource())) {
+      parts.push(chunk);
+    }
+
+    expect(parts.join("")).toBe("hello world");
+  });
+
+  it("skips malformed task_stream payloads", async () => {
+    async function* mockSource(): AsyncIterable<unknown> {
+      yield { type: "other" };
+      yield { type: "task_stream", payload: "not-an-object" };
+      yield { type: "task_stream", payload: { chunk: 1 } };
+      yield { type: "task_stream", payload: {} };
+    }
+
+    const parts: string[] = [];
+    for await (const chunk of asapStreamToOpenAIAgentsTextStream(mockSource())) {
+      parts.push(chunk);
+    }
+
+    expect(parts).toEqual([]);
+  });
+
+  it("closes upstream iterator when consumer breaks early", async () => {
+    const returned = vi.fn();
+    async function* mockSource(): AsyncIterable<{ type: string; payload: { chunk: string } }> {
+      try {
+        yield { type: "task_stream", payload: { chunk: "a" } };
+        yield { type: "task_stream", payload: { chunk: "b" } };
+      } finally {
+        returned();
+      }
+    }
+
+    for await (const chunk of asapStreamToOpenAIAgentsTextStream(mockSource())) {
+      void chunk;
+      break;
+    }
+
+    expect(returned).toHaveBeenCalled();
+  });
+});
+
+describe("asapStreamToOpenAIAgentsRunStreamChunks", () => {
+  it("wraps chunks as text_delta objects", async () => {
+    async function* mockSource(): AsyncIterable<{ type: string; payload: { chunk: string } }> {
+      yield { type: "task_stream", payload: { chunk: "x" } };
+    }
+    const out: { type: string; text: string }[] = [];
+    for await (const ev of asapStreamToOpenAIAgentsRunStreamChunks(mockSource())) {
+      out.push(ev);
+    }
+    expect(out).toEqual([{ type: "text_delta", text: "x" }]);
+  });
+});

--- a/packages/typescript/openai-agents/test/streaming.test.ts
+++ b/packages/typescript/openai-agents/test/streaming.test.ts
@@ -20,6 +20,20 @@ describe("asapStreamToOpenAIAgentsTextStream", () => {
     expect(parts.join("")).toBe("hello world");
   });
 
+  it("skips provider error events and continues with valid task_stream chunks", async () => {
+    async function* mockSource(): AsyncIterable<unknown> {
+      yield { type: "error", payload: { message: "provider failed" } };
+      yield { type: "task_stream", payload: { chunk: "recovered" } };
+    }
+
+    const parts: string[] = [];
+    for await (const chunk of asapStreamToOpenAIAgentsTextStream(mockSource())) {
+      parts.push(chunk);
+    }
+
+    expect(parts).toEqual(["recovered"]);
+  });
+
   it("skips malformed task_stream payloads", async () => {
     async function* mockSource(): AsyncIterable<unknown> {
       yield { type: "other" };

--- a/packages/typescript/openai-agents/tsconfig.build.json
+++ b/packages/typescript/openai-agents/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/typescript/openai-agents/tsconfig.json
+++ b/packages/typescript/openai-agents/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"]
+}

--- a/packages/typescript/openai-agents/vitest.config.ts
+++ b/packages/typescript/openai-agents/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    passWithNoTests: true,
+    include: ["test/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "text-summary"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.d.ts"],
+      thresholds: {
+        lines: 80,
+        statements: 85,
+        functions: 85,
+        branches: 80,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,43 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
 
+  apps/example-openai-agents:
+    dependencies:
+      '@asap-protocol/client':
+        specifier: workspace:*
+        version: link:../../packages/typescript/client
+      '@asap-protocol/openai-agents':
+        specifier: workspace:*
+        version: link:../../packages/typescript/openai-agents
+      '@openai/agents':
+        specifier: ^0.11.4
+        version: 0.11.4(ws@8.20.1)(zod@4.4.2)
+      dotenv:
+        specifier: ^16.6.1
+        version: 16.6.1
+      zod:
+        specifier: ^4.4.2
+        version: 4.4.2
+    devDependencies:
+      '@eslint/js':
+        specifier: 9.18.0
+        version: 9.18.0
+      '@types/node':
+        specifier: ^20.19.0
+        version: 20.19.39
+      eslint:
+        specifier: 9.18.0
+        version: 9.18.0(jiti@2.7.0)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.22.1
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: 8.59.1
+        version: 8.59.1(eslint@9.18.0(jiti@2.7.0))(typescript@5.9.3)
+
   packages/typescript/client:
     dependencies:
       '@noble/ed25519':
@@ -233,6 +270,45 @@ importers:
       zod:
         specifier: ^3.25.76
         version: 3.25.76
+
+  packages/typescript/openai-agents:
+    devDependencies:
+      '@asap-protocol/client':
+        specifier: workspace:*
+        version: link:../client
+      '@eslint/js':
+        specifier: 9.18.0
+        version: 9.18.0
+      '@openai/agents':
+        specifier: ^0.11.4
+        version: 0.11.4(ws@8.20.1)(zod@4.4.2)
+      '@types/node':
+        specifier: ^20.19.0
+        version: 20.19.39
+      '@vitest/coverage-v8':
+        specifier: 4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      agadoo:
+        specifier: 3.0.0
+        version: 3.0.0
+      eslint:
+        specifier: 9.18.0
+        version: 9.18.0(jiti@2.7.0)
+      tshy:
+        specifier: ^3.3.2
+        version: 3.3.2
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: 8.59.1
+        version: 8.59.1(eslint@9.18.0(jiti@2.7.0))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.5)(msw@2.14.6(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.10(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1))
+      zod:
+        specifier: ^4.4.2
+        version: 4.4.2
 
 packages:
 
@@ -1057,6 +1133,29 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@openai/agents-core@0.11.4':
+    resolution: {integrity: sha512-K529uAX9oZV8LUnsv0b+c+nWflIJc+LAJeEfZLN74q0J9UYvyt4pddt30e7OsGS1kPVK/lbChnPCOkPhnd1cpg==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@openai/agents-openai@0.11.4':
+    resolution: {integrity: sha512-NAiiCsUsb+4twlaCIZ4OM8s9WoDNKjHfZBrw1jkE/oXH4sXO5OwRqi85ZM5xtfZNBqBF0IEY5hIuwWOhZntdKg==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@openai/agents-realtime@0.11.4':
+    resolution: {integrity: sha512-SZS22YbsKilfPpsVJmHwigYbNX3W+ZHZFTm5+uDdV3OnziodCQu2P/cMag2dcpwmJq/fW0lANUzD+YC4l0qwoA==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@openai/agents@0.11.4':
+    resolution: {integrity: sha512-HEOnixfXyziXgYcuRWIx+oJRYLgTxX8VFeJPIAum7LSYxznO5orJsn4u+u3w+7xe1BupoB8eUaJ7dDvOSChKPA==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -2098,6 +2197,9 @@ packages:
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.59.1':
     resolution: {integrity: sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2823,6 +2925,10 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -4268,6 +4374,18 @@ packages:
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
+
+  openai@6.38.0:
+    resolution: {integrity: sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
@@ -6171,6 +6289,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.2)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.19)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.19
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.2
+      zod-to-json-schema: 3.25.2(zod@4.4.2)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@mswjs/interceptors@0.41.9':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -6258,6 +6399,57 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@openai/agents-core@0.11.4(ws@8.20.1)(zod@4.4.2)':
+    dependencies:
+      debug: 4.4.3
+      openai: 6.38.0(ws@8.20.1)(zod@4.4.2)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.2)
+      zod: 4.4.2
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-openai@0.11.4(ws@8.20.1)(zod@4.4.2)':
+    dependencies:
+      '@openai/agents-core': 0.11.4(ws@8.20.1)(zod@4.4.2)
+      debug: 4.4.3
+      openai: 6.38.0(ws@8.20.1)(zod@4.4.2)
+      zod: 4.4.2
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-realtime@0.11.4(zod@4.4.2)':
+    dependencies:
+      '@openai/agents-core': 0.11.4(ws@8.20.1)(zod@4.4.2)
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.20.1
+      zod: 4.4.2
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@openai/agents@0.11.4(ws@8.20.1)(zod@4.4.2)':
+    dependencies:
+      '@openai/agents-core': 0.11.4(ws@8.20.1)(zod@4.4.2)
+      '@openai/agents-openai': 0.11.4(ws@8.20.1)(zod@4.4.2)
+      '@openai/agents-realtime': 0.11.4(zod@4.4.2)
+      debug: 4.4.3
+      openai: 6.38.0(ws@8.20.1)(zod@4.4.2)
+      zod: 4.4.2
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -7241,6 +7433,10 @@ snapshots:
 
   '@types/validate-npm-package-name@4.0.2': {}
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.39
+
   '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.18.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.18.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -8002,6 +8198,8 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dotenv@16.6.1: {}
 
   dotenv@17.4.2: {}
 
@@ -9800,6 +9998,11 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
+  openai@6.38.0(ws@8.20.1)(zod@4.4.2):
+    optionalDependencies:
+      ws: 8.20.1
+      zod: 4.4.2
+
   openapi-types@12.1.3: {}
 
   optionator@0.9.4:
@@ -11148,6 +11351,11 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.4.2):
+    dependencies:
+      zod: 4.4.2
+    optional: true
 
   zod-validation-error@4.0.2(zod@4.4.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 packages:
   - "packages/typescript/*"
+  - "packages/typescript/openai-agents"
   - "apps/example-nextjs"
   - "apps/example-mastra"
+  - "apps/example-openai-agents"


### PR DESCRIPTION
## Summary

- Introduces **@asap-protocol/openai-agents**, a dedicated adapter for the **OpenAI Agents SDK** (`@openai/agents`) — distinct from the existing **@asap-protocol/client/adapters/openai** (Chat Completions static tools).
- Exports ASAP capabilities as Agents `tool()` instances, remote handoff helper, JSON Schema → Zod bridge, streaming helpers, and typed errors (`ApprovalRequiredError`, `CapabilityNotGrantedError`).
- Adds **apps/example-openai-agents** (quickstart, compliance script) plus **docs/integrations/openai-agents.md**, mkdocs nav, README link, and a **Developer Experience** card on the web app.
- **@asap-protocol/client** root now exports `AsapExecuteClient` and `AsapCapabilityList` for adapter authors; includes tests for envelope/helpers where added.
- **CI**: `.github/workflows/openai-agents-ci.yml` (typecheck, Vitest with coverage floor, agadoo treeshake; matrix for `@openai/agents` latest + pinned baseline).
- Small **Mastra** follow-up: tighter tool adapter errors, example/compliance copy, and related tests.

## Code review response (PR #152 review)

Follow-up commits on `feat/adapter-openai-agents` address the **Request changes** items from the internal review (`engineering/code-review/private/pr-152-openai-agents-adapter-review.md`).

| Item | Status | Resolution |
|------|--------|------------|
| **2.1 Oversized PR** | Acknowledged | Maintainer approves landing this branch as a **single merge unit** (adapter + example + docs + CI + small Mastra follow-up). Rollback surfaces accepted for v2.3.1 S3 delivery. |
| **2.2 JWT leak on cross-provider handoff** | Fixed | `sameProviderOrigin()` rejects reusing `client.agentJwt` when `providerUrl` differs; optional `remoteAgentJwt` for explicit cross-provider tokens. |
| **2.3 Remote handoff contract** | Fixed | `sendAsapEnvelope()` POSTs JSON-RPC `asap.send` with `task.request` on `agent_start`; tests assert `/asap` fetch + envelope shape. |
| **2.4 Silent describe fallback** | Fixed | `describeCapability` failures throw by default; `allowPermissiveDescribeFallback` + `onDescribeError` are opt-in. |
| **2.5 Tool name collisions** | Fixed | `buildTools()` detects sanitized key collisions and throws an actionable error. |
| **2.6 JSON Schema enums** | Fixed | `zodFromJsonSchema()` maps homogeneous enums to `z.literal` unions; mixed enums throw; array `items` recurse. |
| **4 Concurrency / AbortSignal** | Fixed | Bounded batch describe (5); `signal` forwarded to describe/execute. |
| **4 Docs security** | Fixed | `encodeURIComponent(required)` in approval example; auth/session/CSRF note. |
| **4 Zod peer** | Fixed | Peer narrowed to `zod ^4.1.8` (matches `@openai/agents`). |
| **4 CI lockfile comment** | Fixed | Matrix `--no-frozen-lockfile` rationale documented in workflow. |
| **4 Streaming errors** | Fixed | Test covers in-band provider `error` events (skipped; valid stream continues). |
| **4 API churn docs** | Fixed | Pre-1.0 `@openai/agents` drift warning in integration doc + package README. |

### Follow-up (out of band)

- Bandit Low findings hygiene tracked separately: #154 (CI gate remains `-ll`; no Medium/High issues).

## Test plan

- [x] Confirm **main CI** (Python ruff, mypy, pytest, security) and **openai-agents-ci** pass on this PR.
- [x] `pnpm --filter @asap-protocol/openai-agents` lint, typecheck, test, `check:treeshake`
- [x] `pnpm --filter example-openai-agents` lint, typecheck
- [ ] Optional smoke: `start` with `apps/example-agent` on `8080` + valid `OPENAI_API_KEY`
- [x] `mkdocs build` clean
- [x] `uv run python scripts/lint_no_transport_growth.py` (D4 — no transport growth)