### PR TITLE
feat(v2.5.0): S1 core MCP auth middleware

### DIFF
--- a/engineering/tasks/v2.5.0/sprint-S1-core-middleware.md
+++ b/engineering/tasks/v2.5.0/sprint-S1-core-middleware.md
@@ -10,13 +10,78 @@
 
 ---
 
+## Parallel Execution (Agent Workstreams)
+
+> **Status:** S1 ready — S0 merged on `release/2.5.0` (commit `8a9a1f2`).
+> **Branch:** `feat/v2.5.0-s1-middleware` → PR into `release/2.5.0`.
+> **Rule:** Interactive dev — one sub-task at a time; parallel agents only where noted below.
+
+### Dependency phases
+
+```text
+Phase 1 (gate)       Phase 2 (parallel tests)     Phase 3 (single owner)      Phase 4
+──────────────       ────────────────────────     ──────────────────────      ───────
+1.1 fixtures  ─────► 1.2a failure-path tests  ──┐
+                      1.2b success-path tests ──┼──► 2.x ProtectedMCPServer
+                                                │    (2.1 + 2.2 + 2.3 together)
+                                                └──► 3.1 observability (after 2.x green)
+```
+
+### Agent boundaries
+
+| Agent | Owns | Tasks | Depends on | Can parallelize with |
+|-------|------|-------|------------|----------------------|
+| **A — Fixtures** | `tests/adapters/mcp/conftest.py` | 1.1 | S0 scaffold | — (starts first) |
+| **B — Failure tests** | Missing / expired / tampered JWT cases | 1.2 (partial) | 1.1 | C (after gate) |
+| **C — Success tests** | `public_tools` skip + valid JWT handler runs | 1.2 (partial) | 1.1 | B (after gate) |
+| **D — Middleware** | `protected_server.py` + `protect_server` factory | 2.1, 2.2, 2.3 | 1.2 red | — (single owner; avoid merge conflicts) |
+| **E — Observability** | `mcp.tool.authorized` structured log + caplog test | 3.1 | 2.x green | — |
+
+### Sequential vs parallel summary
+
+| Must be sequential | Safe to parallelize (after 1.1) |
+|--------------------|----------------------------------|
+| **1.1 → 1.2** (fixtures before tests) | **1.2a** ∥ **1.2b** (split `test_auth_middleware.py`) |
+| **1.2 → 2.x** (TDD red before green) | — |
+| **2.1 + 2.2 + 2.3** (one `_handle_tools_call` override) | Agent D owns all three; do not split across agents |
+| **2.x → 3.1** (log on successful auth path) | — |
+
+### Notes for sub-agents
+
+- **Design lock is locked:** `ProtectedMCPServer` subclass in `protected_server.py`; `protect_server` copies `_tools`, `_server_info`, `_instructions` from input server (ADR §2).
+- **S1 scope:** JWT verify + `public_tools` only — **no** `check_grant` yet (S2). Set `enforce_grants=False` or skip grant gate in S1; tests must not require capability grants.
+- **Replace S0 stub test:** `test_protect_server_raises_not_implemented` → full suite; keep import of `protect_server` / `MCPAuthConfig`.
+- **JWT patterns:** Follow `tests/auth/test_agent_jwt.py` and `tests/transport/test_capability_routes.py` for `create_agent_jwt` + host/agent key setup.
+- **Error mapping:** Use `errors.tool_error_result(AUTH_REQUIRED|INVALID_TOKEN, …)` — codes already in S0.
+- **Extractor:** Always `resolve_jwt_extractor(config)` — never call `default_jwt_extractor` directly in middleware.
+- **Verify gate:** `uv run pytest tests/adapters/mcp/test_auth_middleware.py -v` green + `uv run mypy src/asap/adapters/mcp/` clean.
+
+### Sub-agent prompt templates
+
+**Agent A (1.1):**
+> Create `tests/adapters/mcp/conftest.py` with fixtures: `host_identity`, `agent_session`, `capability_registry`, `mint_agent_jwt()`, minimal `MCPServer` with `echo` tool. Pattern: `tests/auth/test_agent_jwt.py`. Verify: `pytest tests/adapters/mcp/ --collect-only`.
+
+**Agent B (1.2a):**
+> After 1.1, add failing tests in `test_auth_middleware.py`: missing JWT → `asap:auth_required`; expired → `asap:invalid_token`; tampered → `asap:invalid_token`. Use fixtures from conftest. Expect red.
+
+**Agent C (1.2b):**
+> After 1.1, add failing tests: `public_tools` tool succeeds without token; valid JWT on protected tool → handler runs. Expect red.
+
+**Agent D (2.x):**
+> Implement `src/asap/adapters/mcp/protected_server.py` (`ProtectedMCPServer`) and wire `protect_server` in `auth_middleware.py`. Override `_handle_tools_call` only. Integrate `verify_agent_jwt`, `resolve_jwt_extractor`, `public_tools` skip. No grant checks (S2). Green on 1.2.
+
+**Agent E (3.1):**
+> After 2.x green: log `mcp.tool.authorized` with `agent_id`, `tool_name` (never JWT). Caplog test asserts fields, token absent.
+
+---
+
 ## Relevant Files
 
 ### New / modify
