### PR TITLE
feat(v2.5.0): S2 capability mapping and grant enforcement

### DIFF
--- a/engineering/tasks/v2.5.0/sprint-S2-capability-mapping.md
+++ b/engineering/tasks/v2.5.0/sprint-S2-capability-mapping.md
@@ -10,11 +10,90 @@
 
 ---
 
+## Parallel Execution (Agent Workstreams)
+
+> **Status:** S2 ready — S1 merged on `release/2.5.0` (commit `60e2e85`).
+> **Branch:** `feat/v2.5.0-s2-capability-map` → PR into `release/2.5.0`.
+> **Rule:** Interactive dev — one sub-task at a time in this chat; parallel agents only where noted below.
+
+### Dependency phases
+
+```text
+Phase 1 (gate)          Phase 2 (parallel tests)           Phase 3 (single owner)              Phase 4
+──────────────          ────────────────────────           ──────────────────────              ───────
+1.1 resolve_capability ─► 1.2/1.3 mapping tests (red)  ──┐
+       + unit tests       2.1/2.2 grant tests (red)   ──┼──► D: protected_server wiring
+                                                          │    (1.2 + 1.3 + 2.1 + 2.2)
+                                                          └──► E: 3.1 hide_unauthorized (MAY/defer)
+```
+
+### Agent boundaries
+
+| Agent | Owns | Tasks | Depends on | Can parallelize with |
+|-------|------|-------|------------|----------------------|
+| **A — Capability map** | `capability_map.py` + `test_capability_map.py` | 1.1 | S1 on `release/2.5.0` | — (starts first) |
+| **B — Mapping tests** | Startup validation + explicit map override tests | 1.2, 1.3 (tests only) | 1.1 API stable | C (after gate) |
+| **C — Grant tests** | Denied grant, JWT claim mismatch, constraint violation tests | 2.1, 2.2 (tests only) | 1.1 + conftest grant helpers | B (after gate) |
+| **D — Middleware** | `protected_server.py` grant gate + registry metadata + startup validation | 1.2, 1.3, 2.1, 2.2 (impl) | Phase 2 red tests | — (single owner; one `_handle_tools_call`) |
+| **E — List filter** | `hide_unauthorized_tools` or design-lock defer note | 3.1 | 2.x green | — |
+
+### Sequential vs parallel summary
+
+| Must be sequential | Safe to parallelize (after 1.1) |
+|--------------------|----------------------------------|
+| **1.1 → Phase 2** (resolver before middleware/tests that import it) | **B ∥ C** (split `test_capability_map.py` vs `test_auth_middleware.py`) |
+| **Phase 2 → D** (TDD red before green) | — |
+| **1.2 + 1.3 + 2.1 + 2.2 impl** (one `_handle_tools_call` + `from_server`) | Agent D owns all; do not split across agents |
+| **2.x → 3.1** (list filter needs grant gate) | 3.1 may defer per design lock §6 |
+
+### Notes for sub-agents
+
+- **Design lock is locked:** Grant gate uses `CapabilityRegistry.check_grant` only — do not call `validate_constraints` in middleware (only in unit tests for formatting helpers).
+- **JWT capabilities claim:** When `enforce_grants=True`, resolved capability MUST appear in JWT `capabilities` claim **and** pass `check_grant` (MCP-AUTH-003).
+- **Error codes:** Use `errors.tool_error_result(CAPABILITY_DENIED|CONSTRAINT_VIOLATION, …)` — constants already in S0.
+- **S1 tests stay green:** Keep `enforce_grants=False` in existing S1 tests; add new S2 tests with `enforce_grants=True` and seeded grants.
+- **Startup validation (1.3):** When `validate_tools_at_startup=True`, every registered tool must resolve to non-empty capability and `config.capability_registry.describe(capability)` must return non-`None`.
+- **3.1 defer path:** stdio `tools/list` has no standard JWT carriage — if not implementing, document in design lock §6 and mark 3.1 deferred with test skip + comment.
+- **Verify gate:** `uv run pytest tests/adapters/mcp/ -v` green + `uv run pytest --cov=asap.adapters.mcp --cov-fail-under=90` + `uv run mypy src/asap/adapters/mcp/` clean.
+
+### Sub-agent prompt templates
+
+**Agent A (1.1):**
+> Create `src/asap/adapters/mcp/capability_map.py` with `resolve_capability(tool_name, config) -> str`: check `config.tool_capability_map` first, default identity `tool_name`. Add `tests/adapters/mcp/test_capability_map.py` (explicit map, default identity, empty map). Export from `__init__.py` if public. Verify: `pytest tests/adapters/mcp/test_capability_map.py -v`.
+
+**Agent B (1.2/1.3 tests):**
+> After 1.1, add **failing** tests in `test_capability_map.py` or dedicated module: (1) explicit `tool_capability_map` overrides default; (2) `validate_tools_at_startup=True` raises when tool maps to unknown capability or empty string. Use `CapabilityRegistry.describe` mock/seed. Expect red until Agent D.
+
+**Agent C (2.1/2.2 tests):**
+> After 1.1, extend `tests/adapters/mcp/conftest.py` with grant-seeding helpers (`grant_capability(agent_id, capability, constraints=…)`). Add **failing** tests in `test_auth_middleware.py`: denied grant → `asap:capability_denied`; JWT missing capability in claim → `asap:capability_denied`; `max` constraint exceeded → `asap:constraint_violation`. Set `enforce_grants=True`. Expect red.
+
+**Agent D (1.2 + 1.3 + 2.x impl):**
+> Wire S2 in `protected_server.py`: import `resolve_capability`; after JWT verify, if `enforce_grants` resolve capability, check JWT `capabilities` claim subset, call `check_grant(agent_id, capability, parsed.arguments)`; map denials to `CAPABILITY_DENIED`, violations to `CONSTRAINT_VIOLATION`. Add bridge registry for per-tool capability metadata (1.2). Run startup validation in `from_server` when `validate_tools_at_startup` (1.3). Green on Phase 2 tests; S1 tests unchanged.
+
+**Agent E (3.1):**
+> After 2.x green: implement `hide_unauthorized_tools` on `_handle_tools_list` **or** add `@pytest.mark.skip` test + design-lock defer note if stdio list lacks JWT. Document limitation in test docstring.
+
+### Conftest extensions (Agent C prep)
+
+Add to `tests/adapters/mcp/conftest.py` (shared by B/C/D):
+
+```python
+@pytest.fixture
+def grant_capability(capability_registry: CapabilityRegistry) -> Callable[..., CapabilityGrant]:
+    """Seed an active grant for tests with enforce_grants=True."""
+    ...
+```
+
+Pattern: `tests/transport/test_capability_routes.py` for grant issuance + constraint shapes.
+
+---
+
 ## Relevant Files
 
 ### New / modify
-- `src/asap/adapters/mcp/capability_map.py` — resolve tool → capability name
-- `src/asap/adapters/mcp/auth_middleware.py` — wire grant check + constraints
+- `src/asap/adapters/mcp/capability_map.py` — resolve tool → capability name; `format_constraint_violations`
+- `src/asap/adapters/mcp/auth_middleware.py` — `bridge_tool_capability_map` on `MCPAuthConfig`
+- `src/asap/adapters/mcp/protected_server.py` — bridge registry, startup validation, grant gate
 - `tests/adapters/mcp/test_capability_map.py`
 - `tests/adapters/mcp/test_auth_middleware.py` — extend with grant/constraint cases
 
