### PR TITLE
docs(registry): ShellClaw S0 marketplace onboarding

### DIFF
--- a/.github/ISSUE_TEMPLATE/register_agent.yml
+++ b/.github/ISSUE_TEMPLATE/register_agent.yml
@@ -69,6 +69,7 @@ body:
         - ""
         - CrewAI
         - OpenClaw
+        - ShellClaw
         - LangChain
         - AutoGen
         - Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ShellClaw static registry onboarding**: Guide
+  [docs/guides/shellclaw-registry.md](docs/guides/shellclaw-registry.md) documents
+  `online_check: false`, GitHub Pages `endpoints.manifest` URLs, and IssueOps vs
+  auto-registration for agents without a live ASAP endpoint in v1.0. Regression
+  fixture `tests/fixtures/registry/shellclaw-v1.0-entry.json` with
+  `test_shellclaw_v1_fixture_validates`.
+- **Marketplace — ShellClaw v1.0** (listing PR pending): ShellClaw v1.0 (C,
+  ~5500 lines) is the first non-Python ASAP agent in the marketplace. It
+  implements ASAP `2.1.0` features: discovery, envelopes, auth, rate limits,
+  Ed25519-signed manifest (TweetNaCl vendored). It targets the NVIDIA Jetson
+  Orin Nano Super with CUDA-accelerated local inference. Static manifest hosting
+  only in v1.0 (no live endpoint until v1.0.1).
+
 ### Security
 
 - **OAuth2 middleware**: Validate JWT `iss` and `aud` when `ASAP_AUTH_ISSUER` / `ASAP_AUTH_AUDIENCE` (or `OAuth2Config.expected_issuer` / `expected_audience`) are set; refactored validation through `validate_jwt()` in `asap.auth.jwks`.

--- a/apps/web/src/app/dashboard/register/register-form.tsx
+++ b/apps/web/src/app/dashboard/register/register-form.tsx
@@ -33,7 +33,15 @@ import { ManifestSchema, type ManifestFormValues } from "@/lib/register-schema";
 import { submitAgentRegistration } from "./actions";
 import { generateAndStoreAgentKeys } from "@/lib/webcrypto";
 