-- `src/asap/adapters/mcp/auth_middleware.py` — implement `protect_server`
-- `src/asap/adapters/mcp/protected_server.py` — optional: wrapper class if design lock chooses delegation
+- `src/asap/adapters/mcp/auth_middleware.py` — `protect_server` factory (lazy import)
+- `src/asap/adapters/mcp/protected_server.py` — `ProtectedMCPServer` JWT gate on `tools/call`
 - `tests/adapters/mcp/test_auth_middleware.py`
-- `tests/adapters/mcp/conftest.py` — fixtures: test host/agent keys, mint Agent JWT
+- `tests/adapters/mcp/conftest.py` — fixtures: host/agent keys, mint Agent JWT, echo MCPServer
 
 ### Reference
 - `src/asap/auth/agent_jwt.py` — `verify_agent_jwt`, `create_agent_jwt`, `JtiReplayCache`
@@ -30,34 +95,34 @@
 
 ### 1.0 Test fixtures (TDD)
 
-- [ ] 1.1 Add MCP auth test fixtures
+- [x] 1.1 Add MCP auth test fixtures
   - **File**: `tests/adapters/mcp/conftest.py` (create)
   - **What**: Pytest fixtures: `host_identity`, `agent_session`, `capability_registry`, `mint_agent_jwt()`, minimal `MCPServer` with `echo` tool
   - **Why**: S1 tests need valid/invalid tokens without duplicating crypto setup
   - **Pattern**: Follow `tests/auth/` JWT fixtures
   - **Verify**: Fixtures load in `pytest tests/adapters/mcp/ --collect-only`
 
-- [ ] 1.2 Write failing tests for auth paths
+- [x] 1.2 Write failing tests for auth paths
   - **File**: `tests/adapters/mcp/test_auth_middleware.py` (create)
   - **What**: Cases: missing JWT → `asap:auth_required`; expired JWT → `asap:invalid_token`; tampered JWT → `asap:invalid_token`; valid JWT on `public_tools` tool → success without token; valid JWT → handler runs
   - **Verify**: Red before implementation
 
 ### 2.0 `protect_server` implementation
 
-- [ ] 2.1 Implement wrapper per design lock
+- [x] 2.1 Implement wrapper per design lock
   - **File**: `src/asap/adapters/mcp/auth_middleware.py` + optional `protected_server.py`
   - **What**: Intercept `tools/call` before `_handle_tools_call` executes user handler. Use `resolve_jwt_extractor(config)` (or `config.jwt_extractor` when set)
   - **Why**: MCP-AUTH-001, MCP-AUTH-006
   - **Pattern**: Minimal diff to `MCPServer`; prefer composition over editing `server.py` core loop
   - **Verify**: Green on 1.2 tests
 
-- [ ] 2.2 Integrate `verify_agent_jwt`
+- [x] 2.2 Integrate `verify_agent_jwt`
   - **File**: `src/asap/adapters/mcp/auth_middleware.py`
   - **What**: Call `await verify_agent_jwt(token, host_store=..., agent_store=..., jti_replay_cache=config.jti_replay_cache, expected_audience=config.expected_audience)`; map `JwtVerifyResult` to error constants
   - **Why**: MCP-AUTH-002
   - **Verify**: Test rejects tampered token
 
