### PR TITLE
release: v2.3.1 TypeScript adapter packages (S4)

### DIFF
--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -43,7 +43,7 @@ Before pushing to the repository, always run the full CI check suite locally to 
 2. **Formatting**: `uv run ruff format --check .` - Ensure consistent code formatting (or `uv run ruff format .` to auto-fix)
 3. **Type Checking**: `uv run mypy src/ scripts/ tests/` - Validate type annotations (strict for src/scripts, relaxed for tests)
 4. **Tests**: `PYTHONPATH=src uv run pytest --cov=src --cov-report=xml` - Run full test suite with coverage
-5. **Security**: `uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex && uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654` — same as the CI security job (see `SECURITY.md`); use full `uv sync --frozen --all-extras --dev` when auditing optional integration extras separately
+5. **Security**: `uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex && uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654 --ignore-vuln PYSEC-2024-271 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183` — same as the CI security job (see `SECURITY.md`); use full `uv sync --frozen --all-extras --dev` when auditing optional integration extras separately
 
 ### Pre-Push CI Verification (Web App / TypeScript)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,8 @@ jobs:
           sync-flags: --no-extra crewai --no-extra llamaindex
       # CVE-2026-4539: pygments advisory with no patched PyPI release yet (override pins >=2.20 when available).
       # CVE-2026-4963 / CVE-2026-2654: smolagents optional extra; OSV lists no fix version on PyPI as of 2026-05 (see SECURITY.md).
+      # PYSEC-2026-89 / PYSEC-2025-183 / PYSEC-2024-271: mkdocs/mcp/locust transitive; see SECURITY.md.
       - name: Scan for vulnerabilities (pip-audit)
-        run: uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654
+        run: uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654 --ignore-vuln PYSEC-2024-271 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183
       - name: Scan for security issues (bandit)
         run: uv run bandit -r src/ -ll

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -1,0 +1,157 @@
+# Tags v2.3.*-hotfix.* / v2.3.*-rc.* → npm publish with dist-tag hotfix or rc (OIDC).
+# PRs (main or hotfix/*) → npm publish --dry-run only. See docs/maintainers/hotfix.md.
+name: Hotfix TypeScript SDK
+
+on:
+  push:
+    tags:
+      - "v2.3.*-hotfix.*"
+      - "v2.3.*-rc.*"
+  pull_request:
+    branches: [main, "hotfix/*"]
+    paths:
+      - "packages/typescript/client/**"
+      - "packages/typescript/mastra/**"
+      - "packages/typescript/openai-agents/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/hotfix-release.yml"
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: hotfix-release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  dry-run:
+    name: npm publish dry-run
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+        with:
+          version: 9.15.4
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build @asap-protocol/client (tshy)
+        run: pnpm --filter @asap-protocol/client run build
+
+      - name: Build @asap-protocol/mastra (tshy)
+        run: pnpm --filter @asap-protocol/mastra run build
+
+      - name: Build @asap-protocol/openai-agents (tshy)
+        run: pnpm --filter @asap-protocol/openai-agents run build
+
+      - name: npm publish --dry-run (@asap-protocol/client)
+        working-directory: packages/typescript/client
+        run: npm publish --dry-run --access public
+
+      - name: npm publish --dry-run (@asap-protocol/mastra)
+        working-directory: packages/typescript/mastra
+        run: npm publish --dry-run --access public
+
+      - name: npm publish --dry-run (@asap-protocol/openai-agents)
+        working-directory: packages/typescript/openai-agents
+        run: npm publish --dry-run --access public
+
+  publish:
+    name: Publish hotfix to npm
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+        with:
+          version: 9.15.4
+
+      # No registry-url: avoid setup-node defaulting NODE_AUTH_TOKEN to GITHUB_TOKEN,
+      # which npm rejects for registry.npmjs.org and breaks OIDC Trusted Publishing.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Upgrade npm for Trusted Publishing (OIDC)
+        run: npm install -g npm@11.5.1
+
+      - name: Set package version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm pkg set "version=${VERSION}" --prefix packages/typescript/client
+          npm pkg set "version=${VERSION}" --prefix packages/typescript/mastra
+          npm pkg set "version=${VERSION}" --prefix packages/typescript/openai-agents
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build @asap-protocol/client (tshy)
+        run: pnpm --filter @asap-protocol/client run build
+
+      - name: Build @asap-protocol/mastra (tshy)
+        run: pnpm --filter @asap-protocol/mastra run build
+
+      - name: Build @asap-protocol/openai-agents (tshy)
+        run: pnpm --filter @asap-protocol/openai-agents run build
+
+      - name: Publish @asap-protocol/client to npm with provenance
+        working-directory: packages/typescript/client
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "${VERSION}" == *-hotfix* ]]; then
+            npm publish --access public --provenance --tag hotfix
+          elif [[ "${VERSION}" == *-* ]]; then
+            npm publish --access public --provenance --tag rc
+          else
+            echo "::error::Hotfix workflow expects a prerelease version (e.g. 2.3.1-hotfix.1). Got ${VERSION}"
+            exit 1
+          fi
+
+      - name: Publish @asap-protocol/mastra to npm with provenance
+        working-directory: packages/typescript/mastra
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "${VERSION}" == *-hotfix* ]]; then
+            npm publish --access public --provenance --tag hotfix
+          elif [[ "${VERSION}" == *-* ]]; then
+            npm publish --access public --provenance --tag rc
+          else
+            echo "::error::Hotfix workflow expects a prerelease version (e.g. 2.3.1-hotfix.1). Got ${VERSION}"
+            exit 1
+          fi
+
+      - name: Publish @asap-protocol/openai-agents to npm with provenance
+        working-directory: packages/typescript/openai-agents
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "${VERSION}" == *-hotfix* ]]; then
+            npm publish --access public --provenance --tag hotfix
+          elif [[ "${VERSION}" == *-* ]]; then
+            npm publish --access public --provenance --tag rc
+          else
+            echo "::error::Hotfix workflow expects a prerelease version (e.g. 2.3.1-hotfix.1). Got ${VERSION}"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ unchanged; no wire-protocol or migration work required for existing deployments.
   public `@asap-protocol/client/adapters/shared`, `jsonSchemaForCapabilityOutput`,
   execution types, and envelope helpers. Non-breaking; existing `@2.3.0` consumers
   remain compatible.
+- **CI security (`pip-audit`)**: Bumped transitive pins (`idna>=3.15`,
+  `markdown>=3.10.2`, `pymdown-extensions>=10.21.3`) and documented `--ignore-vuln`
+  flags for advisories with no PyPI fix yet (`PYSEC-2026-89`, `PYSEC-2025-183`,
+  `PYSEC-2024-271`). See [SECURITY.md](SECURITY.md).
 
 ### Known limitations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.3.1] - 2026-05-18
+## [2.3.1] - 2026-05-20
 
 **Adapter Lab I** — TypeScript-only patch: two new framework adapters on npm and
 additive exports on `@asap-protocol/client`. Python `asap-protocol` core is

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > A production-ready protocol for agent-to-agent communication and task coordination.
 