-const BUILT_WITH_OPTIONS = ['', 'CrewAI', 'OpenClaw', 'LangChain', 'AutoGen', 'Other'] as const;
+const BUILT_WITH_OPTIONS = [
+    '',
+    'CrewAI',
+    'OpenClaw',
+    'ShellClaw',
+    'LangChain',
+    'AutoGen',
+    'Other',
+] as const;
 const EMPTY_VALUE = '__none__'; // Radix Select disallows value=""
 
 export function RegisterAgentForm() {

--- a/apps/web/src/app/docs/register/page.tsx
+++ b/apps/web/src/app/docs/register/page.tsx
@@ -113,6 +113,40 @@ app = create_app(manifest, registry)`}</code>
                             <h2 className="text-2xl font-bold text-white">Publish via IssueOps</h2>
                         </div>
 
+                        <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-6 space-y-3">
+                            <h3 className="text-lg font-semibold text-white">Built with (framework)</h3>
+                            <p className="text-zinc-400 text-sm leading-relaxed">
+                                Optional on registration. Use the same values in the{' '}
+                                <a
+                                    href="https://github.com/adriannoes/asap-protocol/blob/main/.github/ISSUE_TEMPLATE/register_agent.yml"
+                                    className="text-indigo-400 hover:text-indigo-300 underline underline-offset-2"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    GitHub issue template
+                                </a>{' '}
+                                and the web dashboard:
+                            </p>
+                            <p className="text-sm font-mono text-zinc-300">
+                                CrewAI · OpenClaw · ShellClaw · LangChain · AutoGen · Other
+                            </p>
+                            <p className="text-zinc-500 text-xs leading-relaxed">
+                                C-native or static-manifest agents (GitHub Pages only, no live ASAP endpoint in v1.0)
+                                may set{' '}
+                                <code className="text-indigo-400 bg-indigo-500/10 px-1 rounded">online_check: false</code>
+                                . See{' '}
+                                <a
+                                    href="https://github.com/adriannoes/asap-protocol/blob/main/docs/guides/shellclaw-registry.md"
+                                    className="text-indigo-400 hover:text-indigo-300 underline underline-offset-2"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    ShellClaw static registry guide
+                                </a>
+                                .
+                            </p>
+                        </div>
+
                         <div className="grid md:grid-cols-2 gap-6">
                             <div className="p-6 rounded-xl border border-indigo-500/30 bg-indigo-500/5 relative group hover:bg-indigo-500/10 transition-colors">
                                 <ShieldCheck className="w-6 h-6 text-indigo-400 mb-4" />

--- a/docs/guides/shellclaw-registry.md
+++ b/docs/guides/shellclaw-registry.md
@@ -1,0 +1,197 @@
+# ShellClaw marketplace registration (static manifest)
+
+This guide answers upstream questions for [ShellClaw](https://github.com/adriannoes/shellclaw) v1.0 **Wave 6** (Lite Registry / marketplace listing). It documents how to register an agent whose manifest is hosted **statically** (for example GitHub Pages) with **no live ASAP HTTP endpoint** in v1.0.
+
+For maintainer review of Verified badge requests, see [Registry verification review](registry-verification-review.md). For the bot PR path (`POST /registry/agents`), see [Lite Registry auto-registration](../registry/auto-registration.md).
+
+## Upstream answers (ShellClaw §5)
+
+### §5.1 Registry entry validity — **YES, with notes**
+
+The literal ShellClaw v1.0 entry is valid for `RegistryEntry` and `scripts/validate_registry.py`. A copy lives in the repo as a test fixture:
+
+- **Fixture:** [`tests/fixtures/registry/shellclaw-v1.0-entry.json`](https://github.com/adriannoes/asap-protocol/blob/main/tests/fixtures/registry/shellclaw-v1.0-entry.json)
+- **Test:** `test_shellclaw_v1_fixture_validates` in [`tests/discovery/test_registry.py`](https://github.com/adriannoes/asap-protocol/blob/main/tests/discovery/test_registry.py)
+
+| Field | Status |
+|-------|--------|
+| `id` | `urn:asap:agent:shellclaw` — valid URN |
+| `category` | `Infrastructure` — canonical enum |
+| `tags` | Valid; do **not** submit `self-signed` manually (see below) |
+| `built_with` | `Other` — valid today (`ShellClaw` optional in Issue template; see sprint v2.4 S0) |
+| `verification` | `null` — valid |
+| `online_check` | `false` — supported |
+| `endpoints.http` + `endpoints.manifest` | Valid map keys per ADR-15 |
+
+**Before public listing:** replace placeholder `https://shellclaw.example.com/asap` with a real URL when you have one. With `online_check: false`, IssueOps registration is acceptable while the HTTP endpoint is still a placeholder.
+
+**Auto-registration:** `POST /registry/agents` runs Compliance Harness v2 against a **reachable** manifest URL and typically expects a live agent surface. ShellClaw v1.0 should use **IssueOps** (registration issue → maintainer PR) until a live tunnel exists (v1.0.1).
+
+### §5.2 `built_with` enum — **optional**
+
+`Other` is sufficient for v1.0. Adding `ShellClaw` to the registration issue dropdown improves Browse/filter discoverability only.
+
+### §5.3 Trust label — **unchanged**
+
+Manifest `signature.trust_level` and marketplace trust labeling use **`"self-signed"`** (hyphen). This matches `TrustLevel.SELF_SIGNED` in `asap.crypto.trust_levels`.
+
+### §5.4 Static manifest hosting — **accepted**
+
+`online_check: false` tells clients and the web UI to **skip reachability pings** for `endpoints.http`. Listing is **not rejected** because the agent has no live `POST /asap` endpoint in v1.0.
+
+See [Browse and marketplace UI](#browse-and-marketplace-ui-spot-check) below for per-surface behavior.
+
+### §5.5 Manifest URL path — **accepted on static hosts**
+
+`endpoints.manifest` may point to a static URL such as:
+
+`https://adriannoes.github.io/shellclaw/manifest.json`
+
+The `/.well-known/asap/manifest.json` convention applies on the **agent’s own domain** when serving a live agent. It is **not required** on third-party static hosts (GitHub Pages often avoids dot-leading path segments).
+
+---
+
+## Browse and marketplace UI (spot-check)
+
+Read-only audit of `apps/web` (2026-05-24). Seeded registry entries already use `online_check: false` (`apps/web/public/registry.json`); Browse lists them without error.
+
+| Surface | `online_check: false` behavior |
+|---------|------------------------------|
+| **Browse** (`/browse`, `browse-content.tsx`) | Agent appears in the grid like any other listing. Only **revoked** URNs are removed (`browse/page.tsx`). Filters (search, category, tags, skills, SLA, auth) do **not** read `online_check`. **No** reachability probe on load. **No** Online/Offline/Demo badge on cards (`agent-card.tsx`). |
+| **Agent detail** (`/agents/[id]`, `agent-detail-client.tsx`) | `AgentStatusBadge` uses `skipReachabilityCheck={agent.online_check === false}` → muted **Demo** badge. Does **not** ping `/api/proxy/check` and does **not** show **Offline** for an unreachable placeholder `endpoints.http`. |
+| **Dashboard** (`/dashboard`, `dashboard-client.tsx`) | Same **Demo** badge on cards when `online_check === false`. |
+| **Connect** | Endpoint URL is still shown; invoking the agent may fail until a live ASAP endpoint exists (expected for v1.0 static-only). |
+
+**Summary:** Browse does **not** hard-fail or hide static-only agents. There is no red **Offline** badge on Browse cards; reachability UX is on the detail/dashboard surfaces only, and `online_check: false` avoids labeling those agents offline.
+
+---
+
+## Recommended registration path (v1.0)
+
+| Path | Static manifest only | Notes |
+|------|----------------------|--------|
+| **IssueOps** ([Register Agent](https://github.com/adriannoes/asap-protocol/issues/new?template=register_agent.yml)) | **Recommended** | Maintainer validates JSON; no live endpoint required when `online_check: false` |
+| **Auto-registration** (`POST /registry/agents`) | **Not recommended** | Harness expects reachable manifest/agent surface |
+
+---
+
+## Authoring `registry.json` fields
+
+### `online_check: false`
+
+Set when the manifest is served from static hosting and there is **no** live ASAP JSON-RPC endpoint yet. Registry validators and the TypeScript/Python schemas accept `false`. Seeded demo agents in `registry.json` use the same pattern.
+
+### `endpoints.manifest` on `*.github.io`
+
+Use the HTTPS URL where the **signed** manifest JSON is published. ShellClaw v1.0 example:
+
+```json
+"endpoints": {
+  "http": "https://shellclaw.example.com/asap",
+  "manifest": "https://adriannoes.github.io/shellclaw/manifest.json"
+}
+```
+
+### Placeholder `endpoints.http`
+
+A placeholder ASAP URL is allowed for IssueOps while the tunnel ships in a later release. Update `endpoints.http` and manifest `endpoints.asap` when the live endpoint is available; consider setting `online_check: true` (or omitting it) once you want Online/Offline checks in the UI.
+
+### Do not put `self-signed` in `tags`
+
+Submitters must not add the trust label to `tags`. Auto-registration and IssueOps processing add it via `asap.registry.anti_spam` (`TRUST_LEVEL_SELF_SIGNED`).
+
+### `verification`
+
+Use `null` (or omit) for new self-signed listings. Verified badge promotion is a separate [verification request](registry-verification-review.md) flow.
+
+---
+
+## Example entry (ShellClaw v1.0)
+
+```json
+{
+  "id": "urn:asap:agent:shellclaw",
+  "name": "ShellClaw",
+  "description": "The first C-native edge-AI-capable ASAP agent. Runs Phi-3-mini locally on NVIDIA Jetson Orin Nano Super via CUDA, exposes GPIO and I2C primitives on the 40-pin header as LLM-callable tools, and participates in the ASAP ecosystem with Ed25519-signed manifests.",
+  "endpoints": {
+    "http": "https://shellclaw.example.com/asap",
+    "manifest": "https://adriannoes.github.io/shellclaw/manifest.json"
+  },
+  "skills": ["assistant", "edge_briefing", "server_admin", "gpio_control"],
+  "category": "Infrastructure",
+  "tags": ["cuda", "edge-ai", "hardware", "jetson", "local-inference"],
+  "asap_version": "2.1.0",
+  "repository_url": "https://github.com/adriannoes/shellclaw",
+  "documentation_url": "https://github.com/adriannoes/shellclaw#readme",
+  "built_with": "Other",
+  "verification": null,
+  "online_check": false
+}
+```
+
+---
+
+## Validate locally
+
+**Single entry (Pydantic):**
+
+```bash
+PYTHONPATH=src uv run python -c "
+import json
+from pathlib import Path
+from asap.discovery.registry import RegistryEntry
+p = Path('tests/fixtures/registry/shellclaw-v1.0-entry.json')
+RegistryEntry.model_validate(json.loads(p.read_text()))
+print('OK')
+"
+```
+
+Validates that the fixture matches `RegistryEntry`.
+
+**IssueOps dry-run** (`validate_registry.py` agents-array format):
+
+```bash
+uv run python scripts/validate_registry.py tests/fixtures/registry/shellclaw-v1.0-agents-array.json
+```
+
+Same validation path as CI uses for `registry.json` agent objects.
+
+**Full registry file** (when embedded in `registry.json`):
+
+```bash
+uv run python scripts/validate_registry.py path/to/registry.json
+```
+
+**Tests:**
+
+```bash
+PYTHONPATH=src uv run pytest tests/discovery/test_registry.py -k shellclaw -v
+```
+
+Runs the ShellClaw fixture regression test.
+
+---
+
+## ShellClaw handoff (Wave 6.2 IssueOps)
+
+Copy into the shellclaw planning issue or PR when starting marketplace registration:
+
+```text
+ASAP upstream §5 answered (v2.4 S0): https://github.com/adriannoes/asap-protocol/blob/main/docs/guides/shellclaw-registry.md
+
+- §5.1 Registry entry §4: YES (use IssueOps; online_check: false; do not tag self-signed)
+- §5.2 built_with: ShellClaw added to issue template; Other still valid
+- §5.3 trust_level "self-signed": unchanged
+- §5.4 static manifest + no live endpoint v1.0: accepted
+- §5.5 manifest on *.github.io without .well-known: accepted
+
+Open Register Agent issue with literal JSON from guide / tests/fixtures/registry/shellclaw-v1.0-entry.json
+```
+
+---
+
+## Related
+
+- [Identity signing](identity-signing.md) — Ed25519 manifests and `trust_level`
+- [Compliance testing](compliance-testing.md) — Harness expectations when a live endpoint exists
+- [Raw Fetch](../raw-fetch.md) — consume `registry.json` without Python

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,6 +104,7 @@ See [CLI reference](cli.md) (all commands, exit codes, `compliance-check`, `audi
 - [Raw Fetch (non-Python)](raw-fetch.md) — Fetch registry.json and revoked_agents.json directly (curl, fetch); implement your own client in any language
 - [v1.1 Security Model](security/v1.1-security-model.md) — OAuth2 trust limitations, Custom Claims, allowlist (see also [decision record § security](https://github.com/adriannoes/asap-protocol/blob/main/product/decision-records/03-security.md))
 - [Registry verification review (admin)](guides/registry-verification-review.md) — How to vet and approve Verified badge requests for the Lite Registry
+- [ShellClaw static manifest registration](guides/shellclaw-registry.md) — `online_check: false`, GitHub Pages manifest URLs, IssueOps vs auto-registration
 - [Lite Registry auto-registration](registry/auto-registration.md) — Bot PR flow, OAuth2, payloads, rejections, and upgrading to Verified
 
 ### v1.1 features (API reference & guides)

--- a/engineering/tasks/v2.4.0/sprint-S0-shellclaw-marketplace-onboarding.md
+++ b/engineering/tasks/v2.4.0/sprint-S0-shellclaw-marketplace-onboarding.md
@@ -1,0 +1,140 @@
+# Sprint S0: ShellClaw Marketplace Onboarding
+
+> **Goal:** Answer ShellClaw §5 concrete asks; document static-manifest registration; optional `built_with` enum UX.
+> **Parent Roadmap:** [tasks-v2.4.0-roadmap.md](./tasks-v2.4.0-roadmap.md)
+> **Context (literals):** [asap-protocol-questions-for-upstream.md](../../../product/prd/private/asap-protocol-questions-for-upstream.md) §3–§6
+> **Not a blocker:** ShellClaw v1.0 Wave 6 ships with `tags` workaround per Q-ASAP.
+
+---
+
+## Relevant Files
+
+- `tests/fixtures/registry/shellclaw-v1.0-entry.json` — literal ShellClaw §4 registry entry for validation tests
+- `tests/fixtures/registry/shellclaw-v1.0-agents-array.json` — dry-run for `scripts/validate_registry.py`
+- `product/prd/private/asap-protocol-questions-for-upstream.md` — status Answered + link to guide (ShellClaw notification)
+- `src/asap/discovery/registry.py` — `RegistryEntry`, `online_check`
+- `scripts/validate_registry.py` — Lite registry validation
+- `scripts/process_registration.py` — IssueOps → `registry.json`
+- `src/asap/registry/auto_registration.py` — `POST /registry/agents`
+- `src/asap/registry/anti_spam.py` — auto `self-signed` tag
+- `src/asap/crypto/trust_levels.py` — `TrustLevel.SELF_SIGNED` = `"self-signed"`
+- `.github/ISSUE_TEMPLATE/register_agent.yml` — `built_with`, `category`
+- `tests/discovery/test_registry.py` — `test_shellclaw_v1_fixture_validates`, `online_check: false` fixture
+- `docs/guides/shellclaw-registry.md` — static manifest + §5 answers for ShellClaw Wave 6
+- `docs/index.md` — link to shellclaw-registry guide
+- `CHANGELOG.md` — Unreleased ShellClaw marketplace blurb (§6)
+- `.github/ISSUE_TEMPLATE/register_agent.yml` — `ShellClaw` in `built_with` dropdown
+- `apps/web/src/app/docs/register/page.tsx` — `built_with` options + static manifest note
+- `apps/web/src/app/dashboard/register/register-form.tsx` — `ShellClaw` in `BUILT_WITH_OPTIONS`
+- `apps/web/src/app/browse/browse-content.tsx` — audited: no `online_check` / reachability on cards (doc § Browse UI)
+
+---
+
+## Locked answers for ShellClaw (publish in docs when S0 ships)
+
+### §5.1 Registry entry validity — **YES, with notes**
+
+The literal entry in the context doc §4 **should pass** `RegistryEntry.model_validate` and `validate_registry.py`:
+
+| Field | Status |
+|-------|--------|
+| `id` | `urn:asap:agent:shellclaw` — valid URN |
+| `category` | `Infrastructure` — canonical enum |
+| `tags` | Valid; `self-signed` **must not** be submitted manually — `anti_spam.py` adds it |
+| `built_with` | `Other` — valid today |
+| `verification` | `null` — valid (`VerificationStatus \| None`) |
+| `online_check` | `false` — supported ([`test_registry_entry_accepts_online_check_false`](../../../tests/discovery/test_registry.py)) |
+| `endpoints.http` + `endpoints.manifest` | Valid map keys per ADR-15 |
+
+**Action for ShellClaw:** Replace `https://shellclaw.example.com/asap` placeholder before public listing if UI shows “offline”; acceptable for IssueOps with `online_check: false`.
+
+**Auto-registration:** If `POST /registry/agents` is used, compliance harness may fail on **live** reachability — ShellClaw v1.0 should prefer **IssueOps** until v1.0.1 tunnel (per ShellClaw Q-URL).
+
+### §5.2 `built_with` enum — **Optional task below** (cosmetic)
+
+`Other` is sufficient for v1.0. Adding `ShellClaw` improves Browse/filter discoverability.
+
+### §5.3 Trust label — **YES, unchanged**
+
+`trust_level: "self-signed"` (hyphen) remains the correct `TrustLevel` value. Signed manifest `signature.trust_level` matches `SignatureBlock` schema.
+
+### §5.4 Static manifest hosting — **YES**
+
+`online_check: false` skips reachability pings. Browse lists agents normally (no Offline badge on cards); detail/dashboard show **Demo** — **not a rejection**. Wave 6 marketplace registration does **not** require a live `POST /asap` endpoint in v1.0.
+
+### §5.5 Manifest URL path — **YES**
+
+Static hosting at `https://adriannoes.github.io/shellclaw/manifest.json` (no `.well-known` on GitHub Pages) is acceptable for `endpoints.manifest` in `registry.json`. The `.well-known/asap/` convention applies on the **agent's own domain** when live; not required on third-party static hosts.
+
+---
+
+## Trigger / Enables / Depends on
+
+**Trigger:** ShellClaw Phase 5 Wave 6 (marketplace registration) approaching.
+
+**Enables:** Confident IssueOps PR; no upstream schema work required for v1.0 listing.
+
+**Depends on:** Existing v2.3 Lite Registry + Issue template (E4 shipped).
+
+---
+
+## Acceptance Criteria
+
+- [x] Context doc §4 registry JSON validates: `uv run python scripts/validate_registry.py` (fixture or dry-run entry)
+- [x] Maintainer guide documents static manifest + `online_check: false` + manifest URL conventions
+- [x] Issue template optionally lists `ShellClaw` under `built_with`
+- [x] ShellClaw notified (issue comment or doc link) with §5.1–§5.5 answers
+
+---
+
+## Task 0.1: Validate ShellClaw registry fixture
+
+- [x] **0.1.1** Add `tests/fixtures/registry/shellclaw-v1.0-entry.json`
+  - **What:** Copy literal JSON from context doc §4 (update manifest URL if final path differs).
+  - **Verify:** `RegistryEntry.model_validate(json.load(...))` passes in `tests/discovery/test_registry.py`.
+
+- [x] **0.1.2** Add test `test_shellclaw_v1_fixture_validates`
+  - **File:** `tests/discovery/test_registry.py`
+  - **Verify:** `pytest tests/discovery/test_registry.py -k shellclaw` green.
+
+---
+
+## Task 0.2: Document static-manifest registration
+
+- [x] **0.2.1** Create `docs/guides/shellclaw-registry.md` (or section in `docs/guides/registry-verification-review.md`)
+  - **What:** Document:
+    - `online_check: false` for GitHub Pages–only manifests
+    - Acceptable `endpoints.manifest` on `*.github.io` without `.well-known`
+    - Placeholder `endpoints.http` until live tunnel
+    - Do not put `self-signed` in `tags` (auto-added)
+    - IssueOps vs auto-registration for static-only agents
+  - **Verify:** Doc review; link from `docs/index.md`.
+
+- [x] **0.2.2** Add ShellClaw changelog blurb (context doc §6) to `CHANGELOG.md` under Unreleased when listing merges
+
+---
+
+## Task 0.3: Optional — `built_with: ShellClaw`
+
+- [x] **0.3.1** Add `ShellClaw` to register_agent.yml dropdown
+  - **File:** `.github/ISSUE_TEMPLATE/register_agent.yml`
+  - **What:** Insert after `OpenClaw` or before `Other`. Mirror in `process_registration.py` if enum validation exists (free string today — verify).
+  - **Verify:** Manual: template shows new option.
+
+- [x] **0.3.2** Document in register docs page (`apps/web/src/app/docs/register/`) if framework list is duplicated in UI copy
+
+---
+
+## Task 0.4: Browse UX spot-check (static agents)
+
+- [x] **0.4.1** Manual: seed agent with `online_check: false` — confirm Browse does not hard-fail; note any “offline” badge behavior in doc §5.4
+  - **File:** `apps/web/src/app/browse/browse-content.tsx` (read-only audit)
+  - **Verify:** Record behavior in `docs/guides/shellclaw-registry.md`.
+
+---
+
+## Definition of Done
+
+- [x] ShellClaw §5 answers published in-repo (this sprint + [guide](../../../docs/guides/shellclaw-registry.md) + context doc status)
+- [x] Fixture test green (`pytest -k shellclaw`; `validate_registry.py` on `shellclaw-v1.0-agents-array.json`)
+- [x] ShellClaw Wave 6.2 unblocked for IssueOps path (handoff block in guide; no schema changes; `built_with` + `online_check: false` documented)

--- a/engineering/tasks/v2.4.0/sprint-S1-edge-ai-capabilities.md
+++ b/engineering/tasks/v2.4.0/sprint-S1-edge-ai-capabilities.md
@@ -1,0 +1,257 @@
+# Sprint S1: Edge-AI & Hardware Capability Advertising (v2.4)
+
+> **Goal:** Optional `manifest.capabilities.hardware` + `inference`; mirror to `RegistryEntry`; marketplace filters; `find_by_*` discovery helpers.
+> **Parent Roadmap:** [tasks-v2.4.0-roadmap.md](./tasks-v2.4.0-roadmap.md)
+> **Proposal:** [asap-protocol-edge-ai-capabilities.md](../../../product/prd/private/asap-protocol-edge-ai-capabilities.md)
+> **Consumer literals:** [asap-protocol-questions-for-upstream.md](../../../product/prd/private/asap-protocol-questions-for-upstream.md) §3, §4, §7.12
+> **Prerequisite:** S0 optional (parallel OK); design lock in roadmap T0 table
+> **Branch suggestion:** `feat/edge-ai-capabilities`
+
+---
+
+## Relevant Files
+
+### Schema & models
+- `schemas/entities/manifest.schema.json` — `Capability` closed object
+- `src/asap/models/entities.py` — `Capability`, new `HardwareCapability`, `InferenceCapability`, `LocalModelInfo`
+- `src/asap/models/validators.py` — if enum validation helpers needed
+
+### Registry & registration
+- `src/asap/discovery/registry.py` — `RegistryEntry`, `find_by_*`, `generate_registry_entry`
+- `src/asap/registry/auto_registration.py` — derive fields from fetched manifest
+- `scripts/process_registration.py` — optional: derive on IssueOps if manifest URL fetch enabled
+- `scripts/validate_registry.py`
+- `registry.json` — example entries
+
+### Web
+- `apps/web/src/lib/registry-schema.ts`
+- `apps/web/src/types/registry.d.ts`
+- `apps/web/src/app/browse/browse-content.tsx`
+- `apps/web/src/app/docs/register/page.tsx`
+
+### Tests
+- `tests/discovery/test_registry.py`
+- `tests/models/test_entities.py` (or equivalent)
+- `tests/fixtures/registry/shellclaw-v1.0-entry.json` (extend post-S1)
+- `tests/fixtures/manifests/shellclaw-jetson-v1.0.json`, `shellclaw-rpi-v1.1.json`
+
+### TypeScript SDK (if in scope for v2.4)
+- `packages/typescript/client/src/discovery.ts`
+
+---
+
+## Canonical ShellClaw values (for tests & docs)
+
+### Jetson v1.0 — `capabilities` extensions (when S1 merged)
+
+```json
+"hardware": {
+  "class": "edge_accelerator",
+  "model": "jetson_orin_nano_super_8gb",
+  "io": ["gpio", "i2c"]
+},
+"inference": {
+  "modes": ["cloud", "local_cuda"],
+  "local_models": [
+    {
+      "id": "Phi-3-mini-4k-instruct-Q4_K_M",
+      "quantization": "Q4_K_M"
+    }
+  ]
+}
+```
+
+- **Skills v1.0 (manifest + registry):** `assistant`, `edge_briefing`, `server_admin`, `gpio_control` — **not** `sensor_read` / `camera_capture` until ShellClaw v1.2.
+- **`asap_version`:** `2.1.0` (agent honest claim; separate from PyPI `2.4.0` spec package).
+- **Throughput:** omit until ShellClaw Wave 8 benchmarks; then optional self-reported field.
+
+### RPi v1.1 — docs-only example (§7.12 context doc)
+
+- `hardware.class`: `sbc`
+- `hardware.model`: `raspberry_pi_zero_2w`
+- `hardware.io`: `["gpio", "i2c"]`
+- `inference.modes`: `["cloud", "local_cpu"]`
+- `local_models[0].id`: `tinyllama-1.1b-chat-Q4_K_M` (no throughput required)
+
+### Registry mirror (derived at registration)
+
+| Manifest source | `RegistryEntry` field |
+|-----------------|----------------------|
+| `capabilities.hardware.class` | `hardware_class` |
+| `capabilities.inference.modes` | `inference_modes` |
+| `capabilities.hardware.io` | `hardware_io` (optional v2.4 — multi-select filter) |
+
+Do **not** require registrants to duplicate these in IssueOps body when manifest URL is provided.
+
+---
+
+## Trigger / Enables / Depends on
+
+**Trigger:** Edge / hardware agents cannot be discovered beyond free-form `tags`.
+
+**Enables:** ShellClaw v1.0.1+ structured listing; orchestrators filter by CUDA / GPIO; future agent mesh routing.
+
+**Depends on:** Existing `Capability` model; E4 category/tags (shipped v2.1).
+
+---
+
+## Acceptance Criteria
+
+- [ ] `manifest.schema.json` validates optional `hardware` + `inference`; existing manifests unchanged
+- [ ] Pydantic `Capability` round-trips ShellClaw Jetson + RPi fixtures
+- [ ] `RegistryEntry` accepts optional `hardware_class`, `inference_modes`, `hardware_io`
+- [ ] `process_registration` / `auto_registration` populate derived fields from signed manifest when present
+- [ ] Browse filters: hardware class, inference mode, I/O (multi-select)
+- [ ] `find_by_hardware_class`, `find_by_inference_mode`, `find_by_io` implemented with tests
+- [ ] Docs + register page mention new optional manifest fields
+- [ ] Example in `registry.json` or `docs/examples/` (Jetson structured entry)
+
+---
+
+## Task 1.0: JSON Schema — `hardware` + `inference`
+
+- [ ] **1.0.1** Extend `Capability` in `schemas/entities/manifest.schema.json`
+  - **What:** Add optional `hardware` and `inference` objects per proposal §7.3–7.4 (`additionalProperties: false`, closed enums).
+  - **Why:** Source of truth for compliance + non-Python agents.
+  - **Verify:** `asap-compliance` or schema test loads existing manifest fixtures without mutation.
+
+- [ ] **1.0.2** Add JSON Schema examples under `schemas/examples/` (optional)
+  - **What:** `shellclaw-jetson-capabilities.json` snippet.
+  - **Verify:** AJV / `jsonschema` validation in CI if present.
+
+---
+
+## Task 1.1: Pydantic models
+
+- [ ] **1.1.1** Add submodels in `src/asap/models/entities.py`
+  - **What:**
+    - `HardwareCapability` — `class`, `model`, `io` (all optional per ShellClaw hard-rejects on *required*)
+    - `InferenceCapability` — `modes`, `local_models`
+    - `LocalModelInfo` — `id`, `quantization`, `throughput_tokens_per_second` (optional `float`)
+  - **Pattern:** `ConfigDict(extra="forbid")` on nested models.
+  - **Verify:** `Capability.model_validate` with ShellClaw Jetson fixture; without new fields still passes.
+
+- [ ] **1.1.2** Wire into `Capability` model
+  - **What:** `hardware: HardwareCapability | None = None`, `inference: InferenceCapability | None = None`.
+  - **Verify:** `tests/models/` — backward compat + new fields.
+
+---
+
+## Task 1.2: RegistryEntry mirror + derivation
+
+- [ ] **1.2.1** Extend `RegistryEntry` in `src/asap/discovery/registry.py`
+  - **What:**
+    ```python
+    hardware_class: str | None = None
+    inference_modes: list[str] = Field(default_factory=list)
+    hardware_io: list[str] = Field(default_factory=list)
+    ```
+  - **Verify:** `RegistryEntry.model_validate` with derived fields only.
+
+- [ ] **1.2.2** Add `derive_registry_hardware_fields(manifest: Manifest) -> dict[str, Any]`
+  - **What:** Extract from `manifest.capabilities.hardware` / `.inference`; return kwargs for `RegistryEntry`.
+  - **Verify:** Unit test Jetson manifest → `edge_accelerator`, `["cloud","local_cuda"]`, `["gpio","i2c"]`.
+
+- [ ] **1.2.3** Integrate into `src/asap/registry/auto_registration.py`
+  - **What:** After manifest fetch/validate, merge derived fields into entry before bot PR.
+  - **Verify:** Integration test or unit mock — entry JSON includes derived fields.
+
+- [ ] **1.2.4** Integrate into `scripts/process_registration.py` (if manifest URL fetched)
+  - **What:** When registration flow loads manifest, call derivation helper.
+  - **Verify:** `tests/scripts/test_process_registration.py` — extended fixture.
+
+---
+
+## Task 1.3: Discovery helpers
+
+- [ ] **1.3.1** Implement filters in `src/asap/discovery/registry.py`
+  - **What:**
+    - `find_by_hardware_class(registry, cls: str) -> list[RegistryEntry]`
+    - `find_by_inference_mode(registry, mode: str) -> list[RegistryEntry]`
+    - `find_by_io(registry, io_type: str) -> list[RegistryEntry]`
+  - **Pattern:** Mirror `find_by_skill()`.
+  - **Verify:** `tests/discovery/test_registry.py` — multi-agent fixture.
+
+- [ ] **1.3.2** Export from `src/asap/discovery/__init__.py` if public API
+
+---
+
+## Task 1.4: Web marketplace filters
+
+- [ ] **1.4.1** Zod + types
+  - **Files:** `apps/web/src/lib/registry-schema.ts`, `apps/web/src/types/registry.d.ts`
+  - **What:** Optional `hardware_class`, `inference_modes`, `hardware_io`.
+  - **Verify:** `npm run build` in `apps/web`.
+
+- [ ] **1.4.2** Browse sidebar filters
+  - **File:** `apps/web/src/app/browse/browse-content.tsx`
+  - **What:** Dropdown hardware class; inference mode (any / cloud-only / local_cuda / …); I/O badge multi-select.
+  - **Pattern:** Existing category/tags filters (E4).
+  - **Verify:** Manual with seed + ShellClaw fixture entry.
+
+- [ ] **1.4.3** Agent detail — display structured capabilities when present
+  - **File:** `apps/web/src/app/agents/[id]/` (component TBD)
+  - **Verify:** Jetson example shows hardware + inference blocks.
+
+---
+
+## Task 1.5: Docs & registration UX
+
+- [ ] **1.5.1** Update `apps/web/src/app/docs/register/page.tsx`
+  - **What:** Document optional `hardware` / `inference` in manifest; link to schema; note `tags` remain valid supplement.
+
+- [ ] **1.5.2** Update transport/discovery docs (`docs/` — path TBD)
+  - **What:** Closed enums table; migration from `tags: ["cuda","jetson",...]` to structured fields.
+
+- [ ] **1.5.3** Issue template (optional)
+  - **File:** `.github/ISSUE_TEMPLATE/register_agent.yml`
+  - **What:** Note that hardware/inference are inferred from manifest URL when auto-registration is used; no manual duplicate fields.
+
+---
+
+## Task 1.6: Examples & fixtures
+
+- [ ] **1.6.1** Extend `tests/fixtures/registry/shellclaw-v1.0-entry.json` (post-S1 structured)
+  - **What:** Add `hardware_class`, `inference_modes`, `hardware_io` derived values; keep `tags` for backward-compat demo.
+
+- [ ] **1.6.2** Add manifest fixtures
+  - **Files:** `tests/fixtures/manifests/shellclaw-jetson-v1.0.json`, `shellclaw-rpi-v1.1.json`
+  - **Source:** Context doc §3 + §7.12.
+
+- [ ] **1.6.3** Optional: add commented example block to `registry.json` or `docs/examples/registry-shellclaw.md`
+  - **What:** Do not add ShellClaw to live registry until ShellClaw opens registration PR.
+
+---
+
+## Task 1.7: TypeScript client (optional same release)
+
+- [ ] **1.7.1** Extend `packages/typescript/client/src/discovery.ts` types + parsers
+  - **Verify:** `npm test` in package.
+
+---
+
+## Task 1.8: Release
+
+- [ ] **1.8.1** Version bump `pyproject.toml` → `2.4.0`
+- [ ] **1.8.2** CHANGELOG — feat(discovery): hardware and inference capability advertising
+- [ ] **1.8.3** Notify ShellClaw — structured fields available; Wave 6.2 branch B per Q-ASAP
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Enum churn before community Discussion | Ship closed enums per T0; CONTRIBUTING note for extensions |
+| Self-reported throughput misleading | Optional field; UI label "self-reported" |
+| Non-Python agents (ShellClaw C) lag schema | Schema-first; ShellClaw Task 5.1 manifest refactor precedes structured fields |
+| `process_registration` does not fetch manifest | Derivation only guaranteed in auto-registration until 1.2.4 done |
+
+---
+
+## Definition of Done
+
+- [ ] All acceptance criteria checked
+- [ ] Pre-push CI green (ruff, mypy, pytest, web build)
+- [ ] Discussion or issue linked in CHANGELOG (community feedback tracked)
+- [ ] ShellClaw informed for optional migration off `tags`

--- a/engineering/tasks/v2.4.0/tasks-v2.4.0-roadmap.md
+++ b/engineering/tasks/v2.4.0/tasks-v2.4.0-roadmap.md
@@ -1,0 +1,76 @@
+# v2.4.0 Roadmap — Edge-AI Discovery & ShellClaw Onboarding
+
+> **Context:** [asap-protocol-questions-for-upstream.md](../../../product/prd/private/asap-protocol-questions-for-upstream.md) (ShellClaw v1.0 literals + v2.4 proposal).
+> **Related proposal:** [asap-protocol-edge-ai-capabilities.md](../../../product/prd/private/asap-protocol-edge-ai-capabilities.md)
+> **PyPI target:** Minor bump after v2.3.x — additive, backward-compatible.
+
+---
+
+## Goals
+
+1. **Unblock ShellClaw v1.0 marketplace listing** with documented answers for static manifest hosting, `online_check: false`, and registry validation (no schema change required).
+2. **Ship structured edge-AI discovery** via optional `manifest.capabilities.hardware` + `inference`, mirrored to `RegistryEntry`, Browse filters, and `find_by_*` helpers.
+
+---
+
+## Design lock (T0 — recorded 2026-05-24 from ShellClaw upstream session)
+
+| Question | Decision |
+|----------|----------|
+| `hardware.class` / `inference.modes` enums | **Closed** vocabulary; extend via PR |
+| `throughput_tokens_per_second` | **Optional**, self-reported in v2.4; compliance validation deferred |
+| `hardware.io` | **Physical interfaces only** in v2.4 |
+| Link to `auth/capabilities.py` runtime grants | **None** — advertising vs authz stay separate |
+| Hard rejects | Do not require `io` or throughput; do not rename `edge_accelerator`; no CUDA version sub-enums |
+
+---
+
+## Sprints
+
+| Sprint | File | Goal | Blocks ShellClaw v1.0? |
+|--------|------|------|------------------------|
+| **S0** | [sprint-S0-shellclaw-marketplace-onboarding.md](./sprint-S0-shellclaw-marketplace-onboarding.md) | Confirm §5 asks; optional `built_with`; docs for static manifest URL | **No** — ShellClaw ships with `tags` workaround |
+| **S1** | [sprint-S1-edge-ai-capabilities.md](./sprint-S1-edge-ai-capabilities.md) | Schema + registry mirror + UI filters + SDK helpers | **No** — Wave 6.2 switches to structured fields only if merged before registration PR |
+
+---
+
+## Dependency graph
+
+```
+S0 (onboarding docs + small DX)
+ │
+ ├──────────────────────────────┐
+ ▼                              ▼
+ShellClaw Wave 6 (tags)    S1 (edge-ai capabilities)
+                                    │
+                                    ▼
+                            ShellClaw optional migration
+                            (structured hardware/inference)
+```
+
+---
+
+## ShellClaw coordination
+
+Notify `adriannoes/shellclaw` when:
+
+- **S0 complete** — §5 answers published in `docs/guides/shellclaw-registry.md` (or release notes); Wave 6.2 can open IssueOps PR.
+- **S1 merged** — Wave 6.2 may use structured fields instead of `tags` (see literals in S1 Task 1.7).
+
+---
+
+## Out of scope (v2.4.0)
+
+- Registry API backend ([#142](https://github.com/adriannoes/asap-protocol/issues/142) / DEFERRED T3)
+- Runtime `Capability` authz changes (`src/asap/auth/capabilities.py`)
+- Envelope / OAuth2 / capability-escalation changes
+- Compliance harness validating `throughput_tokens_per_second`
+
+---
+
+## Definition of Done (release)
+
+- [ ] S0 acceptance checklist green; ShellClaw registry entry in §4 of context doc validates via `validate_registry.py`
+- [ ] S1 acceptance checklist green; example Jetson + RPi entries in docs
+- [ ] `pyproject.toml` minor version bump; CHANGELOG entry
+- [ ] Pre-push CI suite per `.cursor/rules/git-commits.mdc`

--- a/tests/discovery/test_registry.py
+++ b/tests/discovery/test_registry.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -20,6 +22,9 @@ from asap.discovery.registry import (
 )
 from asap.models.entities import Capability, Endpoint, Manifest, Skill
 
+SHELLCLAW_V1_REGISTRY_FIXTURE = (
+    Path(__file__).resolve().parent.parent / "fixtures" / "registry" / "shellclaw-v1.0-entry.json"
+)
 
 VALID_REGISTRY_JSON = """{
   "version": "1.0",
@@ -115,6 +120,20 @@ class TestRegistrySchemaValidation:
         }
         entry = RegistryEntry.model_validate(data)
         assert entry.online_check is False
+
+    def test_shellclaw_v1_fixture_validates(self) -> None:
+        """ShellClaw v1.0 IssueOps registry entry (context doc §4) passes RegistryEntry."""
+        data = json.loads(SHELLCLAW_V1_REGISTRY_FIXTURE.read_text(encoding="utf-8"))
+        entry = RegistryEntry.model_validate(data)
+        assert entry.id == "urn:asap:agent:shellclaw"
+        assert entry.category == "Infrastructure"
+        assert entry.built_with == "Other"
+        assert entry.online_check is False
+        assert entry.verification is None
+        assert entry.endpoints["manifest"] == (
+            "https://adriannoes.github.io/shellclaw/manifest.json"
+        )
+        assert "self-signed" not in entry.tags
 
     def test_registry_entry_with_category_tags(self) -> None:
         """RegistryEntry parses category and tags from dict (Sprint E4)."""

--- a/tests/fixtures/registry/shellclaw-v1.0-agents-array.json
+++ b/tests/fixtures/registry/shellclaw-v1.0-agents-array.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "urn:asap:agent:shellclaw",
+    "name": "ShellClaw",
+    "description": "The first C-native edge-AI-capable ASAP agent. Runs Phi-3-mini locally on NVIDIA Jetson Orin Nano Super via CUDA, exposes GPIO and I2C primitives on the 40-pin header as LLM-callable tools, and participates in the ASAP ecosystem with Ed25519-signed manifests.",
+    "endpoints": {
+      "http": "https://shellclaw.example.com/asap",
+      "manifest": "https://adriannoes.github.io/shellclaw/manifest.json"
+    },
+    "skills": ["assistant", "edge_briefing", "server_admin", "gpio_control"],
+    "category": "Infrastructure",
+    "tags": ["cuda", "edge-ai", "hardware", "jetson", "local-inference"],
+    "asap_version": "2.1.0",
+    "repository_url": "https://github.com/adriannoes/shellclaw",
+    "documentation_url": "https://github.com/adriannoes/shellclaw#readme",
+    "built_with": "Other",
+    "verification": null,
+    "online_check": false
+  }
+]

--- a/tests/fixtures/registry/shellclaw-v1.0-entry.json
+++ b/tests/fixtures/registry/shellclaw-v1.0-entry.json
@@ -1,0 +1,18 @@
+{
+  "id": "urn:asap:agent:shellclaw",
+  "name": "ShellClaw",
+  "description": "The first C-native edge-AI-capable ASAP agent. Runs Phi-3-mini locally on NVIDIA Jetson Orin Nano Super via CUDA, exposes GPIO and I2C primitives on the 40-pin header as LLM-callable tools, and participates in the ASAP ecosystem with Ed25519-signed manifests.",
+  "endpoints": {
+    "http": "https://shellclaw.example.com/asap",
+    "manifest": "https://adriannoes.github.io/shellclaw/manifest.json"
+  },
+  "skills": ["assistant", "edge_briefing", "server_admin", "gpio_control"],
+  "category": "Infrastructure",
+  "tags": ["cuda", "edge-ai", "hardware", "jetson", "local-inference"],
+  "asap_version": "2.1.0",
+  "repository_url": "https://github.com/adriannoes/shellclaw",
+  "documentation_url": "https://github.com/adriannoes/shellclaw#readme",
+  "built_with": "Other",
+  "verification": null,
+  "online_check": false
+}


### PR DESCRIPTION
## Summary

- Publish upstream answers for ShellClaw §5 (static manifest, `online_check: false`, IssueOps path) in `docs/guides/shellclaw-registry.md`.
- Add registry fixtures and `test_shellclaw_v1_fixture_validates`; dry-run array for `scripts/validate_registry.py`.
- Add `ShellClaw` to `built_with` (GitHub issue template, web register form/docs) and Unreleased CHANGELOG blurb.
- Track completed sprint S0 in `engineering/tasks/v2.4.0/`.

## Test plan

- [x] `uv run ruff check .` && `uv run ruff format --check .`
- [x] `uv run mypy src/ scripts/ tests/`
- [x] `PYTHONPATH=src uv run pytest` (3411 passed)
- [x] `uv run python scripts/validate_registry.py tests/fixtures/registry/shellclaw-v1.0-agents-array.json`
- [x] `PYTHONPATH=src uv run pytest tests/discovery/test_registry.py -k shellclaw`
- [x] `apps/web`: eslint, `tsc --noEmit`, vitest register tests (19 passed)
- [x] `pip-audit` with CI ignore flags (see `.github/workflows/ci.yml`)

## Follow-up (out of scope S0)

- ShellClaw IssueOps PR to add entry to `registry.json` when Wave 6.2 opens.
- Paste handoff block from guide into shellclaw repo (private context doc updated locally only).