@@ -28,19 +107,19 @@
 
 ### 1.0 Capability resolution
 
-- [ ] 1.1 Implement `resolve_capability(tool_name, config) -> str`
+- [x] 1.1 Implement `resolve_capability(tool_name, config) -> str`
   - **File**: `src/asap/adapters/mcp/capability_map.py` (create)
   - **What**: Check `tool_capability_map` first; default identity `tool_name == capability`
   - **Why**: MCP-MAP-001
   - **Verify**: `pytest tests/adapters/mcp/test_capability_map.py -v`
 
-- [ ] 1.2 Optional per-tool capability on register (SHOULD)
+- [x] 1.2 Optional per-tool capability on register (SHOULD)
   - **File**: `src/asap/adapters/mcp/auth_middleware.py` or extend `register_tool` wrapper
   - **What**: Allow `protect_server` to accept optional metadata registry `tool_name -> capability` set at register time
   - **Why**: MCP-MAP-002
   - **Verify**: Test explicit map overrides default
 
-- [ ] 1.3 Startup validation (SHOULD)
+- [x] 1.3 Startup validation (SHOULD)
   - **File**: `src/asap/adapters/mcp/auth_middleware.py`
   - **What**: On `protect_server`, if `config.validate_tools_at_startup`, ensure every registered tool resolves to a non-empty capability and `config.capability_registry.describe(capability)` is present unless an explicit defer is recorded in the design lock.
   - **Why**: MCP-MAP-003
@@ -48,13 +127,13 @@
 
 ### 2.0 Grant enforcement
 
-- [ ] 2.1 Cross-check JWT capabilities claim vs grant store
+- [x] 2.1 Cross-check JWT capabilities claim vs grant store
   - **File**: `src/asap/adapters/mcp/auth_middleware.py`
   - **What**: When `enforce_grants=True`, call `config.capability_registry.check_grant(agent_id, resolved_capability, parsed.arguments)` and also honor the JWT `capabilities` claim subset.
   - **Why**: MCP-AUTH-003
   - **Verify**: Test denied grant → `asap:capability_denied`
 
-- [ ] 2.2 Constraint validation on arguments
+- [x] 2.2 Constraint validation on arguments
   - **File**: `src/asap/adapters/mcp/auth_middleware.py`
   - **What**: Use violations returned by `CapabilityRegistry.check_grant`; call `validate_constraints(grant.constraints, parsed.arguments)` directly only in unit tests for formatting helpers. Format violations into `asap:constraint_violation` messages.
   - **Why**: PRD §4.5
@@ -63,17 +142,18 @@
 
 ### 3.0 Optional tools/list filtering (MAY)
 
-- [ ] 3.1 `hide_unauthorized_tools` for tools/list
+- [x] 3.1 `hide_unauthorized_tools` for tools/list — **deferred per design lock §6**
   - **File**: `src/asap/adapters/mcp/auth_middleware.py`
   - **What**: If enabled and JWT present on list call (or session from initialize — document limitation), filter tool list
   - **Why**: MCP-MAP-004
-  - **Verify**: Test or document as deferred if stdio list has no JWT — mark in design lock
+  - **Verify**: Default-off test + skipped future-behavior test in `test_auth_middleware.py`; defer note in `auth_middleware.py` / `protected_server.py`
 
 ---
 
 ## Acceptance Criteria (S2)
 
-- [ ] Tool→capability mapping with explicit map + default identity
-- [ ] Denied/inactive grants, JWT capability-claim mismatches, and constraint violations return correct `asap:*` codes
-- [ ] Coverage ≥90% on `src/asap/adapters/mcp/` (run `pytest --cov=asap.adapters.mcp`)
-- [ ] All S1 tests still green
+- [x] Tool→capability mapping with explicit map + default identity
+- [x] Denied/inactive grants, JWT capability-claim mismatches, and constraint violations return correct `asap:*` codes
+- [x] Coverage ≥90% on `src/asap/adapters/mcp/` (run `pytest --cov=asap.adapters.mcp`)
+- [x] All S1 tests still green
+- [x] MCP-MAP-004 (`hide_unauthorized_tools`) deferred with tests + design-lock §6 note (default `False` leaves `tools/list` unchanged)