-- [ ] 2.3 `public_tools` allowlist
+- [x] 2.3 `public_tools` allowlist
   - **File**: `src/asap/adapters/mcp/auth_middleware.py`
   - **What**: Skip JWT when `parsed.name in config.public_tools`
   - **Why**: MCP-AUTH-001 exception path
@@ -65,7 +130,7 @@
 
 ### 3.0 Observability
 
-- [ ] 3.1 Log agent URN on successful auth
+- [x] 3.1 Log agent URN on successful auth
   - **File**: `src/asap/adapters/mcp/auth_middleware.py`
   - **What**: Structured log `mcp.tool.authorized` with `agent_id`, `tool_name` (no JWT value)
   - **Why**: MCP-AUTH-004; security doc redaction
@@ -75,8 +140,8 @@
 
 ## Acceptance Criteria (S1)
 
-- [ ] `protect_server` returns server that enforces JWT on non-public tools
-- [ ] Missing/invalid JWT returns MCP result with `isError: true` and `asap:*` prefix
-- [ ] Unprotected `MCPServer` unchanged when `protect_server` not used
-- [ ] `pytest tests/adapters/mcp/test_auth_middleware.py -v` green
-- [ ] `uv run mypy src/asap/adapters/mcp/` clean
+- [x] `protect_server` returns server that enforces JWT on non-public tools
+- [x] Missing/invalid JWT returns MCP result with `isError: true` and `asap:*` prefix
+- [x] Unprotected `MCPServer` unchanged when `protect_server` not used
+- [x] `pytest tests/adapters/mcp/test_auth_middleware.py -v` green
+- [x] `uv run mypy src/asap/adapters/mcp/` clean

