### PR TITLE
chore(security): remove obsolete CVE-2026-46678 pip-audit ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,8 +182,8 @@ jobs:
           sync-flags: --no-extra crewai --no-extra llamaindex
       # CVE-2026-4539: pygments advisory with no patched PyPI release yet (override pins >=2.20 when available).
       # CVE-2026-4963 / CVE-2026-2654: smolagents optional extra; OSV lists no fix version on PyPI as of 2026-05 (see SECURITY.md).
-      # CVE-2026-46678 / PYSEC-2026-89 / PYSEC-2025-183 / PYSEC-2024-271: optional/transitive; see SECURITY.md.
+      # PYSEC-2026-89 / PYSEC-2025-183 / PYSEC-2024-271: optional/transitive; see SECURITY.md.
       - name: Scan for vulnerabilities (pip-audit)
-        run: uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-46678 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654 --ignore-vuln PYSEC-2024-271 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183
+        run: uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654 --ignore-vuln PYSEC-2024-271 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183
       - name: Scan for security issues (bandit)
         run: uv run bandit -r src/ -ll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `extra="forbid"` on ingress payload models (`TaskRequestConfig`, `CommonMetadata`)
 - Opt-in protection for operator APIs (`/usage`, `/sla`, `/audit`)
 - Redis-backed `JtiReplayCache` and distributed Next.js rate limits
-- Bump optional `pydantic-ai` extra (CVE-2026-46678)
+
+### Fixed
+
+- **pydantic-ai (CVE-2026-46678)**: Optional `[pydanticai]` extra pins `pydantic-ai>=1.99.0`; removed obsolete `pip-audit` ignore from CI.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -93,13 +93,13 @@ We continuously monitor dependencies using:
 
 CI runs `pip-audit` after a sync that **excludes** the optional extras `crewai` and `llamaindex`, because those graphs currently pull transitive packages (`diskcache`, `nltk`) that OSV still lists with no fixed release on PyPI. To match the security job locally:
 
-`uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex` then `uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-46678 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654 --ignore-vuln PYSEC-2024-271 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183` (matches CI).
+`uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex` then `uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654 --ignore-vuln PYSEC-2024-271 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183` (matches CI).
 
 **CVE-2026-4539 (Pygments)**: CI uses `--ignore-vuln CVE-2026-4539` until a patched `pygments` release on PyPI resolves the advisory (`tool.uv.override-dependencies` prefers `pygments>=2.20.0` when resolvable).
 
 **PYSEC-2026-161 (starlette, FastAPI stack)**: Resolved by requiring `fastapi>=0.136.1`, which pulls `starlette>=1.0.1` (Host header path validation). Do not add a `pip-audit` ignore for this advisory.
 
-**CVE-2026-46678 (pydantic-ai, optional `[pydanticai]` extra)**: CI uses `--ignore-vuln CVE-2026-46678` until the extra pins `pydantic-ai>=1.99.0` (fix published on PyPI; see CHANGELOG follow-up). Runtime does not import pydantic-ai unless that extra is installed.
+**CVE-2026-46678 (pydantic-ai, optional `[pydanticai]` extra)**: Resolved via `[pydanticai]` extra floor `pydantic-ai>=1.99.0` (1.102.0 in lock as of 2026-06).
 
 **CVE-2026-4963 / CVE-2026-2654 (smolagents, optional `[smolagents]` extra)**: OSV reports these against current PyPI releases with **no `fix_versions`/`fixed` range** yet. CI ignores them until Hugging Face publishes patched `smolagents` wheels; remove the flags when `pip-audit` is clean without them. The reference package does not import smolagents unless that extra is installed.
 


### PR DESCRIPTION
## Summary

- Remove `--ignore-vuln CVE-2026-46678` from CI `pip-audit` (optional `[pydanticai]` extra already pins `pydantic-ai>=1.99.0`, 1.102.0 in lock).
- Update `SECURITY.md` and `CHANGELOG.md` to mark CVE-2026-46678 resolved.

Closes partial #209 (pydantic-ai CVE checkbox sub-item). Does **not** close the full epic #209.

## Test plan

- [x] `uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex && uv run pip-audit` with remaining ignores only — **No known vulnerabilities found**