### PR TITLE
chore(release): v2.4.1 security hardening patch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 **ASAP Protocol** (Async Simple Agent Protocol) is a production-ready standard for agent-to-agent communication.
 - **Stack**: Python 3.13+, FastAPI, Pydantic v2.
 - **Transport**: JSON-RPC 2.0 over HTTP/WebSocket.
-- **Status**: v2.4.0 (released in tree; **PyPI** `asap-protocol` and **npm** `@asap-protocol/client` ship from maintainer tags + publish workflows).
+- **Status**: v2.4.1 (released in tree; **PyPI** `asap-protocol` and **npm** `@asap-protocol/client` ship from maintainer tags + publish workflows).
 - **Framework Integrations**: LangChain, CrewAI, PydanticAI, LlamaIndex, SmolAgents, Vercel AI SDK, MCP, OpenClaw, A2H.
 - **npm (TypeScript)**: The official client is **`@asap-protocol/client`** (scoped, **public** on npm for v2.4.x). Maintainer workflow: `.github/workflows/publish-typescript.yml`; context: `docs/maintainers/npm-publishing.md`.
 - **General contact** (humans coordinating on the protocol; not security): [info@asap-protocol.com](mailto:info@asap-protocol.com) — vulnerabilities: [SECURITY.md](SECURITY.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Follow-up (not in this release)
+
+- `extra="forbid"` on ingress payload models (`TaskRequestConfig`, `CommonMetadata`)
+- Opt-in protection for operator APIs (`/usage`, `/sla`, `/audit`)
+- Redis-backed `JtiReplayCache` and distributed Next.js rate limits
+- Bump optional `pydantic-ai` extra (CVE-2026-46678)
+
+---
+
+## [2.4.1] - 2026-06-14
+
+**Security hardening patch** — OAuth2 `iss`/`aud` validation, fail-closed identity
+binding, web app SSRF/redirect fixes, and dependency bumps. Wire protocol and
+manifest schemas are unchanged from v2.4.0.
+
 ### Security
 
 - **OAuth2 middleware**: Validate JWT `iss` and `aud` when `ASAP_AUTH_ISSUER` / `ASAP_AUTH_AUDIENCE` (or `OAuth2Config.expected_issuer` / `expected_audience`) are set; refactored validation through `validate_jwt()` in `asap.auth.jwks`.
@@ -18,12 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI security (`pip-audit`)**: Bumped transitive pins (`langchain-core`, `langsmith`, `python-multipart`, `urllib3`, `pip`, `smolagents`) and adjusted documented `--ignore-vuln` flags (pygments + **smolagents** CVEs with no PyPI fix yet; pip ≥26.1 clears prior pip ignore). See [SECURITY.md](SECURITY.md).
 - **FastAPI / Starlette**: Raised `fastapi` floor to `>=0.136.1` so `starlette>=1.0.1` resolves **PYSEC-2026-161** (Host header path injection) without a `pip-audit` ignore.
 
-### Follow-up (not in this release)
+### Migration
 
-- `extra="forbid"` on ingress payload models (`TaskRequestConfig`, `CommonMetadata`)
-- Opt-in protection for operator APIs (`/usage`, `/sla`, `/audit`)
-- Redis-backed `JtiReplayCache` and distributed Next.js rate limits
-- Bump optional `pydantic-ai` extra (CVE-2026-46678)
+- **v2.4.0 → v2.4.1**: Security patch — bump dependencies; verify OAuth2 issuer/audience and identity binding if already configured. See
+  [migration guide](docs/migration.md#upgrading-from-v240-to-v241).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > A production-ready protocol for agent-to-agent communication and task coordination.
 
-**Quick Info**: `v2.4.0` (PyPI) · **npm TS [`2.4.0`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.4.0)** | `Apache 2.0` | `Python 3.13+` | [Documentation](https://github.com/adriannoes/asap-protocol/blob/main/docs/index.md) | **[PyPI `asap-protocol`](https://pypi.org/project/asap-protocol/)** | **[npm `@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client)** | [Changelog](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md)
+**Quick Info**: `v2.4.1` (PyPI) · **npm TS [`2.4.1`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.4.1)** | `Apache 2.0` | `Python 3.13+` | [Documentation](https://github.com/adriannoes/asap-protocol/blob/main/docs/index.md) | **[PyPI `asap-protocol`](https://pypi.org/project/asap-protocol/)** | **[npm `@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client)** | [Changelog](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md)
 
 > 📦 Install the ASAP **Python SDK / protocol** from **`https://pypi.org/project/asap-protocol/`** — package name **`asap-protocol`** on [PyPI](https://pypi.org/project/asap-protocol/).
 
@@ -35,7 +35,7 @@ For simple point-to-point communication, a basic HTTP API might suffice; ASAP sh
 - **Identity & capabilities (v2.2, WebAuthn real in v2.2.1)** — Per-runtime Host/Agent JWTs, capability grants with constraints (`max`, `min`, `in`, `not_in`), approval flows (device authorization / CIBA-style), real WebAuthn attestation/assertion for high-risk registration (opt-in via `asap-protocol[webauthn]`).
 - **Streaming & wire protocol (v2.2)** — `POST /asap/stream` (SSE / `TaskStream`), JSON-RPC 2.0 batch on `POST /asap`, `ASAP-Version` negotiation, tamper-evident audit logging, Compliance Harness v2.
 - **Adoption Multiplier (v2.3.0)** — OpenAPI → ASAP via `create_from_openapi` (`[openapi]` extra), official **`@asap-protocol/client`** on npm (Vercel AI / OpenAI / Anthropic adapters), optional **Auto-Registration** (`POST /registry/agents`), **capability escalation**, and **ASAP `WWW-Authenticate`** discovery challenges. All opt-in; wire protocol unchanged. See [docs/index.md](docs/index.md) and [docs/migration.md](docs/migration.md).
-- **Edge-AI discovery (v2.4.0)** — Optional `manifest.capabilities.hardware` + `inference`, Lite Registry mirror, marketplace browse filters, and `@asap-protocol/client@2.4.0` discovery types. Wire protocol unchanged. See [Migration (v2.3.x → v2.4.0)](docs/migration.md#upgrading-from-v23x-to-v240) and [ShellClaw registry guide](docs/guides/shellclaw-registry.md).
+- **Edge-AI discovery (v2.4.0)** — Optional `manifest.capabilities.hardware` + `inference`, Lite Registry mirror, marketplace browse filters, and `@asap-protocol/client@2.4.1` discovery types. Wire protocol unchanged. See [Migration (v2.3.x → v2.4.0)](docs/migration.md#upgrading-from-v23x-to-v240) and [ShellClaw registry guide](docs/guides/shellclaw-registry.md).
 - **Framework adapters (v2.3.1+, npm)** — **`@asap-protocol/mastra`** and **`@asap-protocol/openai-agents`** expose ASAP capabilities as Mastra tools and OpenAI Agents SDK `tool()` definitions. See [Migration (v2.3.0 → v2.3.1)](docs/migration.md#upgrading-from-v230-to-v231).
 - **Economics** — Usage metering, delegation tokens, SLA framework with breach alerts.
 
@@ -56,16 +56,16 @@ Or with pip:
 pip install asap-protocol
 ```
 
-**npm** (TypeScript / JavaScript — [`@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client), **`2.4.0`**). The `latest` dist-tag matches **`npm view @asap-protocol/client version`**.
+**npm** (TypeScript / JavaScript — [`@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client), **`2.4.1`**). The `latest` dist-tag matches **`npm view @asap-protocol/client version`**.
 
-**npm** Mastra [**`@asap-protocol/mastra@2.4.0`**](https://www.npmjs.com/package/@asap-protocol/mastra) bridges ASAP capabilities onto **`@mastra/core`** tools; docs: [`docs/integrations/mastra.md`](docs/integrations/mastra.md), demo: [`apps/example-mastra/README.md`](apps/example-mastra/README.md).
+**npm** Mastra [**`@asap-protocol/mastra@2.4.1`**](https://www.npmjs.com/package/@asap-protocol/mastra) bridges ASAP capabilities onto **`@mastra/core`** tools; docs: [`docs/integrations/mastra.md`](docs/integrations/mastra.md), demo: [`apps/example-mastra/README.md`](apps/example-mastra/README.md).
 
-**npm** OpenAI Agents SDK [**`@asap-protocol/openai-agents@2.4.0`**](https://www.npmjs.com/package/@asap-protocol/openai-agents) exposes ASAP capabilities as **`@openai/agents`** `tool()` definitions — **not** the Chat Completions helper [`adapters/openai`](packages/typescript/client/src/adapters/openai.ts); docs: [`docs/integrations/openai-agents.md`](docs/integrations/openai-agents.md), demo: [`apps/example-openai-agents/README.md`](apps/example-openai-agents/README.md).
+**npm** OpenAI Agents SDK [**`@asap-protocol/openai-agents@2.4.1`**](https://www.npmjs.com/package/@asap-protocol/openai-agents) exposes ASAP capabilities as **`@openai/agents`** `tool()` definitions — **not** the Chat Completions helper [`adapters/openai`](packages/typescript/client/src/adapters/openai.ts); docs: [`docs/integrations/openai-agents.md`](docs/integrations/openai-agents.md), demo: [`apps/example-openai-agents/README.md`](apps/example-openai-agents/README.md).
 
 ```bash
-npm install @asap-protocol/client@2.4.0
-npm install @asap-protocol/mastra@2.4.0 @asap-protocol/client @mastra/core zod
-npm install @asap-protocol/openai-agents@2.4.0 @asap-protocol/client @openai/agents zod
+npm install @asap-protocol/client@2.4.1
+npm install @asap-protocol/mastra@2.4.1 @asap-protocol/client @mastra/core zod
+npm install @asap-protocol/openai-agents@2.4.1 @asap-protocol/client @openai/agents zod
 ```
 
 📦 **Canonical listing:** **[https://pypi.org/project/asap-protocol/](https://pypi.org/project/asap-protocol/)** — package **`asap-protocol`** (`pip install asap-protocol`). Prefer `uv` for reproducible environments when possible.

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -9,11 +9,11 @@ import { fetchRegistry } from '@/lib/registry';
 export const metadata: Metadata = {
   title: 'ASAP Protocol | The Marketplace for Autonomous Agents',
   description:
-    'Discover, verify, and integrate specialized AI agents using the open ASAP Protocol — v2.4.0 adds edge-AI hardware and inference discovery, marketplace filters, and ShellClaw registry onboarding.',
+    'Discover, verify, and integrate specialized AI agents using the open ASAP Protocol — v2.4.1 security hardening; edge-AI hardware and inference discovery, marketplace filters, and ShellClaw registry onboarding.',
   openGraph: {
     title: 'ASAP Protocol | The Marketplace for Autonomous Agents',
     description:
-      'Discover, verify, and integrate specialized AI agents using the open ASAP Protocol — v2.4.0 adds edge-AI hardware and inference discovery, marketplace filters, and ShellClaw registry onboarding.',
+      'Discover, verify, and integrate specialized AI agents using the open ASAP Protocol — v2.4.1 security hardening; edge-AI hardware and inference discovery, marketplace filters, and ShellClaw registry onboarding.',
     type: 'website',
   },
 };

--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -18,15 +18,15 @@ export function HeroSection() {
           >
             <div className="space-y-4">
               <Link
-                href="https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md#240---2026-05-24"
+                href="https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md#241---2026-06-14"
                 target="_blank"
                 rel="noopener noreferrer"
                 data-cta={HOMEPAGE_HERO_CTA_IDS.releaseBadge}
-                aria-label="View ASAP Protocol v2.4.0 changelog on GitHub"
+                aria-label="View ASAP Protocol v2.4.1 changelog on GitHub"
               >
                 <div className="inline-flex items-center rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-sm font-medium text-indigo-300 backdrop-blur-sm transition-colors hover:border-indigo-500/60 hover:bg-indigo-500/15">
                   <span className="mr-2 flex h-2 w-2 animate-pulse rounded-full bg-indigo-500"></span>
-                  v2.4.0 — Edge-AI Discovery
+                  v2.4.1 — Security Hardening
                 </div>
               </Link>
               <AnimatedText

--- a/apps/web/src/components/landing/WhatsNewRibbon.tsx
+++ b/apps/web/src/components/landing/WhatsNewRibbon.tsx
@@ -23,7 +23,7 @@ type Pill = {
 };
 
 const CHANGELOG_URL =
-  'https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md#240---2026-05-24';
+  'https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md#241---2026-06-14';
 const DOCS_EDGE_AI =
   'https://github.com/adriannoes/asap-protocol/blob/main/docs/transport.md#hardware-and-inference-capabilities-v24';
 const DOCS_SHELLCLAW =
@@ -110,7 +110,7 @@ const PILLS: Pill[] = [
 export function WhatsNewRibbon() {
   return (
     <aside
-      aria-label="What's new in ASAP Protocol v2.4.0"
+      aria-label="What's new in ASAP Protocol v2.4.1"
       className="w-full border-y border-zinc-900 bg-zinc-950"
     >
       <div className="container mx-auto flex max-w-5xl flex-col gap-4 px-4 py-8 md:flex-row md:items-center md:gap-4 md:px-6 md:py-10">
@@ -118,10 +118,10 @@ export function WhatsNewRibbon() {
           <Sparkles className="h-4 w-4 shrink-0 text-indigo-400" aria-hidden />
           <div className="flex flex-col">
             <span className="font-mono text-xs uppercase tracking-wider text-indigo-400">
-              What&apos;s new in v2.4.0
+              What&apos;s new in v2.4.1
             </span>
             <span className="text-xs text-zinc-500">
-              Edge-AI discovery &amp; marketplace filters — May 2026
+              Security hardening patch — June 2026
             </span>
           </div>
         </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 **ASAP (Async Simple Agent Protocol)** is a streamlined protocol for agent-to-agent communication, designed to be simpler than existing alternatives while maintaining modern standards functionality.
 
-**Latest reference implementation:** **v2.4.0** on PyPI ([CHANGELOG](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md), [PyPI](https://pypi.org/project/asap-protocol/)). **TypeScript npm line: v2.4.0** — [`@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client), [`@asap-protocol/mastra`](integrations/mastra.md), [`@asap-protocol/openai-agents`](integrations/openai-agents.md). v2.4.0 **Edge-AI discovery**: optional hardware/inference manifest fields, registry mirror, marketplace filters. v2.3.x **Adoption Multiplier**: OpenAPI Adapter, Auto-Registration, capability escalation, ASAP challenges. Upgrade: [v2.3.x → v2.4.0](migration.md#upgrading-from-v23x-to-v240) · [v2.2.x → v2.3.0](migration.md#upgrading-from-v22x-to-v230) · [v2.3.0 → v2.3.1](migration.md#upgrading-from-v230-to-v231).
+**Latest reference implementation:** **v2.4.1** on PyPI ([CHANGELOG](https://github.com/adriannoes/asap-protocol/blob/main/CHANGELOG.md), [PyPI](https://pypi.org/project/asap-protocol/)). **TypeScript npm line: v2.4.1** — [`@asap-protocol/client`](https://www.npmjs.com/package/@asap-protocol/client), [`@asap-protocol/mastra`](integrations/mastra.md), [`@asap-protocol/openai-agents`](integrations/openai-agents.md). v2.4.0 **Edge-AI discovery**: optional hardware/inference manifest fields, registry mirror, marketplace filters. v2.3.x **Adoption Multiplier**: OpenAPI Adapter, Auto-Registration, capability escalation, ASAP challenges. Upgrade: [v2.4.0 → v2.4.1](migration.md#upgrading-from-v240-to-v241) · [v2.3.x → v2.4.0](migration.md#upgrading-from-v23x-to-v240) · [v2.2.x → v2.3.0](migration.md#upgrading-from-v22x-to-v230) · [v2.3.0 → v2.3.1](migration.md#upgrading-from-v230-to-v231).
 
 ## Features
 
@@ -13,7 +13,7 @@
 - **Observability**: First-class tracking with correlation IDs and trace IDs
 - **Security & authorization (v2.2+, WebAuthn real in v2.2.1)**: Per-runtime Host/Agent JWTs, capability grants with constraints, approval flows, opt-in WebAuthn (`asap-protocol[webauthn]`) for browser-controlled and high-risk capability registration — see [Security](security.md) and [Migration](migration.md)
 - **Edge-AI discovery (v2.4.0+)**: Optional `capabilities.hardware` / `inference` on manifests; [Transport](transport.md#hardware-and-inference-capabilities-v24), [ShellClaw registry guide](guides/shellclaw-registry.md), [registry examples](examples/registry-shellclaw.md)
-- **Adoption tools (v2.3.0+)**: [OpenAPI adapter](adapters/openapi.md), [TypeScript client](sdks/typescript.md) (`@asap-protocol/client@2.4.0`), [Mastra adapter](integrations/mastra.md) (`@asap-protocol/mastra@2.4.0`), [OpenAI Agents SDK adapter](integrations/openai-agents.md) (`@asap-protocol/openai-agents@2.4.0`), [Auto-registration](registry/auto-registration.md), [Capability escalation](capabilities/escalation.md), [ASAP HTTP challenge](transport/asap-challenge.md)
+- **Adoption tools (v2.3.0+)**: [OpenAPI adapter](adapters/openapi.md), [TypeScript client](sdks/typescript.md) (`@asap-protocol/client@2.4.1`), [Mastra adapter](integrations/mastra.md) (`@asap-protocol/mastra@2.4.1`), [OpenAI Agents SDK adapter](integrations/openai-agents.md) (`@asap-protocol/openai-agents@2.4.1`), [Auto-registration](registry/auto-registration.md), [Capability escalation](capabilities/escalation.md), [ASAP HTTP challenge](transport/asap-challenge.md)
 
 ## Installation
 
@@ -93,9 +93,9 @@ See [CLI reference](cli.md) (all commands, exit codes, `compliance-check`, `audi
 ## Documentation
 
 - [OpenAPI adapter](adapters/openapi.md) — derive ASAP skills and an upstream proxy from OpenAPI 3.x (`asap.adapters.openapi`)
-- [TypeScript client SDK](sdks/typescript.md) — `@asap-protocol/client@2.4.0` on npm (browser + Node; optional LLM adapters; edge-AI registry fields)
-- [Mastra adapter](integrations/mastra.md) — `@asap-protocol/mastra@2.4.0`: ASAP capabilities as `@mastra/core` tools + streaming bridge
-- [OpenAI Agents SDK adapter](integrations/openai-agents.md) — `@asap-protocol/openai-agents@2.4.0`: ASAP capabilities as `@openai/agents` tools + handoff-oriented remote agent helper (`@openai/agents`, distinct from `@asap-protocol/client/adapters/openai`)
+- [TypeScript client SDK](sdks/typescript.md) — `@asap-protocol/client@2.4.1` on npm (browser + Node; optional LLM adapters; edge-AI registry fields)
+- [Mastra adapter](integrations/mastra.md) — `@asap-protocol/mastra@2.4.1`: ASAP capabilities as `@mastra/core` tools + streaming bridge
+- [OpenAI Agents SDK adapter](integrations/openai-agents.md) — `@asap-protocol/openai-agents@2.4.1`: ASAP capabilities as `@openai/agents` tools + handoff-oriented remote agent helper (`@openai/agents`, distinct from `@asap-protocol/client/adapters/openai`)
 - [CLI reference](cli.md) — all `asap` commands, including `compliance-check`, `audit export`, and exit codes
 - [Audit log](audit.md) — hash chain model, export formats, tamper checks
 - [API Reference](api-reference.md)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -761,6 +761,67 @@ For deployments that enforce self-authorization prevention with real passkeys:
 See [Self-authorization prevention](security/self-authorization-prevention.md)
 (**Real WebAuthn**) for the threat model and ceremony flow.
 
+### Upgrading from v2.4.0 to v2.4.1
+
+v2.4.1 is a **security-hardening patch**. JSON-RPC envelopes, capability grants,
+and manifest schemas are unchanged from v2.4.0. Most deployments upgrade without
+code changes.
+
+#### What changed
+
+- **OAuth2 JWT validation (opt-in)**: When `ASAP_AUTH_ISSUER` and/or
+  `ASAP_AUTH_AUDIENCE` are set (or `OAuth2Config.expected_issuer` /
+  `expected_audience`), the OAuth2 middleware validates JWT `iss` and `aud` via
+  `validate_jwt()` in `asap.auth.jwks`. Tokens with a mismatched issuer or
+  audience are rejected.
+- **Identity binding (fail-closed)**: When `manifest_id` is configured on
+  `OAuth2Config`, requests whose JWT subject does not match the custom claim
+  (`ASAP_AUTH_CUSTOM_CLAIM`) or `ASAP_AUTH_SUBJECT_MAP` allowlist now receive
+  **403** instead of warn-and-pass.
+- **Web app (`apps/web`)**: Hardened against open redirects on E2E fixture login
+  routes (`resolveRedirectUrl`), SSRF on `/api/health-check` (127.0.0.0/8, DNS
+  resolve4/6), and strict Zod validation on public API query params (unknown keys
+  return 400). Default marketplace deployments pick up these fixes on rebuild —
+  **no operator configuration required**.
+- **Dependencies**: Raised `fastapi` floor to `>=0.136.1` (pulls
+  `starlette>=1.0.1`, resolves **PYSEC-2026-161**); bumped transitive pins for
+  `langchain-core`, `langsmith`, `python-multipart`, `urllib3`, `pip`, and
+  `smolagents`. See [SECURITY.md](../SECURITY.md).
+
+#### Upgrade steps
+
+1. **Bump dependencies**:
+   ```bash
+   pip install --upgrade asap-protocol==2.4.1
+   # or
+   uv add asap-protocol==2.4.1
+   ```
+   TypeScript consumers: `npm install @asap-protocol/client@2.4.1`.
+
+2. **OAuth2 operators**: If you already set `ASAP_AUTH_ISSUER` /
+   `ASAP_AUTH_AUDIENCE`, ensure your IdP issues tokens with matching `iss` and
+   `aud`. If unset, behavior is unchanged from v2.4.0.
+
+3. **Identity binding**: If `manifest_id` is set, verify
+   `ASAP_AUTH_CUSTOM_CLAIM` or `ASAP_AUTH_SUBJECT_MAP` covers every legitimate
+   caller — otherwise those callers will now receive 403.
+
+4. **Web app**: Rebuild/redeploy `apps/web` if you self-host the marketplace
+   (fixes ship in the image; no new env vars).
+
+5. **Re-run Compliance Harness v2** after upgrading production agents
+   (`asap compliance-check --exit-on-fail`).
+
+#### Backward compatibility
+
+- **Wire protocol**: Unchanged from v2.4.0.
+- **Breaking changes**: None when `ASAP_AUTH_ISSUER`, `ASAP_AUTH_AUDIENCE`, and
+  `manifest_id` identity binding were already configured correctly. Fail-closed
+  identity binding is a behavior change only for misconfigured deployments that
+  previously passed with warnings.
+
+---
+
 ### Upgrading from v2.3.x to v2.4.0
 
 v2.4.0 is an **additive, backward-compatible** minor release. JSON-RPC envelopes,

--- a/packages/typescript/client/package.json
+++ b/packages/typescript/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asap-protocol/client",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Official TypeScript client for the ASAP Protocol",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/typescript/mastra/package.json
+++ b/packages/typescript/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asap-protocol/mastra",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "ASAP Protocol capabilities as Mastra tools (@mastra/core)",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/typescript/openai-agents/package.json
+++ b/packages/typescript/openai-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asap-protocol/openai-agents",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "ASAP Protocol capabilities as OpenAI Agents SDK tools (@openai/agents)",
   "type": "module",
   "license": "Apache-2.0",

--- a/product/README.md
+++ b/product/README.md
@@ -43,6 +43,7 @@ product/
 | v2.3.1 — Framework adapters (npm) | ✅ Released (2026-05-21) | — (private PRD) | `@asap-protocol/mastra`, `@asap-protocol/openai-agents` @ 2.3.1; Python core stays 2.3.0 |
 | v2.3.2 — Adapter Lab II | 🔒 Private planning | `prd/private/prd-v2.3.2-enterprise-workflow-adapters.md` | Microsoft Agent Framework, Haystack, Letta, workflow automation |
 | v2.3.3 — Distribution Loop | 🔒 Private planning | `prd/private/prd-v2.3.3-distribution-loop.md` | Templates, docs, homepage, metrics, developer activation |
+| **v2.4.1 — Security hardening** | **✅ Released (2026-06-14)** | `engineering/tasks/private/v2.4.1/` | OAuth2 iss/aud validation, fail-closed identity binding, web SSRF/redirect hardening, dependency bumps |
 | **v2.4.0 — Edge-AI discovery** | **✅ Released (2026-05-24)** | `engineering/tasks/v2.4.0/` | Hardware/inference manifest fields, registry mirror, marketplace filters, ShellClaw onboarding |
 | v2.4.x — Spec & Interop (deferred PRD) | 🔭 Vision draft | `prd-v2.4-adoption.md` | MCP Auth Bridge, Formal Spec, Introspection, Privacy (not in shipped 2.4.0 scope) |
 | v3.0 — Economy | 🔭 Long-term | `prd-v3.0-economy.md` | Settlement, billing |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asap-protocol"
-version = "2.4.0"
+version = "2.4.1"
 description = "Async Simple Agent Protocol - A streamlined protocol for agent-to-agent communication"
 authors = [
     {name = "ASAP Protocol Contributors"}

--- a/src/asap/__init__.py
+++ b/src/asap/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 
 __all__ = ["__version__", "create_from_openapi"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "asap-protocol"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Bump Python and npm packages to **2.4.1** (security hardening patch)
- Finalize CHANGELOG `[2.4.1]` with Security/Fixed items; follow-ups remain in `[Unreleased]`
- Add migration guide `### Upgrading from v2.4.0 to v2.4.1` and update public version references (README, docs, landing)

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/ scripts/ tests/`
- [ ] `PYTHONPATH=src uv run pytest --cov=src --cov-report=xml`
- [ ] `pip-audit` (CI security job parity)
- [ ] `cd apps/web && npm run lint && npx tsc --noEmit && npx vitest run`

## Release follow-up (post-merge)
- Tag `v2.4.1` on `main` → triggers PyPI, npm, Docker publish workflows
- Verify artifacts and GitHub Release per `engineering/tasks/private/v2.4.1/sprint-S2-release.md` Task 2.0