--- a/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
+++ b/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
@@ -18,7 +18,7 @@ Based on [PRD v2.5.0 MCP Auth Bridge](../../../product/prd/prd-v2.5.0-mcp-auth-b
 |--------|-------|--------------|----------|--------|
 | **S0** | [Design lock & scaffold](./sprint-S0-design-lock.md) | §6 API, MCP-AUTH-005 | P0 | ✅ Done |
 | **S1** | [Core auth middleware](./sprint-S1-core-middleware.md) | MCP-AUTH-001..004, 006 and auth portions of 007 | P0 | ✅ Done (`feat/v2.5.0-s1-middleware`) |
-| **S2** | [Capability mapping & errors](./sprint-S2-capability-mapping.md) | MCP-MAP-*, §4.5–4.6 | P0 | 🔵 Planned |
+| **S2** | [Capability mapping & errors](./sprint-S2-capability-mapping.md) | MCP-MAP-*, §4.5–4.6 | P0 | 🟢 Impl done; 3.1 MAY deferred to Agent E |
 | **S3** | [Docs, examples & discovery](./sprint-S3-docs-examples.md) | MCP-DISC-*, MCP-DOC-* | P0/P1 | 🔵 Planned |
 | **S4** | [Compliance & integration tests](./sprint-S4-compliance.md) | MCP-DISC-003, harness | P1 | 🔵 Planned |
 | **S5** | [Release v2.5.0](./sprint-S5-release.md) | DoD, metrics | P0 | 🔵 Planned |
@@ -72,10 +72,10 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
   - **Enables:** S3 example server with real grants; S4 compliance cases.
   - **Depends on:** Task 2.0; `CapabilityRegistry.check_grant` / `auth/capabilities.validate_constraints`.
   - **Acceptance criteria:**
-    - [ ] `tool_capability_map` + default identity mapping (tool name == capability)
-    - [ ] Denied grants, JWT capability-claim mismatches, and constraint violations return the correct `asap:*` codes
-    - [ ] Optional startup validation: every registered tool resolves to a capability (MCP-MAP-003)
-    - [ ] Test coverage ≥90% on `asap.adapters.mcp`
+    - [x] `tool_capability_map` + default identity mapping (tool name == capability)
+    - [x] Denied grants, JWT capability-claim mismatches, and constraint violations return the correct `asap:*` codes
+    - [x] Optional startup validation: every registered tool resolves to a capability (MCP-MAP-003)
+    - [x] Test coverage ≥90% on `asap.adapters.mcp`
 
 - [ ] **4.0 Documentation, examples & discovery (S3)**
   - **Trigger:** Protected server runnable locally.
@@ -105,7 +105,8 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 
 - `src/asap/adapters/mcp/__init__.py` — public exports (`protect_server`, `MCPAuthConfig`)
 - `src/asap/adapters/mcp/auth_middleware.py` — JWT extraction, `protect_server`, error mapping
-- `src/asap/adapters/mcp/capability_map.py` — tool → capability resolution
+- `src/asap/adapters/mcp/capability_map.py` — tool → capability resolution; constraint violation formatting
+- `src/asap/adapters/mcp/protected_server.py` — bridge registry, startup validation, grant gate
 - `src/asap/adapters/mcp/errors.py` — ASAP MCP error code constants
 - `tests/adapters/mcp/test_auth_middleware.py` — auth path tests
 - `tests/adapters/mcp/test_capability_map.py` — mapping + constraint tests
@@ -169,3 +170,4 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 | 2026-06-22 | Phase 2: sprint S0–S5 sub-tasks; `release/2.5.0` integration branch |
 | 2026-06-24 | Reconciled task plan with PRD paths, repo APIs, compliance scope, and TypeScript spike/defer gate |
 | 2026-06-24 | S0 complete on `release/2.5.0`; S1 branch `feat/v2.5.0-s1-middleware` opened with parallel agent workstreams |
+| 2026-06-24 | S2 branch `feat/v2.5.0-s2-capability-map` opened; parallel workstreams documented in sprint-S2 |

--- a/src/asap/adapters/mcp/__init__.py
+++ b/src/asap/adapters/mcp/__init__.py
@@ -6,6 +6,7 @@ Opt-in protection for native ``MCPServer`` via ``protect_server``.
 from __future__ import annotations
 
 from asap.adapters.mcp.auth_middleware import MCPAuthConfig, protect_server, resolve_jwt_extractor
+from asap.adapters.mcp.capability_map import resolve_capability
 from asap.adapters.mcp.errors import (
     AUTH_REQUIRED,
     CAPABILITY_DENIED,
@@ -23,6 +24,7 @@ __all__ = [
     "MCPAuthConfig",
     "default_jwt_extractor",
     "protect_server",
+    "resolve_capability",
     "resolve_jwt_extractor",
     "tool_error_result",
 ]

--- a/src/asap/adapters/mcp/auth_middleware.py
+++ b/src/asap/adapters/mcp/auth_middleware.py
@@ -34,8 +34,10 @@ class MCPAuthConfig:
     agent_store: AgentStore
     capability_registry: CapabilityRegistry
     tool_capability_map: dict[str, str] = field(default_factory=dict)
+    bridge_tool_capability_map: dict[str, str] = field(default_factory=dict)
     public_tools: frozenset[str] = frozenset()
     enforce_grants: bool = True
+    # MCP-MAP-004 (MAY): deferred — stdio tools/list has no standard JWT carriage (design-lock §6).
     hide_unauthorized_tools: bool = False
     validate_tools_at_startup: bool = False
     jwt_extractor: Callable[[CallToolRequestParams], str | None] | None = None

--- a/src/asap/adapters/mcp/auth_middleware.py
+++ b/src/asap/adapters/mcp/auth_middleware.py
@@ -68,10 +68,14 @@ def resolve_jwt_extractor(config: MCPAuthConfig) -> Callable[[CallToolRequestPar
 
 
 def protect_server(server: MCPServer, config: MCPAuthConfig) -> MCPServer:
-    """Return an MCP server with JWT verification on ``tools/call`` (S1).
+    """Return an MCP server with JWT and capability enforcement on ``tools/call``.
 
-    S1 enforces Agent JWT extraction/verification and the ``public_tools``
-    allowlist. Capability grant checks via ``enforce_grants`` land in S2.
+    Verifies Agent JWT extraction/verification, the ``public_tools`` allowlist, and
+    (when ``enforce_grants=True``) JWT capability claims plus
+    :meth:`~asap.auth.capabilities.CapabilityRegistry.check_grant`.
+
+    ``from_server`` copies register-time bridge metadata onto the protected instance
+    without mutating ``config``.
 
     See PRD v2.5.0 MCP Auth Bridge (``product/prd/prd-v2.5.0-mcp-auth-bridge.md``)
     and design lock ADR (``engineering/tasks/v2.5.0/design-lock-mcp-auth-bridge.md``).

--- a/src/asap/adapters/mcp/capability_map.py
+++ b/src/asap/adapters/mcp/capability_map.py
@@ -2,17 +2,24 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from asap.adapters.mcp.auth_middleware import MCPAuthConfig
 from asap.auth.capabilities import ConstraintViolation
 
 
-def resolve_capability(tool_name: str, config: MCPAuthConfig) -> str:
+def resolve_capability(
+    tool_name: str,
+    config: MCPAuthConfig,
+    *,
+    bridge_tool_capability_map: Mapping[str, str] | None = None,
+) -> str:
     """Resolve an MCP tool name to an ASAP capability name.
 
     Resolution order (MCP-MAP-001, MCP-MAP-002):
 
     1. ``config.tool_capability_map`` (explicit runtime override)
-    2. ``config.bridge_tool_capability_map`` (register-time bridge metadata)
+    2. ``bridge_tool_capability_map`` argument, else ``config.bridge_tool_capability_map``
     3. Identity default: ``tool_name`` unchanged
 
     Args:
@@ -40,8 +47,13 @@ def resolve_capability(tool_name: str, config: MCPAuthConfig) -> str:
     """
     if tool_name in config.tool_capability_map:
         return config.tool_capability_map[tool_name]
-    if tool_name in config.bridge_tool_capability_map:
-        return config.bridge_tool_capability_map[tool_name]
+    bridge_map = (
+        bridge_tool_capability_map
+        if bridge_tool_capability_map is not None
+        else config.bridge_tool_capability_map
+    )
+    if tool_name in bridge_map:
+        return bridge_map[tool_name]
     return tool_name
 
 

--- a/src/asap/adapters/mcp/capability_map.py
+++ b/src/asap/adapters/mcp/capability_map.py
@@ -1,0 +1,64 @@
+"""Tool-to-capability resolution for MCP Auth Bridge (v2.5.0)."""
+
+from __future__ import annotations
+
+from asap.adapters.mcp.auth_middleware import MCPAuthConfig
+from asap.auth.capabilities import ConstraintViolation
+
+
+def resolve_capability(tool_name: str, config: MCPAuthConfig) -> str:
+    """Resolve an MCP tool name to an ASAP capability name.
+
+    Resolution order (MCP-MAP-001, MCP-MAP-002):
+
+    1. ``config.tool_capability_map`` (explicit runtime override)
+    2. ``config.bridge_tool_capability_map`` (register-time bridge metadata)
+    3. Identity default: ``tool_name`` unchanged
+
+    Args:
+        tool_name: Registered MCP tool name from ``tools/call``.
+        config: MCP auth configuration including capability maps.
+
+    Returns:
+        ASAP capability name used for grant checks.
+
+    Example:
+        >>> from asap.adapters.mcp.auth_middleware import MCPAuthConfig
+        >>> from asap.auth.capabilities import CapabilityRegistry
+        >>> from asap.auth.identity import InMemoryAgentStore, InMemoryHostStore
+        >>> agents = InMemoryAgentStore()
+        >>> config = MCPAuthConfig(
+        ...     host_store=InMemoryHostStore(agent_store=agents),
+        ...     agent_store=agents,
+        ...     capability_registry=CapabilityRegistry(),
+        ...     tool_capability_map={"search": "web_search"},
+        ... )
+        >>> resolve_capability("search", config)
+        'web_search'
+        >>> resolve_capability("echo", config)
+        'echo'
+    """
+    if tool_name in config.tool_capability_map:
+        return config.tool_capability_map[tool_name]
+    if tool_name in config.bridge_tool_capability_map:
+        return config.bridge_tool_capability_map[tool_name]
+    return tool_name
+
+
+def format_constraint_violations(violations: list[ConstraintViolation]) -> str:
+    """Format grant constraint violations for MCP ``tools/call`` error detail.
+
+    Args:
+        violations: Constraint failures from :meth:`CapabilityRegistry.check_grant`.
+
+    Returns:
+        Human-readable detail string joined with ``; ``.
+
+    Example:
+        >>> from asap.auth.capabilities import ConstraintViolation
+        >>> format_constraint_violations([
+        ...     ConstraintViolation("tokens", "max", 100, 150, "tokens: 150 exceeds maximum 100"),
+        ... ])
+        'tokens: 150 exceeds maximum 100'
+    """
+    return "; ".join(v.message for v in violations)

--- a/src/asap/adapters/mcp/protected_server.py
+++ b/src/asap/adapters/mcp/protected_server.py
@@ -47,7 +47,6 @@ class ProtectedMCPServer(MCPServer):
         bridge_caps = getattr(server, "_bridge_tool_capabilities", None)
         if isinstance(bridge_caps, dict) and bridge_caps:
             protected._bridge_tool_capabilities = dict(bridge_caps)
-            config.bridge_tool_capability_map.update(bridge_caps)
 
         if config.validate_tools_at_startup:
             _validate_tools_at_startup(protected)
@@ -75,7 +74,6 @@ class ProtectedMCPServer(MCPServer):
         )
         if capability is not None:
             self._bridge_tool_capabilities[name] = capability
-            self._auth_config.bridge_tool_capability_map[name] = capability
 
     async def _handle_tools_call(self, params: dict[str, Any]) -> dict[str, Any]:
         """Intercept ``tools/call`` for JWT extraction, verification, and grant checks."""
@@ -102,6 +100,11 @@ class ProtectedMCPServer(MCPServer):
         if not verify_result.ok:
             return tool_error_result(INVALID_TOKEN, verify_result.error)
 
+        if self._auth_config.enforce_grants:
+            grant_error = self._check_capability_grant(parsed, verify_result)
+            if grant_error is not None:
+                return grant_error
+
         agent = verify_result.agent
         if agent is not None:
             logger.info(
@@ -109,11 +112,6 @@ class ProtectedMCPServer(MCPServer):
                 agent_id=agent.agent_id,
                 tool_name=parsed.name,
             )
-
-        if self._auth_config.enforce_grants:
-            grant_error = self._check_capability_grant(parsed, verify_result)
-            if grant_error is not None:
-                return grant_error
 
         return await super()._handle_tools_call(params)
 
@@ -123,7 +121,11 @@ class ProtectedMCPServer(MCPServer):
         verify_result: JwtVerifyResult,
     ) -> dict[str, Any] | None:
         """Return a ``tools/call`` error result when grant enforcement fails."""
-        capability = resolve_capability(parsed.name, self._auth_config)
+        capability = resolve_capability(
+            parsed.name,
+            self._auth_config,
+            bridge_tool_capability_map=self._bridge_tool_capabilities,
+        )
         claims = verify_result.claims or {}
         jwt_capabilities = claims.get(CAPABILITIES_CLAIM)
         if not isinstance(jwt_capabilities, list) or capability not in jwt_capabilities:
@@ -161,7 +163,11 @@ def _validate_tools_at_startup(protected: ProtectedMCPServer) -> None:
     config = protected._auth_config
     registry = config.capability_registry
     for tool_name in protected._tools:
-        capability = resolve_capability(tool_name, config)
+        capability = resolve_capability(
+            tool_name,
+            config,
+            bridge_tool_capability_map=protected._bridge_tool_capabilities,
+        )
         if not capability or not capability.strip():
             raise ValueError(
                 f"Tool {tool_name!r} resolves to empty capability name; "

--- a/src/asap/adapters/mcp/protected_server.py
+++ b/src/asap/adapters/mcp/protected_server.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from asap.adapters.mcp.auth_middleware import MCPAuthConfig, resolve_jwt_extractor
-from asap.adapters.mcp.errors import AUTH_REQUIRED, INVALID_TOKEN, tool_error_result
-from asap.auth.agent_jwt import verify_agent_jwt
+from asap.adapters.mcp.capability_map import format_constraint_violations, resolve_capability
+from asap.adapters.mcp.errors import (
+    AUTH_REQUIRED,
+    CAPABILITY_DENIED,
+    CONSTRAINT_VIOLATION,
+    INVALID_TOKEN,
+    tool_error_result,
+)
+from asap.auth.agent_jwt import CAPABILITIES_CLAIM, JwtVerifyResult, verify_agent_jwt
 from asap.mcp.protocol import CallToolRequestParams
 from asap.mcp.server import MCPServer
 from asap.observability import get_logger
@@ -15,12 +23,18 @@ logger = get_logger(__name__)
 
 
 class ProtectedMCPServer(MCPServer):
-    """``MCPServer`` with JWT verification on ``tools/call`` before tool handlers run."""
+    """``MCPServer`` with JWT verification on ``tools/call`` before tool handlers run.
+
+    ``tools/list`` is unchanged unless ``hide_unauthorized_tools`` is implemented;
+    MCP-MAP-004 is deferred (design-lock §6 — no stdio JWT carriage on list).
+    """
 
     def __init__(self, config: MCPAuthConfig) -> None:
         super().__init__()
         self._auth_config = config
         self._jwt_extractor = resolve_jwt_extractor(config)
+        self._bridge_tool_capabilities: dict[str, str] = {}
+        self._startup_tools_validated = False
 
     @classmethod
     def from_server(cls, server: MCPServer, config: MCPAuthConfig) -> ProtectedMCPServer:
@@ -29,10 +43,42 @@ class ProtectedMCPServer(MCPServer):
         protected._server_info = server._server_info
         protected._instructions = server._instructions
         protected._tools = dict(server._tools)
+
+        bridge_caps = getattr(server, "_bridge_tool_capabilities", None)
+        if isinstance(bridge_caps, dict) and bridge_caps:
+            protected._bridge_tool_capabilities = dict(bridge_caps)
+            config.bridge_tool_capability_map.update(bridge_caps)
+
+        if config.validate_tools_at_startup:
+            _validate_tools_at_startup(protected)
+            protected._startup_tools_validated = True
+
         return protected
 
+    def register_tool(
+        self,
+        name: str,
+        func: Callable[..., Any],
+        schema: dict[str, Any],
+        *,
+        description: str = "",
+        title: str | None = None,
+        capability: str | None = None,
+    ) -> None:
+        """Register a tool with optional ASAP capability metadata (MCP-MAP-002)."""
+        super().register_tool(
+            name,
+            func,
+            schema,
+            description=description,
+            title=title,
+        )
+        if capability is not None:
+            self._bridge_tool_capabilities[name] = capability
+            self._auth_config.bridge_tool_capability_map[name] = capability
+
     async def _handle_tools_call(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Intercept ``tools/call`` for JWT extraction and verification (S1)."""
+        """Intercept ``tools/call`` for JWT extraction, verification, and grant checks."""
         try:
             parsed = CallToolRequestParams(**params)
         except Exception as e:
@@ -64,4 +110,65 @@ class ProtectedMCPServer(MCPServer):
                 tool_name=parsed.name,
             )
 
+        if self._auth_config.enforce_grants:
+            grant_error = self._check_capability_grant(parsed, verify_result)
+            if grant_error is not None:
+                return grant_error
+
         return await super()._handle_tools_call(params)
+
+    def _check_capability_grant(
+        self,
+        parsed: CallToolRequestParams,
+        verify_result: JwtVerifyResult,
+    ) -> dict[str, Any] | None:
+        """Return a ``tools/call`` error result when grant enforcement fails."""
+        capability = resolve_capability(parsed.name, self._auth_config)
+        claims = verify_result.claims or {}
+        jwt_capabilities = claims.get(CAPABILITIES_CLAIM)
+        if not isinstance(jwt_capabilities, list) or capability not in jwt_capabilities:
+            return tool_error_result(
+                CAPABILITY_DENIED,
+                f"JWT capabilities claim does not include {capability!r}",
+            )
+
+        agent = verify_result.agent
+        if agent is None:
+            return tool_error_result(CAPABILITY_DENIED, "missing agent identity for grant check")
+
+        grant_result = self._auth_config.capability_registry.check_grant(
+            agent.agent_id,
+            capability,
+            parsed.arguments or {},
+        )
+        if grant_result.allowed:
+            return None
+
+        if grant_result.violations:
+            return tool_error_result(
+                CONSTRAINT_VIOLATION,
+                format_constraint_violations(grant_result.violations),
+            )
+
+        return tool_error_result(
+            CAPABILITY_DENIED,
+            f"no active grant for capability {capability!r}",
+        )
+
+
+def _validate_tools_at_startup(protected: ProtectedMCPServer) -> None:
+    """Ensure every registered tool resolves to a known capability (MCP-MAP-003)."""
+    config = protected._auth_config
+    registry = config.capability_registry
+    for tool_name in protected._tools:
+        capability = resolve_capability(tool_name, config)
+        if not capability or not capability.strip():
+            raise ValueError(
+                f"Tool {tool_name!r} resolves to empty capability name; "
+                "set tool_capability_map or register-time capability metadata"
+            )
+        if registry.describe(capability) is None:
+            raise ValueError(
+                f"Tool {tool_name!r} resolves to unknown capability {capability!r} "
+                f"(not registered; describe returned None)"
+            )

--- a/tests/adapters/mcp/conftest.py
+++ b/tests/adapters/mcp/conftest.py
@@ -14,7 +14,12 @@ import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from asap.auth.agent_jwt import create_agent_jwt
-from asap.auth.capabilities import CapabilityRegistry
+from asap.auth.capabilities import (
+    CapabilityDefinition,
+    CapabilityGrant,
+    CapabilityRegistry,
+    GrantStatus,
+)
 from asap.auth.identity import (
     AgentSession,
     HostIdentity,
@@ -31,7 +36,16 @@ MCP_TEST_AUDIENCE = "urn:asap:agent:mcp-test"
 
 _ECHO_INPUT_SCHEMA: dict[str, Any] = {
     "type": "object",
-    "properties": {"message": {"type": "string"}},
+    "properties": {
+        "message": {"type": "string"},
+        "tokens": {"type": "integer"},
+    },
+    "additionalProperties": False,
+}
+
+_SEARCH_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"query": {"type": "string"}},
     "additionalProperties": False,
 }
 
@@ -106,6 +120,96 @@ def capability_registry() -> CapabilityRegistry:
 
 
 @pytest.fixture
+def seed_capability_definition() -> Callable[..., CapabilityDefinition]:
+    """Register a capability definition on a registry (S2 startup validation).
+
+    Example:
+        >>> cap = seed_capability_definition(registry, "echo", "Echo tool capability")
+    """
+
+    def _seed(
+        registry: CapabilityRegistry,
+        name: str,
+        description: str | None = None,
+    ) -> CapabilityDefinition:
+        definition = CapabilityDefinition(
+            name=name,
+            description=description or f"Test capability {name}",
+        )
+        registry.register(definition)
+        return definition
+
+    return _seed
+
+
+@pytest.fixture
+def register_capability(
+    capability_registry: CapabilityRegistry,
+) -> Callable[..., CapabilityDefinition]:
+    """Register a capability definition (``describe`` / startup validation).
+
+    Example:
+        >>> register_capability("echo", description="Echo tool capability")
+    """
+
+    def _register(
+        name: str,
+        *,
+        description: str = "Test capability",
+        input_schema: dict[str, Any] | None = None,
+        output_schema: dict[str, Any] | None = None,
+        location: str | None = None,
+    ) -> CapabilityDefinition:
+        definition = CapabilityDefinition(
+            name=name,
+            description=description,
+            input_schema=input_schema,
+            output_schema=output_schema,
+            location=location,
+        )
+        capability_registry.register(definition)
+        return definition
+
+    return _register
+
+
+@pytest.fixture
+def grant_capability(
+    capability_registry: CapabilityRegistry,
+) -> Callable[..., CapabilityGrant]:
+    """Seed an active grant for tests with ``enforce_grants=True``.
+
+    Example:
+        >>> grant_capability(agent_session.agent_id, "echo")
+        >>> grant_capability(
+        ...     agent_session.agent_id,
+        ...     "echo",
+        ...     constraints={"tokens": {"max": 100}},
+        ... )
+    """
+
+    def _grant(
+        agent_id: str,
+        capability: str,
+        *,
+        constraints: dict[str, Any] | None = None,
+        status: GrantStatus = "active",
+        reason: str | None = None,
+        granted_by: str | None = None,
+    ) -> CapabilityGrant:
+        return capability_registry.grant(
+            agent_id,
+            capability,
+            constraints=constraints,
+            status=status,
+            reason=reason,
+            granted_by=granted_by,
+        )
+
+    return _grant
+
+
+@pytest.fixture
 def mint_agent_jwt(
     host_sk: Ed25519PrivateKey,
     agent_sk: Ed25519PrivateKey,
@@ -143,8 +247,21 @@ def echo_mcp_server() -> MCPServer:
     server = MCPServer(name="mcp-auth-test", version="0.1.0")
     server.register_tool(
         "echo",
-        lambda message="": message,
+        lambda message="", tokens=0: message,
         _ECHO_INPUT_SCHEMA,
         description="Echo input message",
+    )
+    return server
+
+
+@pytest.fixture
+def search_mcp_server() -> MCPServer:
+    """Minimal MCP server with a ``search`` tool for capability-map tests."""
+    server = MCPServer(name="mcp-auth-test", version="0.1.0")
+    server.register_tool(
+        "search",
+        lambda query="": query,
+        _SEARCH_INPUT_SCHEMA,
+        description="Search the web",
     )
     return server

--- a/tests/adapters/mcp/test_auth_middleware.py
+++ b/tests/adapters/mcp/test_auth_middleware.py
@@ -11,8 +11,14 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from asap.adapters.mcp.auth_middleware import MCPAuthConfig, protect_server
-from asap.adapters.mcp.errors import AUTH_REQUIRED, INVALID_TOKEN
-from asap.auth.capabilities import CapabilityRegistry
+from asap.adapters.mcp.capability_map import resolve_capability
+from asap.adapters.mcp.errors import (
+    AUTH_REQUIRED,
+    CAPABILITY_DENIED,
+    CONSTRAINT_VIOLATION,
+    INVALID_TOKEN,
+)
+from asap.auth.capabilities import CapabilityDefinition, CapabilityGrant, CapabilityRegistry
 from asap.auth.identity import (
     AgentSession,
     HostIdentity,
@@ -48,15 +54,30 @@ def _build_auth_config(
     capability_registry: CapabilityRegistry,
     *,
     public_tools: frozenset[str] = frozenset(),
+    enforce_grants: bool = False,
 ) -> MCPAuthConfig:
-    """MCP auth config for S1 tests (JWT gate only; grants deferred to S2)."""
+    """MCP auth config for middleware tests."""
     return MCPAuthConfig(
         host_store=host_store,
         agent_store=agent_store,
         capability_registry=capability_registry,
         public_tools=public_tools,
-        enforce_grants=False,
+        enforce_grants=enforce_grants,
         expected_audience=MCP_TEST_AUDIENCE,
+    )
+
+
+def _build_grant_auth_config(
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+) -> MCPAuthConfig:
+    """MCP auth config with grant enforcement enabled (S2)."""
+    return _build_auth_config(
+        host_store,
+        agent_store,
+        capability_registry,
+        enforce_grants=True,
     )
 
 
@@ -293,3 +314,327 @@ async def test_dispatch_tools_call_enforces_auth(
     assert "result" in data
     assert data["result"]["isError"] is True
     assert AUTH_REQUIRED in data["result"]["content"][0]["text"]
+
+
+# --- S2 capability mapping (1.2) & startup validation (1.3); Agent D: green when impl lands ---
+
+_BRIDGE_TOOL_CAPABILITIES_ATTR = "_bridge_tool_capabilities"
+
+
+def _s2_auth_config(
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    **kwargs: object,
+) -> MCPAuthConfig:
+    """MCP auth config for S2 mapping/validation tests (no grant enforcement)."""
+    return MCPAuthConfig(
+        host_store=host_store,
+        agent_store=agent_store,
+        capability_registry=capability_registry,
+        enforce_grants=False,
+        expected_audience=MCP_TEST_AUDIENCE,
+        **kwargs,
+    )
+
+
+def test_protect_server_honors_register_time_capability_metadata(
+    search_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    register_capability: Callable[..., CapabilityDefinition],
+) -> None:
+    """Bridge registry from register-time metadata is used when config map is empty."""
+    # Agent D: green when 1.2 impl lands
+    register_capability("web_search", description="Web search capability")
+    setattr(
+        search_mcp_server,
+        _BRIDGE_TOOL_CAPABILITIES_ATTR,
+        {"search": "web_search"},
+    )
+    config = _s2_auth_config(
+        host_store,
+        agent_store,
+        capability_registry,
+        validate_tools_at_startup=True,
+    )
+    protected = protect_server(search_mcp_server, config)
+    assert getattr(protected, "_startup_tools_validated", False) is True
+    assert resolve_capability("search", config) == "web_search"
+
+
+def test_config_tool_capability_map_overrides_register_time_metadata(
+    search_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    register_capability: Callable[..., CapabilityDefinition],
+) -> None:
+    """Runtime ``tool_capability_map`` overrides register-time bridge metadata."""
+    # Agent D: green when 1.2 impl lands
+    register_capability("custom_search", description="Custom search capability")
+    setattr(
+        search_mcp_server,
+        _BRIDGE_TOOL_CAPABILITIES_ATTR,
+        {"search": "web_search"},
+    )
+    config = _s2_auth_config(
+        host_store,
+        agent_store,
+        capability_registry,
+        tool_capability_map={"search": "custom_search"},
+        validate_tools_at_startup=True,
+    )
+    protected = protect_server(search_mcp_server, config)
+    assert getattr(protected, "_startup_tools_validated", False) is True
+    assert resolve_capability("search", config) == "custom_search"
+
+
+def test_validate_tools_at_startup_fails_on_empty_resolved_capability(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    register_capability: Callable[..., CapabilityDefinition],
+) -> None:
+    """Startup validation rejects tools that resolve to an empty capability name."""
+    # Agent D: green when 1.3 impl lands
+    register_capability("echo", description="Echo capability")
+    config = _s2_auth_config(
+        host_store,
+        agent_store,
+        capability_registry,
+        tool_capability_map={"echo": ""},
+        validate_tools_at_startup=True,
+    )
+    with pytest.raises(ValueError, match="empty capability|capability"):
+        protect_server(echo_mcp_server, config)
+
+
+def test_validate_tools_at_startup_fails_on_unknown_capability(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+) -> None:
+    """Startup validation rejects tools whose resolved capability is not in the registry."""
+    # Agent D: green when 1.3 impl lands
+    config = _s2_auth_config(
+        host_store,
+        agent_store,
+        capability_registry,
+        validate_tools_at_startup=True,
+    )
+    assert capability_registry.describe("echo") is None
+    with pytest.raises(ValueError, match="unknown capability|not registered|describe"):
+        protect_server(echo_mcp_server, config)
+
+
+def test_validate_tools_at_startup_succeeds_with_registered_capability(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    register_capability: Callable[..., CapabilityDefinition],
+) -> None:
+    """Startup validation passes when every tool resolves to a known capability."""
+    # Agent D: green when 1.3 impl lands
+    register_capability("echo", description="Echo tool capability")
+    config = _s2_auth_config(
+        host_store,
+        agent_store,
+        capability_registry,
+        validate_tools_at_startup=True,
+    )
+    protected = protect_server(echo_mcp_server, config)
+    assert protected is not None
+    assert getattr(protected, "_startup_tools_validated", False) is True
+
+
+def test_validate_tools_at_startup_succeeds_with_explicit_capability_map(
+    search_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    register_capability: Callable[..., CapabilityDefinition],
+) -> None:
+    """Startup validation passes when mapped capability exists in the registry."""
+    # Agent D: green when 1.3 impl lands
+    register_capability("web_search", description="Web search capability")
+    config = _s2_auth_config(
+        host_store,
+        agent_store,
+        capability_registry,
+        tool_capability_map={"search": "web_search"},
+        validate_tools_at_startup=True,
+    )
+    protected = protect_server(search_mcp_server, config)
+    assert protected is not None
+    assert getattr(protected, "_startup_tools_validated", False) is True
+    assert capability_registry.describe("web_search") is not None
+
+
+# --- S2 grant enforcement (2.1, 2.2) ---
+
+
+@pytest.mark.asyncio
+async def test_denied_grant_returns_capability_denied(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+    register_capability: Callable[..., CapabilityDefinition],
+) -> None:
+    """Valid JWT without registry grant returns ``asap:capability_denied``."""
+    register_capability("echo", description="Echo tool capability")
+    token = mint_agent_jwt(capabilities=["echo"])
+    config = _build_grant_auth_config(host_store, agent_store, capability_registry)
+    protected = protect_server(echo_mcp_server, config)
+    result = await protected._handle_tools_call(
+        _tool_call_params("echo", arguments={"message": "hi"}, jwt=token)
+    )
+    assert CAPABILITY_DENIED in _error_text(result)
+
+
+@pytest.mark.asyncio
+async def test_jwt_capability_claim_mismatch_returns_capability_denied(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+    register_capability: Callable[..., CapabilityDefinition],
+    grant_capability: Callable[..., CapabilityGrant],
+) -> None:
+    """Active grant but JWT missing capability claim returns ``asap:capability_denied``."""
+    register_capability("echo", description="Echo tool capability")
+    grant_capability(agent_session.agent_id, "echo")
+    token = mint_agent_jwt()
+    config = _build_grant_auth_config(host_store, agent_store, capability_registry)
+    protected = protect_server(echo_mcp_server, config)
+    result = await protected._handle_tools_call(
+        _tool_call_params("echo", arguments={"message": "hi"}, jwt=token)
+    )
+    assert CAPABILITY_DENIED in _error_text(result)
+
+
+@pytest.mark.asyncio
+async def test_grant_and_jwt_capability_succeeds(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+    register_capability: Callable[..., CapabilityDefinition],
+    grant_capability: Callable[..., CapabilityGrant],
+) -> None:
+    """Active grant and matching JWT capability claim invoke the handler."""
+    register_capability("echo", description="Echo tool capability")
+    grant_capability(agent_session.agent_id, "echo")
+    token = mint_agent_jwt(capabilities=["echo"])
+    config = _build_grant_auth_config(host_store, agent_store, capability_registry)
+    protected = protect_server(echo_mcp_server, config)
+    result = await protected._handle_tools_call(
+        _tool_call_params("echo", arguments={"message": "granted"}, jwt=token)
+    )
+    assert result["isError"] is False
+    assert result["content"][0]["text"] == "granted"
+
+
+@pytest.mark.asyncio
+async def test_constraint_violation_returns_constraint_violation(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+    register_capability: Callable[..., CapabilityDefinition],
+    grant_capability: Callable[..., CapabilityGrant],
+) -> None:
+    """Arguments exceeding grant ``max`` constraint return ``asap:constraint_violation``."""
+    register_capability("echo", description="Echo tool capability")
+    grant_capability(
+        agent_session.agent_id,
+        "echo",
+        constraints={"tokens": {"max": 100}},
+    )
+    token = mint_agent_jwt(capabilities=["echo"])
+    config = _build_grant_auth_config(host_store, agent_store, capability_registry)
+    protected = protect_server(echo_mcp_server, config)
+    result = await protected._handle_tools_call(
+        _tool_call_params(
+            "echo",
+            arguments={"message": "hi", "tokens": 150},
+            jwt=token,
+        )
+    )
+    assert CONSTRAINT_VIOLATION in _error_text(result)
+
+
+# --- S2 optional tools/list filtering (3.1) — MCP-MAP-004 deferred per design-lock §6 ---
+
+
+def test_hide_unauthorized_tools_default_leaves_tools_list_unchanged(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+) -> None:
+    """Default ``hide_unauthorized_tools=False`` lists all registered tools unchanged."""
+    config = _build_auth_config(host_store, agent_store, capability_registry)
+    assert config.hide_unauthorized_tools is False
+    protected = protect_server(echo_mcp_server, config)
+    result = protected._handle_tools_list(None)
+    tool_names = {tool["name"] for tool in result["tools"]}
+    assert tool_names == set(echo_mcp_server._tools.keys())
+
+
+@pytest.mark.skip(
+    reason="MCP-MAP-004 deferred: stdio tools/list lacks JWT carriage — see design-lock §6"
+)
+@pytest.mark.asyncio
+async def test_hide_unauthorized_tools_filters_unauthorized_when_enabled(
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+    register_capability: Callable[..., CapabilityDefinition],
+    grant_capability: Callable[..., CapabilityGrant],
+) -> None:
+    """Document expected MCP-MAP-004 behavior if ``hide_unauthorized_tools`` is implemented.
+
+    When stdio ``tools/list`` can carry an Agent JWT (transport TBD), enabling
+    ``hide_unauthorized_tools`` should return only tools the caller may invoke:
+    ``public_tools``, tools with an active grant, and a matching JWT
+    ``capabilities`` claim. Unauthorized tools must be omitted from the list.
+    """
+    register_capability("echo", description="Echo tool capability")
+    grant_capability(agent_session.agent_id, "echo")
+    token = mint_agent_jwt(capabilities=["echo"])
+    config = MCPAuthConfig(
+        host_store=host_store,
+        agent_store=agent_store,
+        capability_registry=capability_registry,
+        enforce_grants=True,
+        hide_unauthorized_tools=True,
+        expected_audience=MCP_TEST_AUDIENCE,
+    )
+    protected = protect_server(echo_mcp_server, config)
+    # Future: pass JWT via list-request context once stdio carriage is defined.
+    _ = token
+    result = protected._handle_tools_list(None)
+    tool_names = {tool["name"] for tool in result["tools"]}
+    assert tool_names == {"echo"}

--- a/tests/adapters/mcp/test_auth_middleware.py
+++ b/tests/adapters/mcp/test_auth_middleware.py
@@ -55,6 +55,7 @@ def _build_auth_config(
     *,
     public_tools: frozenset[str] = frozenset(),
     enforce_grants: bool = False,
+    **kwargs: object,
 ) -> MCPAuthConfig:
     """MCP auth config for middleware tests."""
     return MCPAuthConfig(
@@ -64,6 +65,7 @@ def _build_auth_config(
         public_tools=public_tools,
         enforce_grants=enforce_grants,
         expected_audience=MCP_TEST_AUDIENCE,
+        **kwargs,
     )
 
 
@@ -71,6 +73,7 @@ def _build_grant_auth_config(
     host_store: InMemoryHostStore,
     agent_store: InMemoryAgentStore,
     capability_registry: CapabilityRegistry,
+    **kwargs: object,
 ) -> MCPAuthConfig:
     """MCP auth config with grant enforcement enabled (S2)."""
     return _build_auth_config(
@@ -78,6 +81,7 @@ def _build_grant_auth_config(
         agent_store,
         capability_registry,
         enforce_grants=True,
+        **kwargs,
     )
 
 
@@ -361,7 +365,14 @@ def test_protect_server_honors_register_time_capability_metadata(
     )
     protected = protect_server(search_mcp_server, config)
     assert getattr(protected, "_startup_tools_validated", False) is True
-    assert resolve_capability("search", config) == "web_search"
+    assert (
+        resolve_capability(
+            "search",
+            config,
+            bridge_tool_capability_map=protected._bridge_tool_capabilities,
+        )
+        == "web_search"
+    )
 
 
 def test_config_tool_capability_map_overrides_register_time_metadata(
@@ -389,6 +400,38 @@ def test_config_tool_capability_map_overrides_register_time_metadata(
     protected = protect_server(search_mcp_server, config)
     assert getattr(protected, "_startup_tools_validated", False) is True
     assert resolve_capability("search", config) == "custom_search"
+
+
+def test_protected_register_tool_stores_capability_metadata(
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    register_capability: Callable[..., CapabilityDefinition],
+) -> None:
+    """``ProtectedMCPServer.register_tool(..., capability=...)`` records bridge metadata."""
+    register_capability("web_search", description="Web search capability")
+    config = _s2_auth_config(
+        host_store,
+        agent_store,
+        capability_registry,
+        validate_tools_at_startup=True,
+    )
+    protected = protect_server(MCPServer(name="register-test", version="0.1.0"), config)
+    protected.register_tool(
+        "search",
+        lambda query="": query,
+        {"type": "object", "properties": {"query": {"type": "string"}}},
+        capability="web_search",
+    )
+    assert protected._bridge_tool_capabilities["search"] == "web_search"
+    assert (
+        resolve_capability(
+            "search",
+            config,
+            bridge_tool_capability_map=protected._bridge_tool_capabilities,
+        )
+        == "web_search"
+    )
 
 
 def test_validate_tools_at_startup_fails_on_empty_resolved_capability(
@@ -579,6 +622,70 @@ async def test_constraint_violation_returns_constraint_violation(
         )
     )
     assert CONSTRAINT_VIOLATION in _error_text(result)
+
+
+@pytest.mark.asyncio
+async def test_tool_capability_map_checks_resolved_capability_in_jwt(
+    search_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+    register_capability: Callable[..., CapabilityDefinition],
+    grant_capability: Callable[..., CapabilityGrant],
+) -> None:
+    """JWT ``capabilities`` claim must include the resolved capability name, not the tool name."""
+    register_capability("web_search", description="Web search capability")
+    grant_capability(agent_session.agent_id, "web_search")
+    config = _build_grant_auth_config(
+        host_store,
+        agent_store,
+        capability_registry,
+        tool_capability_map={"search": "web_search"},
+    )
+    protected = protect_server(search_mcp_server, config)
+
+    wrong_claim = mint_agent_jwt(capabilities=["search"])
+    denied = await protected._handle_tools_call(
+        _tool_call_params("search", arguments={"query": "hi"}, jwt=wrong_claim)
+    )
+    assert CAPABILITY_DENIED in _error_text(denied)
+
+    correct_claim = mint_agent_jwt(capabilities=["web_search"])
+    allowed = await protected._handle_tools_call(
+        _tool_call_params("search", arguments={"query": "ok"}, jwt=correct_claim)
+    )
+    assert allowed["isError"] is False
+    assert allowed["content"][0]["text"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_denied_grant_does_not_log_authorized(
+    caplog: LogCaptureFixture,
+    echo_mcp_server: MCPServer,
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+    register_capability: Callable[..., CapabilityDefinition],
+) -> None:
+    """Failed grant enforcement must not emit ``mcp.tool.authorized``."""
+    register_capability("echo", description="Echo tool capability")
+    token = mint_agent_jwt(capabilities=["echo"])
+    config = _build_grant_auth_config(host_store, agent_store, capability_registry)
+    protected = protect_server(echo_mcp_server, config)
+
+    with caplog.at_level(logging.INFO):
+        result = await protected._handle_tools_call(
+            _tool_call_params("echo", arguments={"message": "hi"}, jwt=token)
+        )
+
+    assert CAPABILITY_DENIED in _error_text(result)
+    assert "mcp.tool.authorized" not in caplog.text
 
 
 # --- S2 optional tools/list filtering (3.1) — MCP-MAP-004 deferred per design-lock §6 ---

--- a/tests/adapters/mcp/test_capability_map.py
+++ b/tests/adapters/mcp/test_capability_map.py
@@ -1,0 +1,63 @@
+"""Unit tests for resolve_capability (MCP-MAP-001)."""
+
+from __future__ import annotations
+
+from asap.adapters.mcp.auth_middleware import MCPAuthConfig
+from asap.adapters.mcp.capability_map import resolve_capability
+from asap.auth.capabilities import CapabilityRegistry
+from asap.auth.identity import InMemoryAgentStore, InMemoryHostStore
+
+
+def _minimal_config(**kwargs: object) -> MCPAuthConfig:
+    agents = InMemoryAgentStore()
+    return MCPAuthConfig(
+        host_store=InMemoryHostStore(agent_store=agents),
+        agent_store=agents,
+        capability_registry=CapabilityRegistry(),
+        **kwargs,
+    )
+
+
+def test_resolve_capability_default_identity() -> None:
+    """Tool not in map resolves to the tool name (identity default)."""
+    config = _minimal_config()
+    assert resolve_capability("echo", config) == "echo"
+
+
+def test_resolve_capability_explicit_map_override() -> None:
+    """Explicit tool_capability_map entry overrides identity default."""
+    config = _minimal_config(tool_capability_map={"search": "web_search"})
+    assert resolve_capability("search", config) == "web_search"
+    assert resolve_capability("other", config) == "other"
+
+
+def test_resolve_capability_empty_map_uses_identity() -> None:
+    """Empty tool_capability_map still uses identity default."""
+    config = _minimal_config(tool_capability_map={})
+    assert resolve_capability("read_file", config) == "read_file"
+
+
+# --- S2 bridge registry precedence (MCP-MAP-002); Agent D: green when 1.2 impl lands ---
+
+
+def test_resolve_capability_uses_bridge_registry_when_config_map_empty() -> None:
+    """Register-time bridge metadata resolves when config map has no entry."""
+    config = _minimal_config()
+    # Agent D: ``from_server`` populates bridge metadata on config after MCP-MAP-002.
+    object.__setattr__(
+        config,
+        "bridge_tool_capability_map",
+        {"search": "web_search"},
+    )
+    assert resolve_capability("search", config) == "web_search"
+
+
+def test_resolve_capability_config_map_overrides_bridge_registry() -> None:
+    """Explicit ``tool_capability_map`` wins over register-time bridge metadata."""
+    config = _minimal_config(tool_capability_map={"search": "custom_search"})
+    object.__setattr__(
+        config,
+        "bridge_tool_capability_map",
+        {"search": "web_search"},
+    )
+    assert resolve_capability("search", config) == "custom_search"

--- a/tests/adapters/mcp/test_capability_map.py
+++ b/tests/adapters/mcp/test_capability_map.py
@@ -43,21 +43,24 @@ def test_resolve_capability_empty_map_uses_identity() -> None:
 def test_resolve_capability_uses_bridge_registry_when_config_map_empty() -> None:
     """Register-time bridge metadata resolves when config map has no entry."""
     config = _minimal_config()
-    # Agent D: ``from_server`` populates bridge metadata on config after MCP-MAP-002.
-    object.__setattr__(
-        config,
-        "bridge_tool_capability_map",
-        {"search": "web_search"},
+    assert (
+        resolve_capability(
+            "search",
+            config,
+            bridge_tool_capability_map={"search": "web_search"},
+        )
+        == "web_search"
     )
-    assert resolve_capability("search", config) == "web_search"
 
 
 def test_resolve_capability_config_map_overrides_bridge_registry() -> None:
     """Explicit ``tool_capability_map`` wins over register-time bridge metadata."""
     config = _minimal_config(tool_capability_map={"search": "custom_search"})
-    object.__setattr__(
-        config,
-        "bridge_tool_capability_map",
-        {"search": "web_search"},
+    assert (
+        resolve_capability(
+            "search",
+            config,
+            bridge_tool_capability_map={"search": "web_search"},
+        )
+        == "custom_search"
     )
-    assert resolve_capability("search", config) == "custom_search"


### PR DESCRIPTION
## Summary

- Add `resolve_capability` with resolution order: `tool_capability_map` → bridge register-time metadata → identity default (MCP-MAP-001/002)
- Wire grant enforcement on `tools/call`: JWT `capabilities` claim + `CapabilityRegistry.check_grant` with constraint violation formatting (MCP-AUTH-003, PRD §4.5)
- Add optional startup validation when `validate_tools_at_startup=True` (MCP-MAP-003)
- Defer MCP-MAP-004 `hide_unauthorized_tools` per design lock §6 (default-off test + skipped future contract test)

## Test plan

- [x] `uv run ruff check .` and `uv run ruff format --check .`
- [x] `uv run mypy src/ scripts/ tests/`
- [x] `uv run pytest tests/adapters/mcp/ --cov=asap.adapters.mcp --cov-fail-under=90` — 38 passed, 1 skipped, 93.69% coverage
- [x] S1 auth middleware tests remain green
- [ ] CI green on `release/2.5.0`