--- a/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
+++ b/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
@@ -10,14 +10,14 @@ Based on [PRD v2.5.0 MCP Auth Bridge](../../../product/prd/prd-v2.5.0-mcp-auth-b
 - [x] Agent JWT + Host JWT stable (`auth/agent_jwt.py`, v2.2+)
 - [x] Capability grants + constraint validation (`CapabilityRegistry.check_grant`, `validate_constraints`, v2.2+)
 - [x] `MCPServer` stdio + `tools/call` (`mcp/server.py`, MCP 2025-11-25)
-- [ ] S0 design lock: confirm wrapper strategy, `CapabilityRegistry` injection, and `_meta` parser changes before S1
+- [x] S0 design lock: confirm wrapper strategy, `CapabilityRegistry` injection, and `_meta` parser changes before S1
 
 ## Sprint Plan
 
 | Sprint | Focus | PRD sections | Priority | Status |
 |--------|-------|--------------|----------|--------|
-| **S0** | [Design lock & scaffold](./sprint-S0-design-lock.md) | §6 API, MCP-AUTH-005 | P0 | 🔵 Planned |
-| **S1** | [Core auth middleware](./sprint-S1-core-middleware.md) | MCP-AUTH-001..004, 006 and auth portions of 007 | P0 | 🔵 Planned |
+| **S0** | [Design lock & scaffold](./sprint-S0-design-lock.md) | §6 API, MCP-AUTH-005 | P0 | ✅ Done |
+| **S1** | [Core auth middleware](./sprint-S1-core-middleware.md) | MCP-AUTH-001..004, 006 and auth portions of 007 | P0 | ✅ Done (`feat/v2.5.0-s1-middleware`) |
 | **S2** | [Capability mapping & errors](./sprint-S2-capability-mapping.md) | MCP-MAP-*, §4.5–4.6 | P0 | 🔵 Planned |
 | **S3** | [Docs, examples & discovery](./sprint-S3-docs-examples.md) | MCP-DISC-*, MCP-DOC-* | P0/P1 | 🔵 Planned |
 | **S4** | [Compliance & integration tests](./sprint-S4-compliance.md) | MCP-DISC-003, harness | P1 | 🔵 Planned |
@@ -168,3 +168,4 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 | 2026-06-22 | Parent tasks 1.0–5.0 added (Phase 1) |
 | 2026-06-22 | Phase 2: sprint S0–S5 sub-tasks; `release/2.5.0` integration branch |
 | 2026-06-24 | Reconciled task plan with PRD paths, repo APIs, compliance scope, and TypeScript spike/defer gate |
+| 2026-06-24 | S0 complete on `release/2.5.0`; S1 branch `feat/v2.5.0-s1-middleware` opened with parallel agent workstreams |

--- a/src/asap/adapters/mcp/auth_middleware.py
+++ b/src/asap/adapters/mcp/auth_middleware.py
@@ -66,7 +66,10 @@ def resolve_jwt_extractor(config: MCPAuthConfig) -> Callable[[CallToolRequestPar
 
 
 def protect_server(server: MCPServer, config: MCPAuthConfig) -> MCPServer:
-    """Return an MCP server with ``tools/call`` wrapped by ASAP auth and grant checks.
+    """Return an MCP server with JWT verification on ``tools/call`` (S1).
+
+    S1 enforces Agent JWT extraction/verification and the ``public_tools``
+    allowlist. Capability grant checks via ``enforce_grants`` land in S2.
 
     See PRD v2.5.0 MCP Auth Bridge (``product/prd/prd-v2.5.0-mcp-auth-bridge.md``)
     and design lock ADR (``engineering/tasks/v2.5.0/design-lock-mcp-auth-bridge.md``).
@@ -79,6 +82,7 @@ def protect_server(server: MCPServer, config: MCPAuthConfig) -> MCPServer:
         Protected server instance; unprotected ``MCPServer`` usage remains valid when
         this function is not called.
     """
+    # Lazy import: protected_server imports MCPAuthConfig from this module.
     from asap.adapters.mcp.protected_server import ProtectedMCPServer
 
     return ProtectedMCPServer.from_server(server, config)

--- a/src/asap/adapters/mcp/auth_middleware.py
+++ b/src/asap/adapters/mcp/auth_middleware.py
@@ -78,8 +78,7 @@ def protect_server(server: MCPServer, config: MCPAuthConfig) -> MCPServer:
     Returns:
         Protected server instance; unprotected ``MCPServer`` usage remains valid when
         this function is not called.
-
-    Raises:
-        NotImplementedError: Until S1 core middleware is implemented.
     """
-    raise NotImplementedError("protect_server is implemented in sprint S1")
+    from asap.adapters.mcp.protected_server import ProtectedMCPServer
+
+    return ProtectedMCPServer.from_server(server, config)

--- a/src/asap/adapters/mcp/protected_server.py
+++ b/src/asap/adapters/mcp/protected_server.py
@@ -39,6 +39,7 @@ class ProtectedMCPServer(MCPServer):
             raise ValueError(f"Invalid params: {e}") from e
 
         if parsed.name in self._auth_config.public_tools:
+            # Public tools skip JWT entirely; a present _meta.asap_agent_jwt is not verified.
             return await super()._handle_tools_call(params)
 
         token = self._jwt_extractor(parsed)

--- a/src/asap/adapters/mcp/protected_server.py
+++ b/src/asap/adapters/mcp/protected_server.py
@@ -1,0 +1,66 @@
+"""Protected MCP server subclass for ASAP auth on ``tools/call`` (v2.5.0)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from asap.adapters.mcp.auth_middleware import MCPAuthConfig, resolve_jwt_extractor
+from asap.adapters.mcp.errors import AUTH_REQUIRED, INVALID_TOKEN, tool_error_result
+from asap.auth.agent_jwt import verify_agent_jwt
+from asap.mcp.protocol import CallToolRequestParams
+from asap.mcp.server import MCPServer
+from asap.observability import get_logger
+
+logger = get_logger(__name__)
+
+
+class ProtectedMCPServer(MCPServer):
+    """``MCPServer`` with JWT verification on ``tools/call`` before tool handlers run."""
+
+    def __init__(self, config: MCPAuthConfig) -> None:
+        super().__init__()
+        self._auth_config = config
+        self._jwt_extractor = resolve_jwt_extractor(config)
+
+    @classmethod
+    def from_server(cls, server: MCPServer, config: MCPAuthConfig) -> ProtectedMCPServer:
+        """Copy registration state from ``server`` without mutating the original."""
+        protected = cls(config)
+        protected._server_info = server._server_info
+        protected._instructions = server._instructions
+        protected._tools = dict(server._tools)
+        return protected
+
+    async def _handle_tools_call(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Intercept ``tools/call`` for JWT extraction and verification (S1)."""
+        try:
+            parsed = CallToolRequestParams(**params)
+        except Exception as e:
+            raise ValueError(f"Invalid params: {e}") from e
+
+        if parsed.name in self._auth_config.public_tools:
+            return await super()._handle_tools_call(params)
+
+        token = self._jwt_extractor(parsed)
+        if not token:
+            return tool_error_result(AUTH_REQUIRED)
+
+        verify_result = await verify_agent_jwt(
+            token,
+            self._auth_config.host_store,
+            self._auth_config.agent_store,
+            expected_audience=self._auth_config.expected_audience,
+            jti_replay_cache=self._auth_config.jti_replay_cache,
+        )
+        if not verify_result.ok:
+            return tool_error_result(INVALID_TOKEN, verify_result.error)
+
+        agent = verify_result.agent
+        if agent is not None:
+            logger.info(
+                "mcp.tool.authorized",
+                agent_id=agent.agent_id,
+                tool_name=parsed.name,
+            )
+
+        return await super()._handle_tools_call(params)

--- a/tests/adapters/mcp/conftest.py
+++ b/tests/adapters/mcp/conftest.py
@@ -1,0 +1,150 @@
+"""Shared fixtures for MCP auth middleware tests (S1).
+
+Provides host/agent identity, JWT minting, and a minimal ``MCPServer`` with an
+``echo`` tool so auth-path tests avoid duplicating crypto setup.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from asap.auth.agent_jwt import create_agent_jwt
+from asap.auth.capabilities import CapabilityRegistry
+from asap.auth.identity import (
+    AgentSession,
+    HostIdentity,
+    InMemoryAgentStore,
+    InMemoryHostStore,
+    jwk_thumbprint_sha256,
+)
+from asap.mcp.server import MCPServer
+from tests.crypto.jwk_helpers import ed25519_public_jwk
+
+pytestmark = pytest.mark.filterwarnings("ignore:EdDSA is deprecated:UserWarning")
+
+MCP_TEST_AUDIENCE = "urn:asap:agent:mcp-test"
+
+_ECHO_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"message": {"type": "string"}},
+    "additionalProperties": False,
+}
+
+
+@pytest.fixture
+def host_sk() -> Ed25519PrivateKey:
+    """Ed25519 private key for the test host identity."""
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture
+def agent_sk() -> Ed25519PrivateKey:
+    """Ed25519 private key for the test agent session."""
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture
+def agent_store() -> InMemoryAgentStore:
+    """In-memory agent session store."""
+    return InMemoryAgentStore()
+
+
+@pytest.fixture
+def host_store(agent_store: InMemoryAgentStore) -> InMemoryHostStore:
+    """In-memory host store linked to ``agent_store``."""
+    return InMemoryHostStore(agent_store=agent_store)
+
+
+@pytest.fixture
+async def host_identity(
+    host_sk: Ed25519PrivateKey,
+    host_store: InMemoryHostStore,
+) -> HostIdentity:
+    """Registered active host identity persisted in ``host_store``."""
+    now = datetime.now(timezone.utc)
+    identity = HostIdentity(
+        host_id="mcp-test-host",
+        public_key=ed25519_public_jwk(host_sk),
+        status="active",
+        created_at=now,
+        updated_at=now,
+    )
+    await host_store.save(identity)
+    return identity
+
+
+@pytest.fixture
+async def agent_session(
+    agent_sk: Ed25519PrivateKey,
+    host_identity: HostIdentity,
+    agent_store: InMemoryAgentStore,
+) -> AgentSession:
+    """Registered active agent session persisted in ``agent_store``."""
+    now = datetime.now(timezone.utc)
+    session = AgentSession(
+        agent_id="urn:asap:agent:mcp-test-agent",
+        host_id=host_identity.host_id,
+        public_key=ed25519_public_jwk(agent_sk),
+        mode="delegated",
+        status="active",
+        created_at=now,
+        activated_at=now,
+    )
+    await agent_store.save(session)
+    return session
+
+
+@pytest.fixture
+def capability_registry() -> CapabilityRegistry:
+    """Empty capability registry for MCP auth config wiring."""
+    return CapabilityRegistry()
+
+
+@pytest.fixture
+def mint_agent_jwt(
+    host_sk: Ed25519PrivateKey,
+    agent_sk: Ed25519PrivateKey,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+) -> Callable[..., str]:
+    """Mint Agent JWTs for the test host/agent pair.
+
+    Example:
+        >>> token = mint_agent_jwt()
+        >>> token = mint_agent_jwt(aud="custom-aud", capabilities=["echo"])
+    """
+    host_thumbprint = jwk_thumbprint_sha256(host_identity.public_key)
+
+    def _mint(
+        *,
+        agent_id: str | None = None,
+        aud: str | list[str] | None = None,
+        capabilities: list[str] | None = None,
+    ) -> str:
+        return create_agent_jwt(
+            agent_sk,
+            host_thumbprint=host_thumbprint,
+            agent_id=agent_id or agent_session.agent_id,
+            aud=aud if aud is not None else MCP_TEST_AUDIENCE,
+            capabilities=capabilities,
+        )
+
+    return _mint
+
+
+@pytest.fixture
+def echo_mcp_server() -> MCPServer:
+    """Minimal MCP server with a single ``echo`` tool registered."""
+    server = MCPServer(name="mcp-auth-test", version="0.1.0")
+    server.register_tool(
+        "echo",
+        lambda message="": message,
+        _ECHO_INPUT_SCHEMA,
+        description="Echo input message",
+    )
+    return server

--- a/tests/adapters/mcp/test_auth_middleware.py
+++ b/tests/adapters/mcp/test_auth_middleware.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 from collections.abc import Callable
@@ -19,6 +20,7 @@ from asap.auth.identity import (
     InMemoryHostStore,
 )
 from asap.mcp.server import MCPServer
+from asap.mcp.protocol import JSONRPCRequest
 from tests.adapters.mcp.conftest import MCP_TEST_AUDIENCE
 
 if TYPE_CHECKING:
@@ -136,6 +138,26 @@ async def test_tampered_jwt_returns_invalid_token(
     assert INVALID_TOKEN in _error_text(result)
 
 
+@pytest.mark.asyncio
+async def test_audience_mismatch_returns_invalid_token(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+) -> None:
+    """Valid signature with wrong ``aud`` returns ``asap:invalid_token``."""
+    token = mint_agent_jwt(aud="urn:asap:agent:wrong-audience")
+    config = _build_auth_config(host_store, agent_store, capability_registry)
+    protected = protect_server(echo_mcp_server, config)
+    result = await protected._handle_tools_call(
+        _tool_call_params("echo", arguments={"message": "hi"}, jwt=token)
+    )
+    assert INVALID_TOKEN in _error_text(result)
+
+
 # --- Success paths (1.2b) ---
 
 
@@ -171,6 +193,32 @@ async def test_public_tool_succeeds_without_jwt(
     )
     assert result["isError"] is False
     assert result["content"][0]["text"] == "public"
+
+
+@pytest.mark.asyncio
+async def test_public_tool_ignores_invalid_jwt(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+) -> None:
+    """Public tools do not validate JWT; tampered token still succeeds."""
+    token = _tamper_jwt(mint_agent_jwt())
+    config = _build_auth_config(
+        host_store,
+        agent_store,
+        capability_registry,
+        public_tools=frozenset({"echo"}),
+    )
+    protected = protect_server(echo_mcp_server, config)
+    result = await protected._handle_tools_call(
+        _tool_call_params("echo", arguments={"message": "ignored-jwt"}, jwt=token)
+    )
+    assert result["isError"] is False
+    assert result["content"][0]["text"] == "ignored-jwt"
 
 
 @pytest.mark.asyncio
@@ -220,3 +268,28 @@ async def test_successful_auth_logs_agent_id_not_jwt(
     assert agent_session.agent_id in caplog.text
     assert "echo" in caplog.text
     assert token not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tools_call_enforces_auth(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+) -> None:
+    """JSON-RPC ``tools/call`` dispatch path enforces JWT on protected tools."""
+    config = _build_auth_config(host_store, agent_store, capability_registry)
+    protected = protect_server(echo_mcp_server, config)
+    req = JSONRPCRequest(
+        id=1,
+        method="tools/call",
+        params=_tool_call_params("echo", arguments={"message": "hi"}),
+    )
+    response_line = await protected._dispatch_request(req)
+    assert response_line is not None
+    data = json.loads(response_line)
+    assert "result" in data
+    assert data["result"]["isError"] is True
+    assert AUTH_REQUIRED in data["result"]["content"][0]["text"]

--- a/tests/adapters/mcp/test_auth_middleware.py
+++ b/tests/adapters/mcp/test_auth_middleware.py
@@ -1,23 +1,222 @@
-"""Unit tests for protect_server stub (S0)."""
+"""Unit tests for protect_server auth middleware (S1)."""
 
 from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from asap.adapters.mcp.auth_middleware import MCPAuthConfig, protect_server
+from asap.adapters.mcp.errors import AUTH_REQUIRED, INVALID_TOKEN
 from asap.auth.capabilities import CapabilityRegistry
-from asap.auth.identity import InMemoryAgentStore, InMemoryHostStore
+from asap.auth.identity import (
+    AgentSession,
+    HostIdentity,
+    InMemoryAgentStore,
+    InMemoryHostStore,
+)
 from asap.mcp.server import MCPServer
+from tests.adapters.mcp.conftest import MCP_TEST_AUDIENCE
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+
+pytestmark = pytest.mark.filterwarnings("ignore:EdDSA is deprecated:UserWarning")
 
 
-def test_protect_server_raises_not_implemented() -> None:
-    """protect_server stub raises NotImplementedError until S1."""
-    agents = InMemoryAgentStore()
-    server = MCPServer(name="test")
-    config = MCPAuthConfig(
-        host_store=InMemoryHostStore(agent_store=agents),
-        agent_store=agents,
-        capability_registry=CapabilityRegistry(),
+def _tool_call_params(
+    name: str,
+    *,
+    arguments: dict[str, Any] | None = None,
+    jwt: str | None = None,
+) -> dict[str, Any]:
+    """Build ``tools/call`` params with optional Agent JWT in ``_meta``."""
+    params: dict[str, Any] = {"name": name, "arguments": arguments or {}}
+    if jwt is not None:
+        params["_meta"] = {"asap_agent_jwt": jwt}
+    return params
+
+
+def _build_auth_config(
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    *,
+    public_tools: frozenset[str] = frozenset(),
+) -> MCPAuthConfig:
+    """MCP auth config for S1 tests (JWT gate only; grants deferred to S2)."""
+    return MCPAuthConfig(
+        host_store=host_store,
+        agent_store=agent_store,
+        capability_registry=capability_registry,
+        public_tools=public_tools,
+        enforce_grants=False,
+        expected_audience=MCP_TEST_AUDIENCE,
     )
-    with pytest.raises(NotImplementedError, match="sprint S1"):
-        protect_server(server, config)
+
+
+def _error_text(result: dict[str, Any]) -> str:
+    """Extract error text from a ``CallToolResult`` dict."""
+    assert result["isError"] is True
+    return str(result["content"][0]["text"])
+
+
+def _tamper_jwt(token: str) -> str:
+    """Flip the last character so signature verification fails."""
+    suffix = "a" if token[-1] != "a" else "b"
+    return token[:-1] + suffix
+
+
+# --- Failure paths (1.2a) ---
+
+
+@pytest.mark.asyncio
+async def test_missing_jwt_returns_auth_required(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+) -> None:
+    """Protected tool without JWT returns ``asap:auth_required``."""
+    config = _build_auth_config(host_store, agent_store, capability_registry)
+    protected = protect_server(echo_mcp_server, config)
+    result = await protected._handle_tools_call(
+        _tool_call_params("echo", arguments={"message": "hi"})
+    )
+    assert AUTH_REQUIRED in _error_text(result)
+
+
+@pytest.mark.asyncio
+async def test_expired_jwt_returns_invalid_token(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expired Agent JWT returns ``asap:invalid_token``."""
+    t0 = 1_700_000_000.0
+    monkeypatch.setattr(time, "time", lambda: t0)
+    token = mint_agent_jwt()
+    monkeypatch.setattr(time, "time", lambda: t0 + 120.0)
+
+    config = _build_auth_config(host_store, agent_store, capability_registry)
+    protected = protect_server(echo_mcp_server, config)
+    result = await protected._handle_tools_call(
+        _tool_call_params("echo", arguments={"message": "hi"}, jwt=token)
+    )
+    assert INVALID_TOKEN in _error_text(result)
+
+
+@pytest.mark.asyncio
+async def test_tampered_jwt_returns_invalid_token(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+) -> None:
+    """Tampered Agent JWT returns ``asap:invalid_token``."""
+    token = _tamper_jwt(mint_agent_jwt())
+    config = _build_auth_config(host_store, agent_store, capability_registry)
+    protected = protect_server(echo_mcp_server, config)
+    result = await protected._handle_tools_call(
+        _tool_call_params("echo", arguments={"message": "hi"}, jwt=token)
+    )
+    assert INVALID_TOKEN in _error_text(result)
+
+
+# --- Success paths (1.2b) ---
+
+
+@pytest.mark.asyncio
+async def test_unprotected_server_works_without_jwt(echo_mcp_server: MCPServer) -> None:
+    """Unwrapped ``MCPServer`` still invokes tools without JWT (opt-in protection)."""
+    result = await echo_mcp_server._handle_tools_call(
+        _tool_call_params("echo", arguments={"message": "open"})
+    )
+    assert result["isError"] is False
+    assert result["content"][0]["text"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_public_tool_succeeds_without_jwt(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+) -> None:
+    """Tools in ``public_tools`` skip JWT and execute the handler."""
+    config = _build_auth_config(
+        host_store,
+        agent_store,
+        capability_registry,
+        public_tools=frozenset({"echo"}),
+    )
+    protected = protect_server(echo_mcp_server, config)
+    result = await protected._handle_tools_call(
+        _tool_call_params("echo", arguments={"message": "public"})
+    )
+    assert result["isError"] is False
+    assert result["content"][0]["text"] == "public"
+
+
+@pytest.mark.asyncio
+async def test_valid_jwt_runs_handler(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+) -> None:
+    """Valid Agent JWT on a protected tool delegates to the handler."""
+    token = mint_agent_jwt()
+    config = _build_auth_config(host_store, agent_store, capability_registry)
+    protected = protect_server(echo_mcp_server, config)
+    result = await protected._handle_tools_call(
+        _tool_call_params("echo", arguments={"message": "secure"}, jwt=token)
+    )
+    assert result["isError"] is False
+    assert result["content"][0]["text"] == "secure"
+
+
+@pytest.mark.asyncio
+async def test_successful_auth_logs_agent_id_not_jwt(
+    caplog: LogCaptureFixture,
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+) -> None:
+    """Authorized ``tools/call`` logs agent_id and tool_name without the JWT."""
+    token = mint_agent_jwt()
+    config = _build_auth_config(host_store, agent_store, capability_registry)
+    protected = protect_server(echo_mcp_server, config)
+
+    with caplog.at_level(logging.INFO):
+        result = await protected._handle_tools_call(
+            _tool_call_params("echo", arguments={"message": "logged"}, jwt=token)
+        )
+
+    assert result["isError"] is False
+    assert "mcp.tool.authorized" in caplog.text
+    assert agent_session.agent_id in caplog.text
+    assert "echo" in caplog.text
+    assert token not in caplog.text


### PR DESCRIPTION
## Summary

- Implement `protect_server` with `ProtectedMCPServer` subclass that intercepts `tools/call` for Agent JWT verification without mutating the original `MCPServer`.
- Enforce `asap:auth_required` / `asap:invalid_token` on protected tools; honor `public_tools` allowlist; emit `mcp.tool.authorized` structured logs (agent_id + tool_name, no JWT).
- Add S1 test suite with fixtures, failure/success auth paths, logging redaction check, and unprotected-server regression.

## Test plan

- [x] `uv run pytest tests/adapters/mcp/test_auth_middleware.py -v` (7 tests)
- [x] `uv run pytest tests/adapters/mcp/ -v` (18 tests)
- [x] `uv run ruff check src/asap/adapters/mcp/ tests/adapters/mcp/`
- [x] `uv run mypy src/asap/adapters/mcp/`
- [x] S1 acceptance criteria in `engineering/tasks/v2.5.0/sprint-S1-core-middleware.md`