-**Quick Info**: `v2.3.0` | `Apache 2.0` | `Python 3.13+` | [Documentation](https://github.com/adriannoes/asap-protocol/blob/main/docs/index.md) | **[PyPI `asap-protocol`](https://pypi.org/project/asap-protocol/)** | **[npm `@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client)** | [Changelog](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md)
+**Quick Info**: `v2.3.0` (PyPI) · **npm TS `2.3.1`** | `Apache 2.0` | `Python 3.13+` | [Documentation](https://github.com/adriannoes/asap-protocol/blob/main/docs/index.md) | **[PyPI `asap-protocol`](https://pypi.org/project/asap-protocol/)** | **[npm `@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client)** | [Changelog](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md)
 
 > 📦 Install the ASAP **Python SDK / protocol** from **`https://pypi.org/project/asap-protocol/`** — package name **`asap-protocol`** on [PyPI](https://pypi.org/project/asap-protocol/).
 
@@ -35,6 +35,7 @@ For simple point-to-point communication, a basic HTTP API might suffice; ASAP sh
 - **Identity & capabilities (v2.2, WebAuthn real in v2.2.1)** — Per-runtime Host/Agent JWTs, capability grants with constraints (`max`, `min`, `in`, `not_in`), approval flows (device authorization / CIBA-style), real WebAuthn attestation/assertion for high-risk registration (opt-in via `asap-protocol[webauthn]`).
 - **Streaming & wire protocol (v2.2)** — `POST /asap/stream` (SSE / `TaskStream`), JSON-RPC 2.0 batch on `POST /asap`, `ASAP-Version` negotiation, tamper-evident audit logging, Compliance Harness v2.
 - **Adoption Multiplier (v2.3.0)** — OpenAPI → ASAP via `create_from_openapi` (`[openapi]` extra), official **`@asap-protocol/client`** on npm (Vercel AI / OpenAI / Anthropic adapters), optional **Auto-Registration** (`POST /registry/agents`), **capability escalation**, and **ASAP `WWW-Authenticate`** discovery challenges. All opt-in; wire protocol unchanged. See [docs/index.md](docs/index.md) and [docs/migration.md](docs/migration.md).
+- **Framework adapters (v2.3.1, npm TS-only patch)** — **`@asap-protocol/mastra`** and **`@asap-protocol/openai-agents`** expose ASAP capabilities as Mastra tools and OpenAI Agents SDK `tool()` definitions. Python core unchanged. See [Migration (v2.3.0 → v2.3.1)](docs/migration.md#upgrading-from-v230-to-v231).
 - **Economics** — Usage metering, delegation tokens, SLA framework with breach alerts.
 
 ### 🆕 Framework Ecosystem
@@ -54,16 +55,17 @@ Or with pip:
 pip install asap-protocol
 ```
 
-**npm** (TypeScript / JavaScript — [`@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client), aligned with protocol **v2.3.0**). The `latest` dist-tag matches **`npm view @asap-protocol/client version`** (currently **2.3.0**).
+**npm** (TypeScript / JavaScript — [`@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client), **`2.3.1`** with v2.3.1 adapter packages). The `latest` dist-tag matches **`npm view @asap-protocol/client version`**.
 
-**npm** Mastra (**[`@asap-protocol/mastra`](https://www.npmjs.com/package/@asap-protocol/mastra)** when published — today also via monorepo `workspace:*`) bridges ASAP capabilities onto **`@mastra/core`** tools alongside the TypeScript SDK; docs live under [`docs/integrations/mastra.md`](docs/integrations/mastra.md) and runnable UI under [`apps/example-mastra/README.md`](apps/example-mastra/README.md).
+**npm** Mastra (**[`@asap-protocol/mastra@2.3.1`](https://www.npmjs.com/package/@asap-protocol/mastra)** when published — monorepo `workspace:*` until tag) bridges ASAP capabilities onto **`@mastra/core`** tools; docs: [`docs/integrations/mastra.md`](docs/integrations/mastra.md), demo: [`apps/example-mastra/README.md`](apps/example-mastra/README.md).
 
-**npm** OpenAI Agents SDK (**[`@asap-protocol/openai-agents`](https://www.npmjs.com/package/@asap-protocol/openai-agents)** when published — workspace **`packages/typescript/openai-agents`**) exposes ASAP capabilities as **`@openai/agents`** `tool()` definitions — **not** the legacy Chat Completions helper [`adapters/openai`](packages/typescript/client/src/adapters/openai.ts); see [`docs/integrations/openai-agents.md`](docs/integrations/openai-agents.md) and CLI demo [`apps/example-openai-agents/README.md`](apps/example-openai-agents/README.md).
+**npm** OpenAI Agents SDK (**[`@asap-protocol/openai-agents@2.3.1`](https://www.npmjs.com/package/@asap-protocol/openai-agents)** when published — workspace **`packages/typescript/openai-agents`**) exposes ASAP capabilities as **`@openai/agents`** `tool()` definitions — **not** the Chat Completions helper [`adapters/openai`](packages/typescript/client/src/adapters/openai.ts); docs: [`docs/integrations/openai-agents.md`](docs/integrations/openai-agents.md), demo: [`apps/example-openai-agents/README.md`](apps/example-openai-agents/README.md).
 
 ```bash
-npm install @asap-protocol/client
-# reproducible pin (same as latest today):
-# npm install @asap-protocol/client@2.3.0
+npm install @asap-protocol/client@2.3.1
+# adapters (after npm publish):
+# npm install @asap-protocol/mastra@2.3.1 @asap-protocol/client @mastra/core zod
+# npm install @asap-protocol/openai-agents@2.3.1 @asap-protocol/client @openai/agents zod
 ```
 
 📦 **Canonical listing:** **[https://pypi.org/project/asap-protocol/](https://pypi.org/project/asap-protocol/)** — package **`asap-protocol`** (`pip install asap-protocol`). Prefer `uv` for reproducible environments when possible.
@@ -150,6 +152,7 @@ High-level only — see **[Changelog](https://github.com/adriannoes/asap-protoco
 
 | Version | What shipped |
 | :-- | :-- |
+| **v2.3.1** | **npm TS patch** — **`@asap-protocol/mastra`**, **`@asap-protocol/openai-agents`**, **`@asap-protocol/client@2.3.1`** (additive adapter exports). Python **2.3.0** unchanged. See [CHANGELOG](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md#231---2026-05-18) and [Migration (v2.3.0 → v2.3.1)](https://github.com/adriannoes/asap-protocol/blob/main/docs/migration.md#upgrading-from-v230-to-v231) |
 | **v2.3.0** | **OpenAPI Adapter** (`[openapi]`) · **TypeScript client** (`@asap-protocol/client`) · **Auto-Registration** · **Capability escalation** · **ASAP HTTP challenge** — see [CHANGELOG](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md#230---2026-05-04) and [Migration](https://github.com/adriannoes/asap-protocol/blob/main/docs/migration.md#upgrading-from-v22x-to-v230) |
 | **v2.2.1** | Opt-in **WebAuthn** (`asap-protocol[webauthn]`) · `asap compliance-check` & `asap audit export` · stricter `ResolvedAgent.run()` · `AuditChainBroken` · [pinned security deps](https://github.com/adriannoes/asap-protocol/blob/main/SECURITY.md#dependency-policy) |
 | **v2.2** | Per-runtime identity & capability auth · SSE `POST /asap/stream` · `ASAP-Version` · JSON-RPC batch · tamper-evident audit · async state stores · Compliance Harness v2 |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -93,11 +93,21 @@ We continuously monitor dependencies using:
 
 CI runs `pip-audit` after a sync that **excludes** the optional extras `crewai` and `llamaindex`, because those graphs currently pull transitive packages (`diskcache`, `nltk`) that OSV still lists with no fixed release on PyPI. To match the security job locally:
 
-`uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex` then `uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654` (matches CI).
+`uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex` then `uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654 --ignore-vuln PYSEC-2024-271 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183` (matches CI).
 
 **CVE-2026-4539 (Pygments)**: CI uses `--ignore-vuln CVE-2026-4539` until a patched `pygments` release on PyPI resolves the advisory (`tool.uv.override-dependencies` prefers `pygments>=2.20.0` when resolvable).
 
 **CVE-2026-4963 / CVE-2026-2654 (smolagents, optional `[smolagents]` extra)**: OSV reports these against current PyPI releases with **no `fix_versions`/`fixed` range** yet. CI ignores them until Hugging Face publishes patched `smolagents` wheels; remove the flags when `pip-audit` is clean without them. The reference package does not import smolagents unless that extra is installed.
+
+**CVE-2026-45409 (idna)**: Resolved via `tool.uv.override-dependencies` (`idna>=3.15`) — DoS in `idna.encode()` on oversized inputs.
+
+**CVE-2026-46338 (pymdown-extensions)**: Resolved via override (`pymdown-extensions>=10.21.3`) and `[docs]` extra floor — snippets `restrict_base_path` prefix bypass in mkdocs stack.
+
+**PYSEC-2026-89 (markdown, mkdocs stack)**: CI uses `--ignore-vuln PYSEC-2026-89` while OSV still lists **3.10.2** (latest on PyPI as of 2026-05) with no fixed release; override pins `markdown>=3.10.2`. Remove the flag when `pip-audit` passes without it.
+
+**PYSEC-2025-183 (pyjwt, transitive via `[mcp]`)**: CI uses `--ignore-vuln PYSEC-2025-183` — advisory is **disputed by the supplier** (minimum key length is application-defined); override already pins `pyjwt>=2.12.0,<3` for CVE-2026-32597.
+
+**PYSEC-2024-271 (flask-cors, transitive via `locust` in dev/benchmarks)**: CI uses `--ignore-vuln PYSEC-2024-271` — log-injection when debug logging is enabled; **6.0.2 is latest on PyPI** with no fixed release listed. Not on the runtime agent-server path.
 
 **pip**: `tool.uv.override-dependencies` requires `pip>=26.1` so **CVE-2026-3219** (GHSA affecting pip ≤26.0.1) no longer requires a `pip-audit` ignore.
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -17,6 +17,8 @@ GITHUB_CLIENT_SECRET=
 # Registry & Revoked List
 # -----------------------------------------------------------------------------
 # URL to fetch registry.json (GitHub Pages or raw URL).
+# Local dev: `http://127.0.0.1:3000/registry.json` serves `public/registry.json`.
+# If you use `next dev --port N`, the app rewrites localhost registry URLs to PORT automatically.
 REGISTRY_URL=
 # URL to fetch revoked_agents.json
 REVOKED_URL=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --hostname 127.0.0.1",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/apps/web/src/app/developer-experience/page.tsx
+++ b/apps/web/src/app/developer-experience/page.tsx
@@ -153,6 +153,11 @@ export default function DeveloperExperiencePage() {
                             { name: 'OpenClaw', icon: 'openclaw', desc: 'Interoperable chat-based agent patterns.' },
                             { name: 'Vercel AI SDK', icon: 'vercel', desc: 'Bridge ASAP agents into Next.js/React apps with native tool-calling support.' },
                             {
+                                name: 'Mastra',
+                                icon: 'mastra',
+                                desc: 'ASAP capabilities as Mastra createTool definitions (`@asap-protocol/mastra` + `@mastra/core`).',
+                            },
+                            {
                                 name: 'OpenAI Agents',
                                 icon: 'openai-agents',
                                 desc: 'ASAP capability tools for the OpenAI Agents SDK (`@asap-protocol/openai-agents`; separate from the Chat Completions adapter in `@asap-protocol/client`).',

--- a/apps/web/src/app/features/[slug]/page.tsx
+++ b/apps/web/src/app/features/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import type { LucideIcon } from 'lucide-react';
-import { ArrowLeft, Database, ShieldCheck, Zap, Activity, Globe, Lock, Code, Fingerprint, KeySquare, Radio, Clock, GaugeCircle, Layers, Waypoints, FileCode, Braces, CloudUpload } from 'lucide-react';
+import { ArrowLeft, Database, ShieldCheck, Zap, Activity, Globe, Lock, Code, Fingerprint, KeySquare, Radio, Clock, GaugeCircle, Layers, Waypoints, FileCode, Braces, CloudUpload, Bot, Sparkles } from 'lucide-react';
 import { notFound } from 'next/navigation';
 import { BentoGrid, BentoCard } from '@/components/ui/bento-grid';
 
@@ -9,6 +9,8 @@ export function generateStaticParams() {
     return [
         { slug: 'openapi-adapter' },
         { slug: 'typescript-sdk' },
+        { slug: 'mastra-adapter' },
+        { slug: 'openai-agents-adapter' },
         { slug: 'auto-registration' },
         { slug: 'lite-registry' },
         { slug: 'verified-trust' },
@@ -245,6 +247,59 @@ const FEATURE_CONTENT: Record<
                 <p className="mb-6">
                     The monorepo ships <code className="rounded bg-zinc-800 px-1 py-0.5 text-sm text-indigo-300">apps/example-nextjs</code> as a runnable integration sample alongside the package sources under{' '}
                     <code className="rounded bg-zinc-800 px-1 py-0.5 text-sm text-indigo-300">packages/typescript/client/</code>.
+                </p>
+            </>
+        ),
+    },
+    'mastra-adapter': {
+        title: 'Mastra Adapter',
+        description: 'ASAP capabilities as Mastra createTool definitions.',
+        icon: Bot,
+        capabilities: [
+            { title: 'Tool bridge', description: 'Maps manifest capabilities to Mastra inputSchema/outputSchema via Zod.', icon: Code },
+            { title: 'Agent wrapper', description: 'Optional createAsapMastraAgent helper with sane defaults for ASAP-backed agents.', icon: Bot },
+            { title: 'Streaming', description: 'asapStreamToMastraTextStream bridges TaskStream chunks to Mastra-style text.', icon: Radio },
+        ],
+        content: (
+            <>
+                <p className="mb-6">
+                    Install{' '}
+                    <code className="rounded bg-zinc-800 px-1 py-0.5 text-sm text-indigo-300">@asap-protocol/mastra</code>{' '}
+                    alongside{' '}
+                    <code className="rounded bg-zinc-800 px-1 py-0.5 text-sm text-indigo-300">@mastra/core</code>{' '}
+                    to call remote ASAP capabilities from Mastra agents without hand-writing tool schemas.
+                </p>
+                <p className="mb-6">
+                    Runnable UI sample:{' '}
+                    <code className="rounded bg-zinc-800 px-1 py-0.5 text-sm text-indigo-300">apps/example-mastra</code>{' '}
+                    (Compliance Harness v2 score 1.0). Docs:{' '}
+                    <code className="rounded bg-zinc-800 px-1 py-0.5 text-sm text-indigo-300">docs/integrations/mastra.md</code>.
+                </p>
+            </>
+        ),
+    },
+    'openai-agents-adapter': {
+        title: 'OpenAI Agents Adapter',
+        description: 'ASAP capabilities as OpenAI Agents SDK tool() definitions.',
+        icon: Sparkles,
+        capabilities: [
+            { title: 'tool() bridge', description: 'asapToolsForOpenAIAgents builds @openai/agents tool definitions from a manifest.', icon: Sparkles },
+            { title: 'Remote handoffs', description: 'asapAsRemoteAgent wraps an ASAP gateway as a handoff target for multi-agent runs.', icon: Waypoints },
+            { title: 'Not Chat Completions', description: 'Distinct from @asap-protocol/client/adapters/openai static ChatCompletionTool[] helper.', icon: ShieldCheck },
+        ],
+        content: (
+            <>
+                <p className="mb-6">
+                    Install{' '}
+                    <code className="rounded bg-zinc-800 px-1 py-0.5 text-sm text-indigo-300">@asap-protocol/openai-agents</code>{' '}
+                    with{' '}
+                    <code className="rounded bg-zinc-800 px-1 py-0.5 text-sm text-indigo-300">@openai/agents</code>{' '}
+                    and Zod 4 to run OpenAI Agents SDK loops against ASAP-backed capabilities.
+                </p>
+                <p className="mb-6">
+                    CLI demo:{' '}
+                    <code className="rounded bg-zinc-800 px-1 py-0.5 text-sm text-indigo-300">apps/example-openai-agents</code>. Docs:{' '}
+                    <code className="rounded bg-zinc-800 px-1 py-0.5 text-sm text-indigo-300">docs/integrations/openai-agents.md</code>.
                 </p>
             </>
         ),

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -9,11 +9,11 @@ import { fetchRegistry } from '@/lib/registry';
 export const metadata: Metadata = {
   title: 'ASAP Protocol | The Marketplace for Autonomous Agents',
   description:
-    'Discover, verify, and integrate specialized AI agents using the open ASAP Protocol — v2.3.0 adds OpenAPI onboarding, the TypeScript client, auto-registration, capability escalation, and ASAP discovery challenges.',
+    'Discover, verify, and integrate specialized AI agents using the open ASAP Protocol — v2.3.1 adds Mastra and OpenAI Agents SDK adapters plus additive TypeScript client exports.',
   openGraph: {
     title: 'ASAP Protocol | The Marketplace for Autonomous Agents',
     description:
-      'Discover, verify, and integrate specialized AI agents using the open ASAP Protocol — v2.3.0 adds OpenAPI onboarding, the TypeScript client, auto-registration, capability escalation, and ASAP discovery challenges.',
+      'Discover, verify, and integrate specialized AI agents using the open ASAP Protocol — v2.3.1 adds Mastra and OpenAI Agents SDK adapters plus additive TypeScript client exports.',
     type: 'website',
   },
 };

--- a/apps/web/src/components/landing/FeaturesSection.tsx
+++ b/apps/web/src/components/landing/FeaturesSection.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { LANDING_FEATURE_SLUGS } from '@/lib/telemetry/homepage-cta-ids';
-import { Database, ShieldCheck, Zap, Activity, ArrowRight, Fingerprint, KeySquare, Radio, FileCode, Braces, CloudUpload } from 'lucide-react';
+import { Database, ShieldCheck, Zap, Activity, ArrowRight, Fingerprint, KeySquare, Radio, FileCode, Braces, CloudUpload, Bot, Sparkles } from 'lucide-react';
 
 const INLINE_CODE = 'rounded bg-zinc-800 px-1 py-0.5 text-sm text-indigo-300';
 
@@ -33,6 +33,28 @@ const FEATURE_DEFINITIONS: Record<FeatureSlug, Omit<FeatureCard, 'slug'>> = {
       </>
     ),
     icon: Braces,
+    className: 'md:col-span-1',
+  },
+  'mastra-adapter': {
+    title: 'Mastra Adapter',
+    description: (
+      <>
+        <code className={INLINE_CODE}>@asap-protocol/mastra</code> exposes ASAP capabilities as Mastra{' '}
+        <code className={INLINE_CODE}>createTool</code> definitions with streaming bridge support.
+      </>
+    ),
+    icon: Bot,
+    className: 'md:col-span-1',
+  },
+  'openai-agents-adapter': {
+    title: 'OpenAI Agents Adapter',
+    description: (
+      <>
+        <code className={INLINE_CODE}>@asap-protocol/openai-agents</code> maps capabilities to OpenAI Agents SDK{' '}
+        <code className={INLINE_CODE}>tool()</code> definitions and remote-agent handoffs.
+      </>
+    ),
+    icon: Sparkles,
     className: 'md:col-span-1',
   },
   'auto-registration': {
@@ -111,7 +133,7 @@ export function FeaturesSection() {
             Protocol Features
           </h2>
           <p className="mx-auto max-w-[600px] text-zinc-400">
-            Everything you need to orchestrate complex multi-agent systems reliably — identity, capabilities, streaming, and v2.3 adoption tools (OpenAPI, TypeScript SDK, auto-registration).
+            Everything you need to orchestrate complex multi-agent systems reliably — identity, capabilities, streaming, and v2.3.1 framework adapters (Mastra, OpenAI Agents SDK).
           </p>
         </div>
 

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -18,15 +18,15 @@ export function HeroSection() {
           >
             <div className="space-y-4">
               <Link
-                href="https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md#230---2026-05-04"
+                href="https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md#231---2026-05-18"
                 target="_blank"
                 rel="noopener noreferrer"
                 data-cta={HOMEPAGE_HERO_CTA_IDS.releaseBadge}
-                aria-label="View ASAP Protocol v2.3.0 changelog on GitHub"
+                aria-label="View ASAP Protocol v2.3.1 changelog on GitHub"
               >
                 <div className="inline-flex items-center rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-sm font-medium text-indigo-300 backdrop-blur-sm transition-colors hover:border-indigo-500/60 hover:bg-indigo-500/15">
                   <span className="mr-2 flex h-2 w-2 animate-pulse rounded-full bg-indigo-500"></span>
-                  v2.3.0 Now Live
+                  v2.3.1 — New Adapters
                 </div>
               </Link>
               <AnimatedText

--- a/apps/web/src/components/landing/WhatsNewRibbon.tsx
+++ b/apps/web/src/components/landing/WhatsNewRibbon.tsx
@@ -22,11 +22,15 @@ type Pill = {
 };
 
 const CHANGELOG_URL =
-  'https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md#230---2026-05-04';
+  'https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md#231---2026-05-18';
 const DOCS_OPENAPI =
   'https://github.com/adriannoes/asap-protocol/blob/main/docs/adapters/openapi.md';
 const DOCS_TS_SDK =
   'https://github.com/adriannoes/asap-protocol/blob/main/docs/sdks/typescript.md';
+const DOCS_MASTRA =
+  'https://github.com/adriannoes/asap-protocol/blob/main/docs/integrations/mastra.md';
+const DOCS_OPENAI_AGENTS =
+  'https://github.com/adriannoes/asap-protocol/blob/main/docs/integrations/openai-agents.md';
 const DOCS_AUTO_REG =
   'https://github.com/adriannoes/asap-protocol/blob/main/docs/registry/auto-registration.md';
 const DOCS_ESCALATION =
@@ -34,11 +38,18 @@ const DOCS_ESCALATION =
 
 const PILLS: Pill[] = [
   {
-    label: 'OpenAPI',
-    href: DOCS_OPENAPI,
-    icon: Layers,
+    label: 'Mastra',
+    href: DOCS_MASTRA,
+    icon: Sparkles,
     external: true,
-    dataCta: WHATS_NEW_RIBBON_CTA_IDS.docsOpenapi,
+    dataCta: WHATS_NEW_RIBBON_CTA_IDS.docsMastraIntegration,
+  },
+  {
+    label: 'OpenAI Agents',
+    href: DOCS_OPENAI_AGENTS,
+    icon: Code,
+    external: true,
+    dataCta: WHATS_NEW_RIBBON_CTA_IDS.docsOpenaiAgentsIntegration,
   },
   {
     label: 'TypeScript SDK',
@@ -46,6 +57,13 @@ const PILLS: Pill[] = [
     icon: Code,
     external: true,
     dataCta: WHATS_NEW_RIBBON_CTA_IDS.docsTypescript,
+  },
+  {
+    label: 'OpenAPI',
+    href: DOCS_OPENAPI,
+    icon: Layers,
+    external: true,
+    dataCta: WHATS_NEW_RIBBON_CTA_IDS.docsOpenapi,
   },
   {
     label: 'Auto-Reg',
@@ -85,7 +103,7 @@ const PILLS: Pill[] = [
 export function WhatsNewRibbon() {
   return (
     <aside
-      aria-label="What's new in ASAP Protocol v2.3.0"
+      aria-label="What's new in ASAP Protocol v2.3.1"
       className="w-full border-y border-zinc-900 bg-zinc-950"
     >
       <div className="container mx-auto flex max-w-5xl flex-col gap-4 px-4 py-8 md:flex-row md:items-center md:gap-4 md:px-6 md:py-10">
@@ -93,10 +111,10 @@ export function WhatsNewRibbon() {
           <Sparkles className="h-4 w-4 shrink-0 text-indigo-400" aria-hidden />
           <div className="flex flex-col">
             <span className="font-mono text-xs uppercase tracking-wider text-indigo-400">
-              What&apos;s new in v2.3.0
+              What&apos;s new in v2.3.1
             </span>
             <span className="text-xs text-zinc-500">
-              OpenAPI adapter, TypeScript SDK, auto-registration, escalation — May 2026
+              Mastra &amp; OpenAI Agents adapters on npm — May 2026
             </span>
           </div>
         </div>

--- a/apps/web/src/lib/registry.test.ts
+++ b/apps/web/src/lib/registry.test.ts
@@ -1,18 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resolveRegistryFetchUrl } from '@/lib/registry';
 
 describe('resolveRegistryFetchUrl', () => {
-  const originalEnv = { ...process.env };
-
   beforeEach(() => {
-    process.env = { ...originalEnv, NODE_ENV: 'development' };
-    delete process.env.REGISTRY_URL;
-    delete process.env.PORT;
+    vi.unstubAllEnvs();
+    vi.stubEnv('NODE_ENV', 'development');
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    vi.unstubAllEnvs();
   });
 
   it('uses GitHub default when REGISTRY_URL is unset', () => {
@@ -20,21 +17,21 @@ describe('resolveRegistryFetchUrl', () => {
   });
 
   it('rewrites localhost registry.json to process.env.PORT in development', () => {
-    process.env.REGISTRY_URL = 'http://127.0.0.1:3000/registry.json';
-    process.env.PORT = '3010';
+    vi.stubEnv('REGISTRY_URL', 'http://127.0.0.1:3000/registry.json');
+    vi.stubEnv('PORT', '3010');
     expect(resolveRegistryFetchUrl()).toBe('http://127.0.0.1:3010/registry.json');
   });
 
   it('does not rewrite remote REGISTRY_URL', () => {
-    process.env.REGISTRY_URL = 'https://example.com/registry.json';
-    process.env.PORT = '3010';
+    vi.stubEnv('REGISTRY_URL', 'https://example.com/registry.json');
+    vi.stubEnv('PORT', '3010');
     expect(resolveRegistryFetchUrl()).toBe('https://example.com/registry.json');
   });
 
   it('does not rewrite in production', () => {
-    process.env.NODE_ENV = 'production';
-    process.env.REGISTRY_URL = 'http://127.0.0.1:3000/registry.json';
-    process.env.PORT = '3010';
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('REGISTRY_URL', 'http://127.0.0.1:3000/registry.json');
+    vi.stubEnv('PORT', '3010');
     expect(resolveRegistryFetchUrl()).toBe('http://127.0.0.1:3000/registry.json');
   });
 });

--- a/apps/web/src/lib/registry.test.ts
+++ b/apps/web/src/lib/registry.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveRegistryFetchUrl } from '@/lib/registry';
+
+describe('resolveRegistryFetchUrl', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, NODE_ENV: 'development' };
+    delete process.env.REGISTRY_URL;
+    delete process.env.PORT;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses GitHub default when REGISTRY_URL is unset', () => {
+    expect(resolveRegistryFetchUrl()).toContain('raw.githubusercontent.com');
+  });
+
+  it('rewrites localhost registry.json to process.env.PORT in development', () => {
+    process.env.REGISTRY_URL = 'http://127.0.0.1:3000/registry.json';
+    process.env.PORT = '3010';
+    expect(resolveRegistryFetchUrl()).toBe('http://127.0.0.1:3010/registry.json');
+  });
+
+  it('does not rewrite remote REGISTRY_URL', () => {
+    process.env.REGISTRY_URL = 'https://example.com/registry.json';
+    process.env.PORT = '3010';
+    expect(resolveRegistryFetchUrl()).toBe('https://example.com/registry.json');
+  });
+
+  it('does not rewrite in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.REGISTRY_URL = 'http://127.0.0.1:3000/registry.json';
+    process.env.PORT = '3010';
+    expect(resolveRegistryFetchUrl()).toBe('http://127.0.0.1:3000/registry.json');
+  });
+});

--- a/apps/web/src/lib/registry.ts
+++ b/apps/web/src/lib/registry.ts
@@ -72,6 +72,37 @@ function normalizeRegistryAgent(agent: RegistryAgentValidated): RegistryAgent {
   return normalized as unknown as RegistryAgent;
 }
 
+const DEFAULT_REGISTRY_URL =
+  'https://raw.githubusercontent.com/adriannoes/asap-protocol/main/registry.json';
+
+/**
+ * In development, `.env` often pins REGISTRY_URL to `http://127.0.0.1:3000/registry.json`
+ * while `next dev --port N` listens elsewhere. Rewrite local registry URLs to `process.env.PORT`.
+ */
+export function resolveRegistryFetchUrl(explicitUrl?: string): string {
+  const url = explicitUrl ?? process.env.REGISTRY_URL ?? DEFAULT_REGISTRY_URL;
+
+  if (process.env.NODE_ENV !== 'development') {
+    return url;
+  }
+
+  try {
+    const parsed = new URL(url);
+    const isLocalHost =
+      parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost';
+    const isRegistryJson = parsed.pathname.endsWith('/registry.json');
+
+    if (!isLocalHost || !isRegistryJson) {
+      return url;
+    }
+
+    const port = process.env.PORT ?? parsed.port ?? '3000';
+    return `http://127.0.0.1:${port}${parsed.pathname}`;
+  } catch {
+    return url;
+  }
+}
+
 /**
  * Fetch the ASAP Lite Registry.
  * We fetch from REGISTRY_URL (GitHub Pages or raw URL). Next.js ISR uses REGISTRY_REVALIDATE_SECONDS.
@@ -80,9 +111,7 @@ function normalizeRegistryAgent(agent: RegistryAgentValidated): RegistryAgent {
  */
 export async function fetchRegistry(): Promise<RegistryAgent[]> {
   // Server-side only: use REGISTRY_URL (not NEXT_PUBLIC_) to avoid leaking in client bundle.
-  const REGISTRY_URL =
-    process.env.REGISTRY_URL ||
-    'https://raw.githubusercontent.com/adriannoes/asap-protocol/main/registry.json';
+  const REGISTRY_URL = resolveRegistryFetchUrl();
 
   try {
     const res = await fetch(REGISTRY_URL, {

--- a/apps/web/src/lib/telemetry/homepage-cta-ids.ts
+++ b/apps/web/src/lib/telemetry/homepage-cta-ids.ts
@@ -13,6 +13,8 @@ export const HOMEPAGE_HERO_CTA_IDS = {
 export const WHATS_NEW_RIBBON_CTA_IDS = {
   docsOpenapi: 'docs-openapi',
   docsTypescript: 'docs-typescript',
+  docsMastraIntegration: 'docs-mastra-integration',
+  docsOpenaiAgentsIntegration: 'docs-openai-agents-integration',
   docsAutoRegistration: 'docs-auto-registration',
   featurePerAgentIdentity: 'feature-per-agent-identity',
   featureScopedCapabilities: 'feature-scoped-capabilities',
@@ -24,6 +26,8 @@ export const WHATS_NEW_RIBBON_CTA_IDS = {
 export const LANDING_FEATURE_SLUGS = [
   'openapi-adapter',
   'typescript-sdk',
+  'mastra-adapter',
+  'openai-agents-adapter',
   'auto-registration',
   'lite-registry',
   'verified-trust',
@@ -41,6 +45,8 @@ export const HOMEPAGE_CTA_IDS = [
   HOMEPAGE_HERO_CTA_IDS.registerAgent,
   WHATS_NEW_RIBBON_CTA_IDS.docsOpenapi,
   WHATS_NEW_RIBBON_CTA_IDS.docsTypescript,
+  WHATS_NEW_RIBBON_CTA_IDS.docsMastraIntegration,
+  WHATS_NEW_RIBBON_CTA_IDS.docsOpenaiAgentsIntegration,
   WHATS_NEW_RIBBON_CTA_IDS.docsAutoRegistration,
   WHATS_NEW_RIBBON_CTA_IDS.docsCapabilitiesEscalation,
   ...LANDING_FEATURE_SLUGS.map((slug) => `feature-${slug}` as const),

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 **ASAP (Async Simple Agent Protocol)** is a streamlined protocol for agent-to-agent communication, designed to be simpler than existing alternatives while maintaining modern standards functionality.
 
-**Latest reference implementation:** **v2.3.0** ([CHANGELOG](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md), [PyPI](https://pypi.org/project/asap-protocol/), npm [`@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client)) — **Adoption Multiplier** on top of v2.2.x: **OpenAPI Adapter** (`create_from_openapi`, optional `[openapi]` extra), **TypeScript client** with framework adapters, **Auto-Registration** (`POST /registry/agents`), **capability escalation** (`POST /asap/agent/request-capability`), and **ASAP `WWW-Authenticate` challenges** for discovery. v2.2.1 WebAuthn, compliance/audit CLIs, and dependency policy remain as documented. Upgrade notes: [Migration (v2.2.x → v2.3.0)](migration.md#upgrading-from-v22x-to-v230).
+**Latest reference implementation:** **v2.3.0** on PyPI ([CHANGELOG](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md), [PyPI](https://pypi.org/project/asap-protocol/)). **TypeScript npm line: v2.3.1** — [`@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client), [`@asap-protocol/mastra`](integrations/mastra.md), [`@asap-protocol/openai-agents`](integrations/openai-agents.md) (TS-only patch; wire protocol unchanged). v2.3.0 **Adoption Multiplier**: OpenAPI Adapter, TypeScript client, Auto-Registration, capability escalation, ASAP challenges. Upgrade: [v2.2.x → v2.3.0](migration.md#upgrading-from-v22x-to-v230) · [v2.3.0 → v2.3.1](migration.md#upgrading-from-v230-to-v231).
 
 ## Features
 
@@ -12,7 +12,7 @@
 - **Transport Agnostic**: Clean separation between protocol logic and transport capability (HTTP JSON-RPC, WebSocket, SSE)
 - **Observability**: First-class tracking with correlation IDs and trace IDs
 - **Security & authorization (v2.2+, WebAuthn real in v2.2.1)**: Per-runtime Host/Agent JWTs, capability grants with constraints, approval flows, opt-in WebAuthn (`asap-protocol[webauthn]`) for browser-controlled and high-risk capability registration — see [Security](security.md) and [Migration](migration.md)
-- **Adoption tools (v2.3.0)**: [OpenAPI adapter](adapters/openapi.md), TypeScript client ([`packages/typescript/client`](https://github.com/adriannoes/asap-protocol/tree/main/packages/typescript/client)), Mastra adapter ([`integrations/mastra.md`](integrations/mastra.md) · `@asap-protocol/mastra`), OpenAI Agents SDK adapter ([`integrations/openai-agents.md`](integrations/openai-agents.md) · `@asap-protocol/openai-agents`), [Auto-registration](registry/auto-registration.md), [Capability escalation](capabilities/escalation.md), [ASAP HTTP challenge](transport/asap-challenge.md)
+- **Adoption tools (v2.3.0+)**: [OpenAPI adapter](adapters/openapi.md), [TypeScript client](sdks/typescript.md) (`@asap-protocol/client@2.3.1`), [Mastra adapter](integrations/mastra.md) (`@asap-protocol/mastra@2.3.1`), [OpenAI Agents SDK adapter](integrations/openai-agents.md) (`@asap-protocol/openai-agents@2.3.1`), [Auto-registration](registry/auto-registration.md), [Capability escalation](capabilities/escalation.md), [ASAP HTTP challenge](transport/asap-challenge.md)
 
 ## Installation
 
@@ -92,8 +92,9 @@ See [CLI reference](cli.md) (all commands, exit codes, `compliance-check`, `audi
 ## Documentation
 
 - [OpenAPI adapter](adapters/openapi.md) — derive ASAP skills and an upstream proxy from OpenAPI 3.x (`asap.adapters.openapi`)
-- [TypeScript client SDK](sdks/typescript.md) — `@asap-protocol/client` on npm (browser + Node; optional LLM adapters)
-- [OpenAI Agents SDK adapter](integrations/openai-agents.md) — `@asap-protocol/openai-agents`: ASAP capabilities as `@openai/agents` tools + handoff-oriented remote agent helper (`@openai/agents`, distinct from `@asap-protocol/client/adapters/openai`)
+- [TypeScript client SDK](sdks/typescript.md) — `@asap-protocol/client@2.3.1` on npm (browser + Node; optional LLM adapters)
+- [Mastra adapter](integrations/mastra.md) — `@asap-protocol/mastra@2.3.1`: ASAP capabilities as `@mastra/core` tools + streaming bridge
+- [OpenAI Agents SDK adapter](integrations/openai-agents.md) — `@asap-protocol/openai-agents@2.3.1`: ASAP capabilities as `@openai/agents` tools + handoff-oriented remote agent helper (`@openai/agents`, distinct from `@asap-protocol/client/adapters/openai`)
 - [CLI reference](cli.md) — all `asap` commands, including `compliance-check`, `audit export`, and exit codes
 - [Audit log](audit.md) — hash chain model, export formats, tamper checks
 - [API Reference](api-reference.md)

--- a/docs/maintainers/hotfix.md
+++ b/docs/maintainers/hotfix.md
@@ -1,0 +1,186 @@
+# Hotfix runbook (v2.3.x line)
+
+Maintainer guide for shipping urgent fixes after a **v2.3.x** TypeScript release without disturbing `latest` on npm or the Python protocol version when only adapters need a patch. Read [npm-publishing.md](./npm-publishing.md) for OIDC, Trusted Publishing, and `NPM_TOKEN_EMERGENCY` before executing a hotfix.
+
+## Maintainer cross-links
+
+- **npm publish (normal + emergency)**: [npm-publishing.md](./npm-publishing.md)
+- **Release checklist (v2.3.1)**: [engineering/tasks/private/v2.3.1/release-checklist.md](../../engineering/tasks/private/v2.3.1/release-checklist.md) — §4.0 rollback points here
+- **Hotfix CI**: [.github/workflows/hotfix-release.yml](../../.github/workflows/hotfix-release.yml) — tags `v2.3.*-hotfix.*` / `v2.3.*-rc.*`
+
+## § Decision: hotfix now vs wait for next minor
+
+| Signal | Prefer **hotfix** | Prefer **wait** (next minor, e.g. v2.3.2 / v2.4.0) |
+|--------|-------------------|-----------------------------------------------------|
+| Severity | Published adapter broken for all consumers (install fails, runtime crash on documented path, security advisory) | Cosmetic docs, non-blocking DX, internal examples only |
+| Blast radius | `@asap-protocol/client`, `mastra`, or `openai-agents` on npm | Unpublished code, private examples, maintainer-only scripts |
+| Protocol contract | Envelope / JSON-RPC / shared types wrong on wire | Adapter-only bug with unchanged protocol surface |
+| Workaround | None or unsafe (data loss, auth bypass) | Pin older version, document workaround, feature flag |
+| Timeline | Fix needed within days | Can ride the next planned minor with full test matrix |
+
+**Default**: if the issue does not affect a **published** npm package on a **supported** code path, schedule the fix in the next minor rather than opening a hotfix branch.
+
+## § Version scheme
+
+Two tracks — pick one before branching:
+
+### A. Protocol / shared-client fix (bumps patch on the release line)
+
+- Example: `2.3.1` → **`2.3.2`**
+- Applies when `@asap-protocol/client` types or behavior change in a way consumers must pick up, or multiple packages must move together.
+- **Tag**: `v2.3.2` on `main` (after merge).
+- **Publish**: [.github/workflows/publish-typescript.yml](../../.github/workflows/publish-typescript.yml) (stable tag → `latest` on npm).
+- **Python**: only bump PyPI `asap-protocol` if the Python core changed; v2.3.x adapter-only releases typically leave PyPI at **2.3.0**.
+
+### B. Adapter-only fix (no protocol version bump)
+
+- Example: `@asap-protocol/mastra@`**`2.3.1-hotfix.1`** (semver prerelease on the **2.3.1** line).
+- Same pattern for `@asap-protocol/openai-agents` or, rarely, client-only adapter surface without protocol bump.
+- **Tag**: `v2.3.1-hotfix.1` (increment `.N` for subsequent adapter hotfixes: `hotfix.2`, …).
+- **Publish**: [.github/workflows/hotfix-release.yml](../../.github/workflows/hotfix-release.yml) → npm dist-tag **`hotfix`** (not `latest`).
+- **Install**: `npm install @asap-protocol/mastra@hotfix` or exact version `2.3.1-hotfix.1`.
+
+**Do not** republish the same semver to npm. If a hotfix publish fails mid-flight, fix forward with the next version (e.g. `2.3.1-hotfix.2` or `2.3.2`).
+
+## § Branching strategy
+
+1. Identify the last good release tag (e.g. `v2.3.1`):
+
+   ```bash
+   git fetch --tags
+   git tag -l 'v2.3.*'
+   ```
+
+2. Create a hotfix branch **from that tag** (name encodes the fix generation):
+
+   ```bash
+   git checkout -b hotfix/2.3.1.1 v2.3.1
+   ```
+
+   Use `hotfix/2.3.1.2` for a second hotfix wave on the same base if the first branch was already merged and tagged.
+
+3. Implement the minimal fix; run the same gates as release (see [release-checklist.md](../../engineering/tasks/private/v2.3.1/release-checklist.md) §1): `pnpm test`, `pnpm typecheck`, `pnpm lint`, and adapter compliance if touched.
+
+4. Bump versions per § Version scheme (adapter-only: set `package.json` to `2.3.1-hotfix.1` in affected packages only, or protocol path: `2.3.2` everywhere that ships).
+
+5. Add a **public** CHANGELOG subsection (factual, no private PRD context).
+
+## § Cherry-pick workflow
+
+After the hotfix tag is published and verified:
+
+1. Merge or cherry-pick the hotfix commit(s) onto `main` so the fix is not lost on the next minor:
+
+   ```bash
+   git checkout main
+   git pull origin main
+   git cherry-pick <commit-sha>   # repeat per commit, or merge hotfix/2.3.1.1
+   ```
+
+2. On `main`, set package versions to the **next development** target (e.g. `2.3.2` or `2.3.2-dev.0` per team convention — do not leave `2.3.1-hotfix.1` on `main` unless intentionally staging another hotfix).
+
+3. Resolve conflicts in `pnpm-lock.yaml` and integration docs; re-run CI.
+
+4. If the hotfix used dist-tag `hotfix`, document in CHANGELOG that consumers on `latest` should upgrade to the next stable patch when it ships.
+
+## § Publish (automated)
+
+### Trusted Publishing
+
+Register **each** published package on npm → **Trusted Publishers** → **GitHub Actions**:
+
+| Field | Value |
+|-------|--------|
+| Repository | `adriannoes/asap-protocol` |
+| Workflow file | `.github/workflows/hotfix-release.yml` |
+| Environment | (none, unless you add a `release` environment later) |
+
+Allow several minutes after saving. Toolchain matches [npm-publishing.md](./npm-publishing.md): Node **22**, `npm install -g npm@11.5.1`, **no** `registry-url` on `actions/setup-node` for the publish job.
+
+### Tag and push
+
+**Adapter-only (track B):**
+
+```bash
+git tag -a v2.3.1-hotfix.1 -m "Hotfix: <one-line summary>"
+git push origin hotfix/2.3.1.1
+git push origin v2.3.1-hotfix.1
+```
+
+**Protocol patch (track A):** merge to `main`, tag `v2.3.2`, push — uses `publish-typescript.yml`, not the hotfix workflow.
+
+### Verify
+
+```bash
+npm view @asap-protocol/mastra version
+npm view @asap-protocol/mastra dist-tags
+# hotfix track: expect dist-tags.hotfix == 2.3.1-hotfix.1
+```
+
+## § Emergency manual publish (OIDC broken)
+
+If Trusted Publishing fails during a hotfix window:
+
+1. Follow [npm-publishing.md § Emergency manual publish](./npm-publishing.md#-emergency-manual-publish-oidc-broken) using **`NPM_TOKEN_EMERGENCY`** (never commit the token).
+2. For adapter-only versions, publish with the **`hotfix`** dist-tag explicitly:
+
+   ```bash
+   npm publish --access public --provenance=false --tag hotfix
+   ```
+
+3. Restore OIDC before the next tag; confirm `hotfix-release.yml` is registered on npm for all affected packages.
+
+## § CI: dry-run vs tag-only publish
+
+| Event | Workflow behavior |
+|-------|-------------------|
+| **Pull request** to `main` (paths: TS packages + hotfix workflow) | `npm publish --dry-run` only — validates pack contents without registry write or `id-token` |
+| **Pull request** to `hotfix/*` | Same dry-run job (validates the branch before tag) |
+| **Push** tag `v2.3.*-hotfix.*` or `v2.3.*-rc.*` | Real publish with OIDC + provenance |
+
+Real publishes are **tag-only** because npm Trusted Publishing and provenance are bound to release tags, not branch heads. Dry-run on PR is the pre-flight gate; do not rely on branch pushes to publish.
+
+## § Post-mortem template
+
+Copy into a private maintainer doc or internal issue after any production-impacting hotfix:
+
+```markdown
+## Hotfix post-mortem — v2.3.x
+
+**Date**:
+**Incident owner**:
+**Versions shipped** (npm tags / dist-tags):
+**Track** (A protocol patch / B adapter-only):
+
+### Summary
+(2–3 sentences: what broke, who was affected.)
+
+### Timeline
+| Time (UTC) | Event |
+|------------|--------|
+| | Detection |
+| | Branch opened |
+| | Fix merged / tagged |
+| | npm verified |
+
+### Root cause
+(Technical cause; link PR/commit.)
+
+### Why hotfix vs minor
+(One paragraph referencing § Decision criteria.)
+
+### What went well / what to improve
+-
+
+### Follow-ups
+- [ ] Cherry-pick on `main` confirmed
+- [ ] CHANGELOG / migration note (if consumer-facing)
+- [ ] Trusted Publisher / workflow registry checked
+- [ ] Promotion-gate or telemetry review scheduled (if adoption impact)
+```
+
+## References
+
+- [npm-publishing.md](./npm-publishing.md) — OIDC, `NPM_TOKEN_EMERGENCY`, normal `v2.3.*` tags
+- [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers)
+- [Semantic Versioning — prerelease](https://semver.org/#spec-item-9)

--- a/docs/maintainers/npm-publishing.md
+++ b/docs/maintainers/npm-publishing.md
@@ -5,6 +5,7 @@ Maintainer guide for scoped package bootstrap, Trusted Publishing (OIDC), and re
 ## Maintainer cross-links
 
 - **Release checklist (npm gate)**: [engineering/tasks/v2.3.0/release-checklist.md](../../engineering/tasks/v2.3.0/release-checklist.md) — §**4.3** (verify install after publish).
+- **Hotfix runbook**: [hotfix.md](./hotfix.md) — adapter-only `2.3.1-hotfix.N` vs protocol patch `2.3.2`, branching, cherry-pick, emergency publish.
 - **Sprint notes (historical)**: [engineering/tasks/private/v2.3.1/sprint-S0-unblock-npm.md](../../engineering/tasks/private/v2.3.1/sprint-S0-unblock-npm.md) — first-publish / OIDC troubleshooting narrative.
 
 ## Normal path (after bootstrap)
@@ -87,5 +88,6 @@ When Trusted Publishing or GitHub OIDC fails but you must ship a fix:
 
 ## References
 
+- [hotfix.md](./hotfix.md) — post-release hotfix decision tree, tags, and `.github/workflows/hotfix-release.yml`
 - [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers)
 - [GitHub: npm provenance](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npmjs-registry)

--- a/engineering/manual-release-testing.md
+++ b/engineering/manual-release-testing.md
@@ -83,7 +83,7 @@ Repeat the same scenarios covered by CI without running the full suite:
 
 ## 11. Security audit (same graph as CI)
 
-- [ ] `uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex && uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654` — matches CI (see `SECURITY.md` if flags change)
+- [ ] `uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex && uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654 --ignore-vuln PYSEC-2024-271 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183` — matches CI (see `SECURITY.md` if flags change)
 
 ---
 

--- a/engineering/tasks/v2.3.0/release-checklist.md
+++ b/engineering/tasks/v2.3.0/release-checklist.md
@@ -17,7 +17,7 @@ Run from repository root (`/Users/adrianno/GitHub/asap-protocol` or CI clone):
 | Format | `uv run ruff format --check .` | |
 | Types | `uv run mypy src/ scripts/ tests/` | |
 | Python tests | `PYTHONPATH=src uv run pytest --cov=src --cov-report=xml` | **2026-05-04**: 3213 passed, 11 skipped (requires extras incl. `webauthn` for full collection) |
-| pip-audit | `uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654` | Same ignores as CI |
+| pip-audit | `uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654 --ignore-vuln PYSEC-2024-271 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183` | Same ignores as CI |
 | TS client | `pnpm install && pnpm test && pnpm typecheck && pnpm lint` | Root `package.json` delegates to `@asap-protocol/client` + `example-nextjs` lint |
 | Web app (if touched) | `cd apps/web && pnpm test` | Vitest; Playwright E2E optional for release gate |
 

--- a/product/README.md
+++ b/product/README.md
@@ -40,7 +40,7 @@ product/
 | **v2.2.0** | **✅ Released (2026-04-15)** | `prd-v2.2-protocol-hardening.md` | Identity, capabilities, streaming, batch, audit |
 | **v2.2.1** | **✅ Released (2026-04-21)** | `prd-v2.2.1-patch.md` | WebAuthn real, CLI compliance/audit |
 | v2.3.0 — Adoption Core | ✅ Released (2026-05-04, tag `v2.3.0` pending maintainer push) | `prd-v2.3-scale.md` | OpenAPI Adapter, TypeScript SDK, Auto-Registration, escalation, ASAP challenge |
-| v2.3.1 — Adapter Lab I | 🔒 Private planning | `prd/private/prd-v2.3.1-adapter-lab.md` | OpenAI Agents SDK, Google ADK, Mastra, LangGraph validation |
+| v2.3.1 — Framework adapters (npm) | 🚀 Releasing (TS patch) | — (private PRD) | `@asap-protocol/mastra`, `@asap-protocol/openai-agents` @ 2.3.1; Python core stays 2.3.0 |
 | v2.3.2 — Adapter Lab II | 🔒 Private planning | `prd/private/prd-v2.3.2-enterprise-workflow-adapters.md` | Microsoft Agent Framework, Haystack, Letta, workflow automation |
 | v2.3.3 — Distribution Loop | 🔒 Private planning | `prd/private/prd-v2.3.3-distribution-loop.md` | Templates, docs, homepage, metrics, developer activation |
 | v2.4.0 — Spec & Interop | 🚧 VISION DRAFT (rescoped) | `prd-v2.4-adoption.md` | MCP Auth Bridge, Formal Spec, Introspection, Privacy |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ docs = [
     "ghp-import>=2.1.0",
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.27",
-    "pymdown-extensions>=10.21",
+    "pymdown-extensions>=10.21.3",
 ]
 dns-sd = [
     "zeroconf>=0.80",
@@ -129,6 +129,9 @@ Issues = "https://github.com/adriannoes/asap-protocol/issues"
 # - urllib3>=2.7.0 for CVE-2026-44431 / CVE-2026-44432
 # - pip>=26.1 for CVE-2026-6357 (transitive via pip-api / venv)
 # - python-dotenv>=1.2.2 for CVE-2026-28684 (transitive, e.g. pydantic-settings / uvicorn stacks)
+# - idna>=3.15 for CVE-2026-45409 (DoS in idna.encode; transitive via httpx/requests)
+# - markdown>=3.10.2 for PYSEC-2026-89 (DoS in html.parser during Markdown parse; mkdocs stack)
+# - pymdown-extensions>=10.21.3 for CVE-2026-46338 (snippets base_path prefix bypass; mkdocs stack)
 [tool.uv]
 override-dependencies = [
     "pyjwt>=2.12.0,<3",
@@ -145,6 +148,9 @@ override-dependencies = [
     "urllib3>=2.7.0",
     "pip>=26.1",
     "python-dotenv>=1.2.2",
+    "idna>=3.15",
+    "markdown>=3.10.2",
+    "pymdown-extensions>=10.21.3",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -5,13 +5,16 @@ requires-python = ">=3.13"
 [manifest]
 overrides = [
     { name = "cryptography", specifier = ">=46.0.7,<47" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "langchain-core", specifier = ">=1.3.3" },
     { name = "langsmith", specifier = ">=0.8.0" },
+    { name = "markdown", specifier = ">=3.10.2" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pip", specifier = ">=26.1" },
     { name = "pyasn1", specifier = ">=0.6.3" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.12.0,<3" },
+    { name = "pymdown-extensions", specifier = ">=10.21.3" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.27" },
@@ -339,7 +342,7 @@ requires-dist = [
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "pydantic", specifier = ">=2.12.5,<3" },
     { name = "pydantic-ai", marker = "extra == 'pydanticai'", specifier = ">=0.2" },
-    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21.3" },
     { name = "pypistats", marker = "extra == 'telemetry'", specifier = ">=1.11.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
@@ -1906,11 +1909,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -2508,11 +2511,11 @@ wheels = [
 
 [[package]]
 name = "markdown"
-version = "3.10"
+version = "3.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/7dd27d9d863b3376fcf23a5a13cb5d024aed1db46f963f1b5735ae43b3be/markdown-3.10.tar.gz", hash = "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e", size = 364931, upload-time = "2025-11-03T19:51:15.007Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl", hash = "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c", size = 107678, upload-time = "2025-11-03T19:51:13.887Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]
@@ -4221,15 +4224,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add v2.3.1 homepage landing cards for Mastra and OpenAI Agents adapters with telemetry `data-cta` ids (S4 §4.1–4.3).
- Update public docs (`README`, `docs/index`, `product/README`) and set CHANGELOG release date to **2026-05-20**.
- Publish maintainer hotfix runbook (`docs/maintainers/hotfix.md`) and `hotfix-release.yml` workflow (S4 R9).

Builds on `origin/main` release prep (`7aa5b15`: version bumps, CHANGELOG, migration note, publish workflow).
