### PR TITLE
feat(v2.5.0): S3 MCP auth bridge docs, example and discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ For coverage and pre-push gates, see [`.cursor/README.md`](.cursor/README.md#can
 - **Arch Decisions (ADRs)**: `product/decision-records/`
 - **Documentation checkpoints** (post-release PRD follow-up): `product/checkpoints.md`
 - **Tech Stack**: `engineering/architecture/tech-stack-decisions.md`
+- **MCP Auth Bridge**: `asap.adapters.mcp` (`protect_server`, `MCPAuthConfig`) — [docs/adapters/mcp-auth-bridge.md](docs/adapters/mcp-auth-bridge.md)
 
 ### 2. Development Status
 - **Active Sprint**: `engineering/tasks/`
@@ -60,6 +61,7 @@ For coverage and pre-push gates, see [`.cursor/README.md`](.cursor/README.md#can
 ### Project Structure
 ```text
 src/asap/
+├── adapters/      # Third-party wire adapters (OpenAPI, MCP auth bridge)
 ├── models/        # Data models (Envelope, TaskRequest, TaskStream)
 ├── auth/          # OAuth2/OIDC, Agent Identity, Capabilities, Approval
 ├── transport/     # HTTP Client/Server, WebSocket, SSE Streaming

--- a/docs/adapters/mcp-auth-bridge.md
+++ b/docs/adapters/mcp-auth-bridge.md
@@ -1,0 +1,342 @@
+# MCP Auth Bridge adapter (Python)
+
+The `asap.adapters.mcp` package adds **opt-in** Agent JWT and capability enforcement to a native **stdio MCP** server (`MCPServer`). Call `protect_server` to wrap an existing server without forking the JSON-RPC protocol loop (Mode A).
+
+**Default behavior:** Unprotected `MCPServer` usage remains valid. Protection is explicit (MCP-DOC-004).
+
+**Out of scope (v2.5.0):** An `initialize` session-token handshake is **deferred** per the [design lock](../../engineering/tasks/v2.5.0/design-lock-mcp-auth-bridge.md) — not shipped in this release. Clients must pass the Agent JWT on each protected `tools/call` via `_meta.asap_agent_jwt`.
+
+For MCP-over-ASAP envelopes (Mode B), see [MCP integration](../mcp-integration.md).
+
+## Architecture
+
+```text
+stdio MCP client
+        │
+        ▼
+  tools/call params
+        │
+        ▼
+  CallToolRequestParams (incl. _meta)
+        │
+        ▼
+  resolve_jwt_extractor(config)
+        │  reads params.meta["asap_agent_jwt"]
+        │  (optional dev-only ASAP_AGENT_JWT when allow_env_jwt_fallback=True)
+        ▼
+  missing token? ──► CallToolResult isError + asap:auth_required
+        │              (skipped for public_tools)
+        ▼
+  verify_agent_jwt(host_store, agent_store, jti_cache, audience)
+        │
+        ▼
+  invalid? ──► asap:invalid_token
+        │
+        ▼
+  resolve_capability(tool_name, config)
+        │  tool_capability_map → bridge metadata → identity (tool name)
+        ▼
+  capability_registry.check_grant(agent_id, capability, arguments)
+        │
+        ▼
+  denied / constraint fail? ──► asap:capability_denied / asap:constraint_violation
+        │
+        ▼
+  MCPServer._handle_tools_call  ──► schema validate + tool handler
+```
+
+- **Single interception point:** `ProtectedMCPServer` overrides `_handle_tools_call` only; `serve_stdio`, `_dispatch_request`, and notification handling are unchanged (MCP-AUTH-006).
+- **No mutation:** `protect_server` returns a new server instance; the input `MCPServer` is not modified.
+- **Shared grant store:** Use the same `CapabilityRegistry` as your A2A HTTP surface — there is no parallel MCP-specific grant database in v2.5.0.
+- **`tools/list`:** Unchanged by default. Filtering unauthorized tools (`hide_unauthorized_tools`) is deferred (MCP-MAP-004) because stdio `tools/list` has no standard JWT carriage today.
+
+## Quick usage
+
+Wire identity stores, register capabilities and grants, register MCP tools, then wrap with `protect_server`:
+
+```python
+import asyncio
+from datetime import datetime, timezone
+
+from asap.adapters.mcp import MCPAuthConfig, protect_server
+from asap.auth.capabilities import (
+    CapabilityDefinition,
+    CapabilityGrant,
+    CapabilityRegistry,
+    GrantStatus,
+)
+from asap.auth.identity import InMemoryAgentStore, InMemoryHostStore
+from asap.mcp.server import MCPServer
+
+
+async def echo(message: str) -> dict[str, str]:
+    return {"message": message}
+
+
+async def secure_action(action: str) -> dict[str, str]:
+    return {"status": "ok", "action": action}
+
+
+async def main() -> None:
+    agent_store = InMemoryAgentStore()
+    host_store = InMemoryHostStore(agent_store=agent_store)
+    registry = CapabilityRegistry()
+
+    registry.register(
+        CapabilityDefinition(
+            name="secure_action",
+            description="Protected MCP tool",
+            input_schema={"type": "object", "properties": {"action": {"type": "string"}}},
+        )
+    )
+    now = datetime.now(timezone.utc)
+    registry.grant(
+        CapabilityGrant(
+            grant_id="demo-grant",
+            agent_id="urn:asap:agent:demo",
+            capability="secure_action",
+            status=GrantStatus.ACTIVE,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+
+    server = MCPServer()
+    server.register_tool(
+        "echo",
+        echo,
+        {"type": "object", "properties": {"message": {"type": "string"}}},
+        description="Public echo tool",
+    )
+    server.register_tool(
+        "secure_action",
+        secure_action,
+        {"type": "object", "properties": {"action": {"type": "string"}}},
+        description="Requires Agent JWT + grant",
+        capability="secure_action",
+    )
+
+    config = MCPAuthConfig(
+        host_store=host_store,
+        agent_store=agent_store,
+        capability_registry=registry,
+        public_tools=frozenset({"echo"}),
+        tool_capability_map={"secure_action": "secure_action"},
+    )
+    protected = protect_server(server, config)
+    await protected.run_stdio()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### Passing the Agent JWT
+
+Clients attach the token on each protected `tools/call` in MCP `_meta`:
+
+```json
+{
+  "name": "secure_action",
+  "arguments": {"action": "deploy"},
+  "_meta": {"asap_agent_jwt": "<Agent-JWT>"}
+}
+```
+
+The JWT must include the resolved capability in its `capabilities` claim and the agent must hold an active grant in `CapabilityRegistry`.
+
+### Dev-only environment fallback
+
+For single-agent local testing, set `allow_env_jwt_fallback=True` on `MCPAuthConfig` and export `ASAP_AGENT_JWT`. **Do not enable in production** — a process-wide token bypasses per-call auth intent.
+
+## Configuration reference
+
+### `MCPAuthConfig`
+
+| Field | Type | Default | Description |
+|:------|:-----|:--------|:------------|
+| `host_store` | `HostStore` | *(required)* | Host identity store for `verify_agent_jwt`. |
+| `agent_store` | `AgentStore` | *(required)* | Agent session store for `verify_agent_jwt`. |
+| `capability_registry` | `CapabilityRegistry` | *(required)* | Shared capability definitions and grants; used by `check_grant`. |
+| `tool_capability_map` | `dict[str, str]` | `{}` | Runtime override: MCP tool name → ASAP capability name (MCP-MAP-001). Checked first. |
+| `bridge_tool_capability_map` | `dict[str, str]` | `{}` | Fallback map copied from bridge registration metadata. |
+| `public_tools` | `frozenset[str]` | `frozenset()` | Tool names that skip JWT verification entirely. |
+| `enforce_grants` | `bool` | `True` | When `False`, JWT is verified but grant/constraint checks are skipped. |
+| `hide_unauthorized_tools` | `bool` | `False` | **Deferred (MAY).** Does not filter `tools/list` in v2.5.0. |
+| `validate_tools_at_startup` | `bool` | `False` | When `True`, `protect_server` fails fast if any registered tool resolves to an unknown capability (MCP-MAP-003). |
+| `jwt_extractor` | `Callable[[CallToolRequestParams], str \| None] \| None` | `None` | Custom JWT extractor; when `None`, middleware uses `resolve_jwt_extractor`. |
+| `allow_env_jwt_fallback` | `bool` | `False` | When `True`, read `ASAP_AGENT_JWT` if `_meta.asap_agent_jwt` is absent. **Dev only.** |
+| `jti_replay_cache` | `JtiReplayCache \| None` | `None` | Optional replay protection for JWT `jti` claims. |
+| `expected_audience` | `str \| list[str] \| None` | `None` | Expected JWT `aud` passed to `verify_agent_jwt`. |
+| `manifest_url` | `str \| None` | `None` | Optional HTTPS URL to the agent manifest for discovery alignment (see [Discovery](#discovery)). |
+
+### Functions
+
+| Function | Description |
+|:---------|:------------|
+| `protect_server(server, config)` | Return a `ProtectedMCPServer` that enforces auth on `tools/call`. Input server is not mutated. |
+| `resolve_jwt_extractor(config)` | Return the effective JWT extractor (custom `config.jwt_extractor` or `default_jwt_extractor` with `allow_env_jwt_fallback`). **Middleware must use this** — do not call a `None` extractor. |
+| `resolve_capability(tool_name, config, *, bridge_tool_capability_map=None)` | Resolve MCP tool name → ASAP capability. Order: `tool_capability_map` → bridge map → identity (`tool_name`). |
+| `default_jwt_extractor(params, *, allow_env_fallback=False)` | Read `params.meta["asap_agent_jwt"]`; optional `ASAP_AGENT_JWT` env when `allow_env_fallback=True`. |
+
+### Register-time capability metadata
+
+When registering tools on a `ProtectedMCPServer`, pass `capability=` to set per-tool mapping without editing `tool_capability_map`:
+
+```python
+protected.register_tool(
+    "search",
+    search_handler,
+    input_schema,
+    capability="web_search",
+)
+```
+
+Resolution still honors `tool_capability_map` overrides first.
+
+### Public exports
+
+```python
+from asap.adapters.mcp import MCPAuthConfig, protect_server, resolve_capability, resolve_jwt_extractor
+```
+
+Error constants: `AUTH_REQUIRED`, `INVALID_TOKEN`, `CAPABILITY_DENIED`, `CONSTRAINT_VIOLATION`.
+
+## Error codes
+
+Protected `tools/call` failures return a `CallToolResult` with `isError: true`. The text content uses ASAP-namespaced codes from `asap.adapters.mcp.errors`:
+
+| Code | When | Typical detail |
+|:-----|:-----|:---------------|
+| `asap:auth_required` | No JWT in `_meta.asap_agent_jwt` (and no dev env fallback) on a non-`public_tools` call | — |
+| `asap:invalid_token` | JWT signature, expiry, audience, replay, or identity validation failed | Verifier error message appended after `:` |
+| `asap:capability_denied` | JWT `capabilities` claim missing the resolved capability, or no active grant | e.g. `JWT capabilities claim does not include 'secure_action'` |
+| `asap:constraint_violation` | Grant exists but tool arguments fail constraint validation | Semicolon-joined violation messages |
+
+Unknown tool names and schema validation errors remain the inner `MCPServer` behavior (not rewritten to ASAP auth codes).
+
+Example error payload shape:
+
+```json
+{
+  "content": [{"type": "text", "text": "asap:auth_required"}],
+  "isError": true
+}
+```
+
+## Security notes
+
+- **Never log JWTs.** Middleware logs `agent_id` and `tool_name` on successful authorization only — not token material.
+- **`allow_env_jwt_fallback` is dev-only.** Defaults to `False` so production cannot inherit a process-wide `ASAP_AGENT_JWT`.
+- **Opt-in protection (MCP-DOC-004).** Existing unprotected MCP servers remain valid until operators call `protect_server`.
+- **Use `resolve_jwt_extractor`.** Custom extractors must not bypass verification; env fallback is gated by config.
+- **`public_tools` skip auth entirely.** A present `_meta.asap_agent_jwt` on a public tool is not verified — keep the public list minimal.
+- **Shared registry.** Register `CapabilityDefinition` rows and issue `CapabilityGrant` records before exposing protected tools; JWT `capabilities` and registry grants must align.
+- **Deferred `initialize` token (MCP-DOC-003).** Session tokens negotiated at MCP `initialize` are not implemented in v2.5.0; plan per-call `_meta` carriage or wait for a future release.
+
+## Discovery
+
+Operators may set `MCPAuthConfig.manifest_url` to the HTTPS URL where clients and registries fetch the agent's signed manifest. This does not auto-publish the manifest — it documents the canonical discovery endpoint for tooling that aligns MCP tool names with ASAP capability ids.
+
+### Aligning `skills[].id` with MCP tools
+
+Grant checks use **ASAP capability names**, not raw MCP tool names unless they are identical. Keep three surfaces consistent:
+
+1. **MCP tool name** — `tools/call` `name` and `tools/list` entries.
+2. **Resolved capability** — output of `resolve_capability` (`tool_capability_map`, register-time `capability=`, or identity default).
+3. **Manifest `skills[].id`** — advertised to A2A clients and registry flows.
+
+Example manifest excerpt for a protected MCP bridge (`echo` public, `secure_action` mapped 1:1):
+
+```json
+{
+  "id": "urn:asap:agent:mcp-auth-bridge-demo",
+  "name": "MCP Auth Bridge Demo",
+  "version": "1.0.0",
+  "description": "Native stdio MCP with ASAP capability grants",
+  "capabilities": {
+    "asap_version": "2.5",
+    "skills": [
+      {
+        "id": "echo",
+        "description": "Public echo tool (no JWT required)",
+        "input_schema": {
+          "type": "object",
+          "properties": {"message": {"type": "string"}},
+          "required": ["message"]
+        },
+        "output_schema": {"type": "object"}
+      },
+      {
+        "id": "secure_action",
+        "description": "Protected tool; requires Agent JWT + grant",
+        "input_schema": {
+          "type": "object",
+          "properties": {"action": {"type": "string"}},
+          "required": ["action"]
+        },
+        "output_schema": {"type": "object"}
+      }
+    ],
+    "state_persistence": false,
+    "streaming": false,
+    "mcp_tools": ["echo", "secure_action"]
+  },
+  "endpoints": {
+    "asap": "https://my-host.example/asap",
+    "events": null
+  }
+}
+```
+
+When tool names differ from capability ids, reflect the mapping in config and manifest:
+
+| MCP tool (`tools/call` name) | `tool_capability_map` | Manifest `skills[].id` |
+|:-----------------------------|:----------------------|:-----------------------|
+| `search` | `"search": "web_search"` | `web_search` |
+| `secure_action` | *(identity)* | `secure_action` |
+
+Set `manifest_url` to the published document, for example `https://my-host.example/.well-known/asap/manifest.json`.
+
+### Registry cross-links
+
+- [Lite Registry auto-registration](../registry/auto-registration.md) — `POST /registry/agents` with `manifest_url`; compliance harness validates the signed manifest before listing.
+- [Transport — manifest discovery](../transport.md#get-well-knownasapmanifestjson---discovery-endpoint) — canonical `/.well-known/asap/manifest.json` shape and `Skill` fields.
+- [Registry verification review](../guides/registry-verification-review.md) — separate path for the **Verified** badge (not auto-merge).
+
+Listing `capabilities.mcp_tools` in the manifest helps clients discover which skills are exposed via native MCP versus pure A2A `task.request` handlers.
+
+## Runnable example
+
+The repo includes `examples/mcp_auth_bridge/` with a protected stdio server (`echo` public, `secure_action` protected), grant seeding, and JWT minting instructions.
+
+```bash
+uv run python examples/mcp_auth_bridge/server.py --help
+```
+
+## Common pitfalls
+
+### Token carriage vs `initialize`
+
+Do not assume an MCP `initialize` handshake will deliver session tokens — that pattern is **deferred**. Clients must send `_meta.asap_agent_jwt` on each protected `tools/call`.
+
+### Capability name drift
+
+If `tool_capability_map` renames a tool to a different capability, update manifest `skills[].id`, JWT `capabilities` claims, and `CapabilityRegistry` grants together. Enable `validate_tools_at_startup=True` during development to catch unregistered capabilities early.
+
+### Public tool scope
+
+Any tool in `public_tools` is callable without authentication. Do not add sensitive tools to this set.
+
+### Mode A vs Mode B
+
+This adapter protects **native stdio `MCPServer`** (Mode A). MCP invoked inside ASAP envelopes (`mcp.tool_call` / Mode B) follows the HTTP server's existing auth — see [MCP integration](../mcp-integration.md).
+
+## Related documentation
+
+- [MCP integration](../mcp-integration.md) — Mode A vs Mode B, migration notes
+- [Security](../security.md) — Agent JWT, Host/Agent identity
+- [Self-authorization prevention](../security/self-authorization-prevention.md) — grants and approval flows
+- [Transport](../transport.md) — manifest discovery, `create_app`
+- [Design lock: MCP Auth Bridge](../../engineering/tasks/v2.5.0/design-lock-mcp-auth-bridge.md) — hook strategy, deferred features
+- [PRD v2.5.0 MCP Auth Bridge](https://github.com/adriannoes/asap-protocol/blob/main/product/prd/prd-v2.5.0-mcp-auth-bridge.md) — MCP-AUTH-* / MCP-DISC-* requirements

--- a/docs/adapters/mcp-auth-bridge.md
+++ b/docs/adapters/mcp-auth-bridge.md
@@ -172,12 +172,12 @@ For single-agent local testing, set `allow_env_jwt_fallback=True` on `MCPAuthCon
 
 ### Functions
 
-| Function | Description |
-|:---------|:------------|
-| `protect_server(server, config)` | Return a `ProtectedMCPServer` that enforces auth on `tools/call`. Input server is not mutated. |
-| `resolve_jwt_extractor(config)` | Return the effective JWT extractor (custom `config.jwt_extractor` or `default_jwt_extractor` with `allow_env_jwt_fallback`). **Middleware must use this** — do not call a `None` extractor. |
-| `resolve_capability(tool_name, config, *, bridge_tool_capability_map=None)` | Resolve MCP tool name → ASAP capability. Order: `tool_capability_map` → bridge map → identity (`tool_name`). |
-| `default_jwt_extractor(params, *, allow_env_fallback=False)` | Read `params.meta["asap_agent_jwt"]`; optional `ASAP_AGENT_JWT` env when `allow_env_fallback=True`. |
+| Function | Module | Description |
+|:---------|:-------|:------------|
+| `protect_server(server, config)` | `asap.adapters.mcp` | Return a `ProtectedMCPServer` that enforces auth on `tools/call`. Input server is not mutated. |
+| `resolve_jwt_extractor(config)` | `asap.adapters.mcp.auth_middleware` | Return the effective JWT extractor (custom `config.jwt_extractor` or `default_jwt_extractor` with `allow_env_jwt_fallback`). **Middleware must use this** — do not call a `None` extractor. |
+| `resolve_capability(tool_name, config, *, bridge_tool_capability_map=None)` | `asap.adapters.mcp.capability_map` | Resolve MCP tool name → ASAP capability. Order: `tool_capability_map` → bridge map → identity (`tool_name`). |
+| `default_jwt_extractor(params, *, allow_env_fallback=False)` | `asap.adapters.mcp.jwt_extractor` | Read `params.meta["asap_agent_jwt"]`; optional `ASAP_AGENT_JWT` env when `allow_env_fallback=True`. |
 
 ### Register-time capability metadata
 
@@ -196,11 +196,24 @@ Resolution still honors `tool_capability_map` overrides first.
 
 ### Public exports
 
+Package root (`asap.adapters.mcp`) intentionally exposes only the primary integration surface:
+
 ```python
-from asap.adapters.mcp import MCPAuthConfig, protect_server, resolve_capability, resolve_jwt_extractor
+from asap.adapters.mcp import MCPAuthConfig, protect_server
 ```
 
-Error constants: `AUTH_REQUIRED`, `INVALID_TOKEN`, `CAPABILITY_DENIED`, `CONSTRAINT_VIOLATION`.
+Advanced helpers and error constants live in submodules:
+
+```python
+from asap.adapters.mcp.auth_middleware import resolve_jwt_extractor
+from asap.adapters.mcp.capability_map import resolve_capability
+from asap.adapters.mcp.errors import (
+    AUTH_REQUIRED,
+    CAPABILITY_DENIED,
+    CONSTRAINT_VIOLATION,
+    INVALID_TOKEN,
+)
+```
 
 ## Error codes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@
 - **Observability**: First-class tracking with correlation IDs and trace IDs
 - **Security & authorization (v2.2+, WebAuthn real in v2.2.1)**: Per-runtime Host/Agent JWTs, capability grants with constraints, approval flows, opt-in WebAuthn (`asap-protocol[webauthn]`) for browser-controlled and high-risk capability registration — see [Security](security.md) and [Migration](migration.md)
 - **Edge-AI discovery (v2.4.0+)**: Optional `capabilities.hardware` / `inference` on manifests; [Transport](transport.md#hardware-and-inference-capabilities-v24), [ShellClaw registry guide](guides/shellclaw-registry.md), [registry examples](examples/registry-shellclaw.md)
-- **Adoption tools (v2.3.0+)**: [OpenAPI adapter](adapters/openapi.md), [TypeScript client](sdks/typescript.md) (`@asap-protocol/client@2.4.1`), [Mastra adapter](integrations/mastra.md) (`@asap-protocol/mastra@2.4.1`), [OpenAI Agents SDK adapter](integrations/openai-agents.md) (`@asap-protocol/openai-agents@2.4.1`), [Auto-registration](registry/auto-registration.md), [Capability escalation](capabilities/escalation.md), [ASAP HTTP challenge](transport/asap-challenge.md)
+- **Adoption tools (v2.3.0+)**: [OpenAPI adapter](adapters/openapi.md), [MCP Auth Bridge](adapters/mcp-auth-bridge.md) (v2.5.0 — opt-in JWT + capability grants for native stdio MCP), [TypeScript client](sdks/typescript.md) (`@asap-protocol/client@2.4.1`), [Mastra adapter](integrations/mastra.md) (`@asap-protocol/mastra@2.4.1`), [OpenAI Agents SDK adapter](integrations/openai-agents.md) (`@asap-protocol/openai-agents@2.4.1`), [Auto-registration](registry/auto-registration.md), [Capability escalation](capabilities/escalation.md), [ASAP HTTP challenge](transport/asap-challenge.md)
 
 ## Installation
 
@@ -93,6 +93,7 @@ See [CLI reference](cli.md) (all commands, exit codes, `compliance-check`, `audi
 ## Documentation
 
 - [OpenAPI adapter](adapters/openapi.md) — derive ASAP skills and an upstream proxy from OpenAPI 3.x (`asap.adapters.openapi`)
+- [MCP Auth Bridge](adapters/mcp-auth-bridge.md) — opt-in Agent JWT + capability enforcement for native stdio `MCPServer` (`asap.adapters.mcp.protect_server`)
 - [TypeScript client SDK](sdks/typescript.md) — `@asap-protocol/client@2.4.1` on npm (browser + Node; optional LLM adapters; edge-AI registry fields)
 - [Mastra adapter](integrations/mastra.md) — `@asap-protocol/mastra@2.4.1`: ASAP capabilities as `@mastra/core` tools + streaming bridge
 - [OpenAI Agents SDK adapter](integrations/openai-agents.md) — `@asap-protocol/openai-agents@2.4.1`: ASAP capabilities as `@openai/agents` tools + handoff-oriented remote agent helper (`@openai/agents`, distinct from `@asap-protocol/client/adapters/openai`)

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -13,6 +13,48 @@ ASAP provides:
 - `asap.mcp.MCPClient`: Connect to an MCP server (e.g. for tests or automation).
 - Protocol types in `asap.mcp.protocol` (JSON-RPC, Initialize, Tool, CallToolResult, etc.).
 
+## Integration modes (v2.5.0)
+
+ASAP supports two complementary ways to combine MCP with agent communication. Pick the mode that matches your transport and auth surface.
+
+| | **Mode A — Native stdio MCP** | **Mode B — MCP-over-ASAP envelope** |
+|:--|:------------------------------|:------------------------------------|
+| **Wire** | MCP JSON-RPC over stdio (`MCPServer` / `MCPClient`) | ASAP `Envelope` with `payload_type` `mcp_tool_call` / `mcp_tool_result` |
+| **Typical use** | IDE hosts (Claude Desktop, Cursor) launch your server as a subprocess | A2A agents invoke MCP tools on a remote peer via HTTP/WebSocket |
+| **Auth (v2.5.0)** | Opt-in via [`asap.adapters.mcp.protect_server`](adapters/mcp-auth-bridge.md) — Agent JWT + capability grants on each `tools/call` | Existing ASAP transport auth (Host/Agent JWT, capability grants on the HTTP server) |
+| **Reference** | [`examples/mcp_auth_bridge/`](../examples/mcp_auth_bridge/) | [`src/asap/examples/mcp_integration.py`](../src/asap/examples/mcp_integration.py) (`McpToolCall` / `mcp_tool_call`) |
+
+### Mode A: native stdio MCP + Auth Bridge
+
+Use `asap.mcp.MCPServer` when a host application starts your process and speaks MCP over stdin/stdout. To enforce Agent JWT and capability grants on protected tools, wrap the server with `protect_server` from `asap.adapters.mcp` — see the **[MCP Auth Bridge adapter guide](adapters/mcp-auth-bridge.md)** for architecture, `MCPAuthConfig`, error codes, and a runnable example.
+
+**Opt-in migration (MCP-DOC-004):** Unprotected `MCPServer` usage remains fully valid. Protection is explicit: call `protect_server` only when you want JWT + grant checks on `tools/call`. Existing deployments do not need to change until operators opt in.
+
+**Deferred in v2.5.0:** An MCP `initialize` session-token handshake (negotiating a token once at connect instead of per-call `_meta`) is **not shipped** in this release — see [design lock §3](../engineering/tasks/v2.5.0/design-lock-mcp-auth-bridge.md). Clients must pass the Agent JWT on each protected `tools/call` via `_meta.asap_agent_jwt` until a future release adds session tokens.
+
+### Mode B: MCP inside ASAP envelopes
+
+When agents already communicate over ASAP HTTP (or WebSocket), invoke MCP tools by sending envelopes with `payload_type` `mcp_tool_call` and a `McpToolCall` payload (`tool_name`, `arguments`, optional `mcp_context`). The recipient returns `mcp_tool_result`. This path does not use the stdio Auth Bridge; authorization follows your ASAP server's existing middleware.
+
+```python
+from asap.models.envelope import Envelope
+from asap.models.payloads import McpToolCall
+from asap.transport.client import ASAPClient
+
+payload = McpToolCall(request_id="req-1", tool_name="echo", arguments={"message": "hi"})
+envelope = Envelope(
+    asap_version="0.1",
+    sender="urn:asap:agent:caller",
+    recipient="urn:asap:agent:mcp-gateway",
+    payload_type="mcp_tool_call",
+    payload=payload.model_dump(),
+)
+async with ASAPClient("http://127.0.0.1:8000") as client:
+    response = await client.send(envelope)
+```
+
+Full walkthrough: `uv run python -m asap.examples.mcp_integration`.
+
 ## How to Expose ASAP Agents as MCP Servers
 
 You can expose an ASAP agent’s capabilities as MCP tools by running an MCP server that forwards tool calls to your agent (e.g. via ASAP envelopes).

--- a/engineering/tasks/v2.5.0/sprint-S3-docs-examples.md
+++ b/engineering/tasks/v2.5.0/sprint-S3-docs-examples.md
@@ -10,13 +10,80 @@
 
 ---
 
+## Parallel Execution (Agent Workstreams)
+
+> **Status:** S3 ready — S2 merged on `release/2.5.0` (commit `8352936`).
+> **Branch:** `feat/v2.5.0-s3-docs-examples` → PR into `release/2.5.0`.
+> **Rule:** Interactive dev in this chat — one sub-task at a time; parallel agents only where noted below.
+> **Commits:** Hold until user approves a batch (no drive-by commits on this branch).
+
+### Dependency phases
+
+```text
+Phase 1 (parallel)              Phase 2 (parallel)           Phase 3 (gate)
+──────────────────              ──────────────────           ──────────────
+A: 1.1 server.py        ──────► A: 1.2 README
+B: 2.1 + 2.2 adapter guide      E: smoke test (after 1.1)  C: 2.3 mcp-integration + index link
+D: 3.1 __all__ audit            D: 2.4 AGENTS.md           Final verify + acceptance checklist
+```
+
+### Agent boundaries
+
+| Agent | Owns | Tasks | Depends on | Can parallelize with |
+|-------|------|-------|------------|----------------------|
+| **A — Reference example** | `examples/mcp_auth_bridge/` | 1.1, 1.2 (+ optional `client.py`) | S2 on `release/2.5.0` | B, D (Phase 1) |
+| **B — Adapter guide** | `docs/adapters/mcp-auth-bridge.md` | 2.1, 2.2 (Discovery §) | S0 design lock + `MCPAuthConfig` API | A, D (Phase 1) |
+| **C — Integration docs** | `docs/mcp-integration.md`, `docs/index.md` | 2.3 + index link | B doc path stable (cross-links) | D (Phase 3) |
+| **D — Knowledge map + API** | `AGENTS.md`, `src/asap/adapters/mcp/__init__.py` | 2.4, 3.1 | S2 exports landed | A, B (Phase 1); 2.4 after B draft |
+| **E — Example smoke test** | `tests/examples/test_mcp_auth_bridge_example.py` | (acceptance) | 1.1 `server.py` exists | 1.2 README (Phase 2) |
+
+### Sequential vs parallel summary
+
+| Must be sequential | Safe to parallelize |
+|--------------------|---------------------|
+| **1.1 → 1.2** (README documents the server) | **A ∥ B ∥ D (3.1)** on Phase 1 |
+| **1.1 → E** (smoke test imports/runs server) | **E ∥ 1.2** after 1.1 lands |
+| **B → C** (`mcp-integration.md` links to adapter guide) | **C ∥ D (2.4)** once `docs/adapters/mcp-auth-bridge.md` exists |
+| **All → acceptance** (example runs + docs indexed) | — |
+
+### Notes for sub-agents
+
+- **S2 is done:** Use `protect_server`, `MCPAuthConfig`, `resolve_capability`, grant seeding — mirror `tests/adapters/mcp/conftest.py` (not a test import; copy the setup pattern into the example).
+- **Example tools:** `echo` = `public_tools`; `secure_action` = protected, requires grant + JWT with `capabilities` claim.
+- **In-memory stores:** `InMemoryHostStore`, `InMemoryAgentStore`, `CapabilityRegistry` — no secrets in repo; document `ASAP_AGENT_JWT` only with `allow_env_jwt_fallback=True` for local dev.
+- **Initialize session-token:** **Deferred** per design-lock §3 — docs MUST state deferred, not shipped (MCP-DOC-003).
+- **Mode A vs Mode B:** Mode A = native stdio `MCPServer` + `asap.adapters.mcp.protect_server`; Mode B = MCP inside ASAP envelopes (`McpToolCall` / `mcp_tool_call` payload) — see `src/asap/examples/mcp_integration.py`.
+- **Discovery:** Document optional `MCPAuthConfig.manifest_url`; snippet showing `skills[].id` aligned with `tool_capability_map` / default identity mapping.
+- **3.1 audit:** Current `__all__` may already be correct — verify public-only exports; hide `protected_server` internals; run `python -c "from asap.adapters.mcp import protect_server, MCPAuthConfig"`.
+- **No secrets:** Example keys generated at runtime; if env vars needed, add `examples/mcp_auth_bridge/.env.example` only.
+- **Verify gate:** `uv run python examples/mcp_auth_bridge/server.py --help` (or short-timeout start); `uv run pytest tests/examples/test_mcp_auth_bridge_example.py -v`; docs link check in `docs/index.md`.
+
+### Sub-agent prompt templates
+
+**Agent A (1.1 + 1.2):**
+> Create `examples/mcp_auth_bridge/server.py`: register `echo` (public) and `secure_action` (protected); wire `protect_server` with in-memory host/agent stores and `CapabilityRegistry` (register capability defs + grant for demo agent). Print startup instructions (how to mint JWT, pass `_meta.asap_agent_jwt`). Follow `examples/openapi_petstore/main.py` argparse/`main()` pattern; entry runs `asyncio.run(server.run_stdio())` only when executed directly. Add `examples/mcp_auth_bridge/README.md` with reproducible JWT flow. Optional: minimal `client.py` using `MCPClient` + `_meta`. Verify: `uv run python examples/mcp_auth_bridge/server.py --help`.
+
+**Agent B (2.1 + 2.2):**
+> Create `docs/adapters/mcp-auth-bridge.md` following `docs/adapters/openapi.md` structure: architecture diagram (stdio MCP → JWT extract → verify → capability grant → handler), `MCPAuthConfig` / `protect_server` reference, error code table (`asap:auth_required`, `asap:invalid_token`, `asap:capability_denied`, `asap:constraint_violation`), security notes (never log JWT). Add § Discovery: `manifest_url`, manifest snippet with `skills[].id` matching mapped MCP tools (MCP-DISC-001/002). Cross-link registry docs if applicable.
+
+**Agent C (2.3 + index):**
+> Update `docs/mcp-integration.md`: distinguish Mode A (native MCP + auth bridge) vs Mode B (MCP-over-ASAP envelope); opt-in migration — unprotected servers remain valid. State `initialize` session-token is **deferred** (design-lock §3). Link to `docs/adapters/mcp-auth-bridge.md`. Add one-line link under Adoption tools in `docs/index.md`.
+
+**Agent D (2.4 + 3.1):**
+> Add `asap.adapters.mcp` to `AGENTS.md` integrations/knowledge map pointing to `docs/adapters/mcp-auth-bridge.md` (single mention, no conflicting MCP guidance). Audit `src/asap/adapters/mcp/__init__.py` `__all__` — export only supported public symbols. Verify import one-liner.
+
+**Agent E (smoke test):**
+> After 1.1, add `tests/examples/test_mcp_auth_bridge_example.py`: subprocess or import smoke — server module loads, `--help` exits 0, or protected path returns expected error without JWT. Pattern: `tests/examples/test_examples_dx.py`. No network, no committed keys.
+
+---
+
 ## Relevant Files
 
 ### New
-- `docs/adapters/mcp-auth-bridge.md`
-- `examples/mcp_auth_bridge/README.md`
-- `examples/mcp_auth_bridge/server.py`
-- `examples/mcp_auth_bridge/client.py` (optional minimal caller)
+- `docs/adapters/mcp-auth-bridge.md` — adapter guide (2.1 + 2.2 Discovery §)
+- `examples/mcp_auth_bridge/README.md` — Agent A (S3, task 1.2)
+- `examples/mcp_auth_bridge/server.py` — Agent A (S3, task 1.1)
+- `examples/mcp_auth_bridge/client.py` — Agent A (S3, optional minimal caller)
 - `tests/examples/test_mcp_auth_bridge_example.py` — smoke import or subprocess
 
 ### Modify
@@ -32,14 +99,14 @@
 
 ### 1.0 Reference example
 
-- [ ] 1.1 Protected MCP server example
+- [x] 1.1 Protected MCP server example
   - **File**: `examples/mcp_auth_bridge/server.py` (create)
   - **What**: Register 2 tools (`echo` public, `secure_action` protected); `protect_server` with in-memory stores; print startup instructions
   - **Why**: MCP-DOC-002 one-command demo
   - **Pattern**: Follow `examples/openapi_petstore/main.py` structure
   - **Verify**: `uv run python examples/mcp_auth_bridge/server.py` starts without error (short timeout or `--help`)
 
-- [ ] 1.2 Example README
+- [x] 1.2 Example README
   - **File**: `examples/mcp_auth_bridge/README.md` (create)
   - **What**: How to mint Agent JWT, pass via `_meta.asap_agent_jwt`, env fallback for dev
   - **Why**: MCP-DOC-002
@@ -47,25 +114,25 @@
 
 ### 2.0 Documentation
 
-- [ ] 2.1 Adapter guide
+- [x] 2.1 Adapter guide
   - **File**: `docs/adapters/mcp-auth-bridge.md` (create)
   - **What**: Architecture diagram (stdio MCP → JWT → capability), API reference for `MCPAuthConfig` / `protect_server`, error code table, security notes (no JWT in logs)
   - **Why**: MCP-DOC-001
   - **Verify**: Linked from `docs/index.md`
 
-- [ ] 2.2 Manifest / discovery note (SHOULD)
+- [x] 2.2 Manifest / discovery note (SHOULD)
   - **File**: `docs/adapters/mcp-auth-bridge.md` § Discovery
   - **What**: Document optional `manifest_url` in config; include a manifest snippet showing `skills[].id` matching mapped MCP tool capabilities.
   - **Why**: MCP-DISC-001, MCP-DISC-002
   - **Verify**: Cross-link to registry docs if applicable
 
-- [ ] 2.3 Existing MCP integration guide update
+- [x] 2.3 Existing MCP integration guide update
   - **File**: `docs/mcp-integration.md` (modify)
   - **What**: Distinguish Mode A (native MCP protected by `asap.adapters.mcp`) from Mode B (MCP-over-ASAP envelope), state that existing unprotected MCP servers remain valid unless operators opt into `protect_server`, and document whether `initialize` session-token support is shipped or deferred after the S0 design lock.
   - **Why**: MCP-DOC-003, MCP-DOC-004
   - **Verify**: Guide links back to `docs/adapters/mcp-auth-bridge.md`.
 
-- [ ] 2.4 Knowledge map update
+- [x] 2.4 Knowledge map update
   - **File**: `AGENTS.md` (modify)
   - **What**: Add `asap.adapters.mcp` to the integration/package map and point maintainers to `docs/adapters/mcp-auth-bridge.md`.
   - **Why**: v2.5.0 DoD requires the agent knowledge map to know the new adapter package.
@@ -73,7 +140,7 @@
 
 ### 3.0 Public API polish
 
-- [ ] 3.1 Finalize `__all__` exports
+- [x] 3.1 Finalize `__all__` exports
   - **File**: `src/asap/adapters/mcp/__init__.py`
   - **What**: Export only supported public symbols; hide internals
   - **Verify**: `python -c "from asap.adapters.mcp import protect_server, MCPAuthConfig"`
@@ -82,9 +149,9 @@
 
 ## Acceptance Criteria (S3)
 
-- [ ] Example runs locally with documented JWT flow
-- [ ] `docs/adapters/mcp-auth-bridge.md` complete and indexed
-- [ ] `docs/mcp-integration.md` documents Mode A vs Mode B and opt-in migration behavior
-- [ ] Discovery section includes `skills[].id` ↔ mapped MCP capability example
-- [ ] `AGENTS.md` knowledge map references `asap.adapters.mcp`
-- [ ] No secrets in example files; use `.env.example` pattern if needed
+- [x] Example runs locally with documented JWT flow
+- [x] `docs/adapters/mcp-auth-bridge.md` complete and indexed
+- [x] `docs/mcp-integration.md` documents Mode A vs Mode B and opt-in migration behavior
+- [x] Discovery section includes `skills[].id` ↔ mapped MCP capability example
+- [x] `AGENTS.md` knowledge map references `asap.adapters.mcp`
+- [x] No secrets in example files; use `.env.example` pattern if needed

--- a/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
+++ b/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
@@ -19,7 +19,7 @@ Based on [PRD v2.5.0 MCP Auth Bridge](../../../product/prd/prd-v2.5.0-mcp-auth-b
 | **S0** | [Design lock & scaffold](./sprint-S0-design-lock.md) | §6 API, MCP-AUTH-005 | P0 | ✅ Done |
 | **S1** | [Core auth middleware](./sprint-S1-core-middleware.md) | MCP-AUTH-001..004, 006 and auth portions of 007 | P0 | ✅ Done (`feat/v2.5.0-s1-middleware`) |
 | **S2** | [Capability mapping & errors](./sprint-S2-capability-mapping.md) | MCP-MAP-*, §4.5–4.6 | P0 | 🟢 Impl done; 3.1 MAY deferred to Agent E |
-| **S3** | [Docs, examples & discovery](./sprint-S3-docs-examples.md) | MCP-DISC-*, MCP-DOC-* | P0/P1 | 🔵 Planned |
+| **S3** | [Docs, examples & discovery](./sprint-S3-docs-examples.md) | MCP-DISC-*, MCP-DOC-* | P0/P1 | ✅ Done on `feat/v2.5.0-s3-docs-examples` (awaiting commit/PR) |
 | **S4** | [Compliance & integration tests](./sprint-S4-compliance.md) | MCP-DISC-003, harness | P1 | 🔵 Planned |
 | **S5** | [Release v2.5.0](./sprint-S5-release.md) | DoD, metrics | P0 | 🔵 Planned |
 
@@ -77,16 +77,16 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
     - [x] Optional startup validation: every registered tool resolves to a capability (MCP-MAP-003)
     - [x] Test coverage ≥90% on `asap.adapters.mcp`
 
-- [ ] **4.0 Documentation, examples & discovery (S3)**
+- [x] **4.0 Documentation, examples & discovery (S3)**
   - **Trigger:** Protected server runnable locally.
   - **Enables:** External adopters; S4 harness documentation paths.
   - **Depends on:** Task 3.0.
   - **Acceptance criteria:**
-    - [ ] `docs/adapters/mcp-auth-bridge.md` published (architecture, token carriage, config reference)
-    - [ ] `examples/mcp_auth_bridge/` runs: `uv run python examples/mcp_auth_bridge/server.py`
-    - [ ] `docs/mcp-integration.md` distinguishes Mode A (native MCP) vs Mode B (ASAP envelope)
-    - [ ] Manifest ↔ tool alignment pattern documented, including `skills[].id` ↔ MCP tool snippets (MCP-DISC-001/002)
-    - [ ] Migration note states unprotected MCP servers remain valid and protection is opt-in (MCP-DOC-004)
+    - [x] `docs/adapters/mcp-auth-bridge.md` published (architecture, token carriage, config reference)
+    - [x] `examples/mcp_auth_bridge/` runs: `uv run python examples/mcp_auth_bridge/server.py`
+    - [x] `docs/mcp-integration.md` distinguishes Mode A (native MCP) vs Mode B (ASAP envelope)
+    - [x] Manifest ↔ tool alignment pattern documented, including `skills[].id` ↔ MCP tool snippets (MCP-DISC-001/002)
+    - [x] Migration note states unprotected MCP servers remain valid and protection is opt-in (MCP-DOC-004)
 
 - [ ] **5.0 Compliance, quality & release (S4–S5)**
   - **Trigger:** Example server + docs merged.
@@ -171,3 +171,4 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 | 2026-06-24 | Reconciled task plan with PRD paths, repo APIs, compliance scope, and TypeScript spike/defer gate |
 | 2026-06-24 | S0 complete on `release/2.5.0`; S1 branch `feat/v2.5.0-s1-middleware` opened with parallel agent workstreams |
 | 2026-06-24 | S2 branch `feat/v2.5.0-s2-capability-map` opened; parallel workstreams documented in sprint-S2 |
+| 2026-06-24 | S2 merged on `release/2.5.0` (`8352936`); S3 branch `feat/v2.5.0-s3-docs-examples` opened with parallel workstreams |

--- a/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
+++ b/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
@@ -1,6 +1,6 @@
 # Tasks: v2.5.0 MCP Auth Bridge — Sprint Index
 
-**Status: 🟢 READY** — parent tasks + per-sprint sub-tasks defined and reconciled with PRD/API details; integration branch **`release/2.5.0`**.
+**Status: 🟡 IN PROGRESS** — S0–S2 merged on **`release/2.5.0`**; S3 complete on **`feat/v2.5.0-s3-docs-examples`** ([PR #232](https://github.com/adriannoes/asap-protocol/pull/232) open); S4–S5 planned.
 
 Based on [PRD v2.5.0 MCP Auth Bridge](../../../product/prd/prd-v2.5.0-mcp-auth-bridge.md). Each sprint maps to a PR into **`release/2.5.0`** (see [BRANCHING.md](./BRANCHING.md)); merge to `main` only after S5.
 
@@ -17,9 +17,9 @@ Based on [PRD v2.5.0 MCP Auth Bridge](../../../product/prd/prd-v2.5.0-mcp-auth-b
 | Sprint | Focus | PRD sections | Priority | Status |
 |--------|-------|--------------|----------|--------|
 | **S0** | [Design lock & scaffold](./sprint-S0-design-lock.md) | §6 API, MCP-AUTH-005 | P0 | ✅ Done |
-| **S1** | [Core auth middleware](./sprint-S1-core-middleware.md) | MCP-AUTH-001..004, 006 and auth portions of 007 | P0 | ✅ Done (`feat/v2.5.0-s1-middleware`) |
-| **S2** | [Capability mapping & errors](./sprint-S2-capability-mapping.md) | MCP-MAP-*, §4.5–4.6 | P0 | 🟢 Impl done; 3.1 MAY deferred to Agent E |
-| **S3** | [Docs, examples & discovery](./sprint-S3-docs-examples.md) | MCP-DISC-*, MCP-DOC-* | P0/P1 | ✅ Done on `feat/v2.5.0-s3-docs-examples` (awaiting commit/PR) |
+| **S1** | [Core auth middleware](./sprint-S1-core-middleware.md) | MCP-AUTH-001..004, 006 and auth portions of 007 | P0 | ✅ Done (merged `60e2e85`, PR #229) |
+| **S2** | [Capability mapping & errors](./sprint-S2-capability-mapping.md) | MCP-MAP-*, §4.5–4.6 | P0 | ✅ Done (merged `8352936`, PR #231; MCP-MAP-004 deferred) |
+| **S3** | [Docs, examples & discovery](./sprint-S3-docs-examples.md) | MCP-DISC-*, MCP-DOC-* | P0/P1 | 🟡 PR open ([#232](https://github.com/adriannoes/asap-protocol/pull/232) → `release/2.5.0`) |
 | **S4** | [Compliance & integration tests](./sprint-S4-compliance.md) | MCP-DISC-003, harness | P1 | 🔵 Planned |
 | **S5** | [Release v2.5.0](./sprint-S5-release.md) | DoD, metrics | P0 | 🔵 Planned |
 
@@ -47,27 +47,27 @@ S1 depends on S0. S2 depends on S1. S3 depends on S2 (example server calls prote
 
 Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 
-- [ ] **1.0 Design lock & package scaffold (S0)**
+- [x] **1.0 Design lock & package scaffold (S0)**
   - **Trigger:** Kickoff v2.5.0 after v2.4.1 ship.
   - **Enables:** S1 middleware implementation in `asap.adapters.mcp`.
   - **Depends on:** Stable `verify_agent_jwt`, `MCPServer` in tree.
   - **Acceptance criteria:**
-    - [ ] Package `src/asap/adapters/mcp/` exists with `MCPAuthConfig` dataclass and public exports
-    - [ ] `MCPAuthConfig` includes `host_store`, `agent_store`, `capability_registry`, `jti_replay_cache`, and `expected_audience`
-    - [ ] Design note documents `tools/call` hook strategy (wrap vs refactor) and grant-check flow
-    - [ ] Default `jwt_extractor` interface defined ( `_meta.asap_agent_jwt` + dev env fallback)
+    - [x] Package `src/asap/adapters/mcp/` exists with `MCPAuthConfig` dataclass and public exports
+    - [x] `MCPAuthConfig` includes `host_store`, `agent_store`, `capability_registry`, `jti_replay_cache`, and `expected_audience`
+    - [x] Design note documents `tools/call` hook strategy (wrap vs refactor) and grant-check flow
+    - [x] Default `jwt_extractor` interface defined ( `_meta.asap_agent_jwt` + dev env fallback)
 
-- [ ] **2.0 Core auth middleware (S1)**
+- [x] **2.0 Core auth middleware (S1)**
   - **Trigger:** S0 complete.
   - **Enables:** S2 capability checks; protected `tools/call` path.
   - **Depends on:** Task 1.0; `auth/agent_jwt.verify_agent_jwt`.
   - **Acceptance criteria:**
-    - [ ] `protect_server(server, config)` wraps `tools/call` without breaking unprotected servers
-    - [ ] Missing/invalid JWT returns MCP `CallToolResult` with `isError: true` and `asap:*` codes
-    - [ ] `public_tools` allowlist skips JWT for named tools only
-    - [ ] Unit tests: missing token, expired token, tampered token, success path
+    - [x] `protect_server(server, config)` wraps `tools/call` without breaking unprotected servers
+    - [x] Missing/invalid JWT returns MCP `CallToolResult` with `isError: true` and `asap:*` codes
+    - [x] `public_tools` allowlist skips JWT for named tools only
+    - [x] Unit tests: missing token, expired token, tampered token, success path
 
-- [ ] **3.0 Capability mapping & constraint enforcement (S2)**
+- [x] **3.0 Capability mapping & constraint enforcement (S2)**
   - **Trigger:** S1 `protect_server` dispatches authenticated calls.
   - **Enables:** S3 example server with real grants; S4 compliance cases.
   - **Depends on:** Task 2.0; `CapabilityRegistry.check_grant` / `auth/capabilities.validate_constraints`.
@@ -110,14 +110,17 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 - `src/asap/adapters/mcp/errors.py` — ASAP MCP error code constants
 - `tests/adapters/mcp/test_auth_middleware.py` — auth path tests
 - `tests/adapters/mcp/test_capability_map.py` — mapping + constraint tests
-- `examples/mcp_auth_bridge/` — runnable protected MCP server
-- `docs/adapters/mcp-auth-bridge.md` — integration guide
+- `examples/mcp_auth_bridge/` — runnable protected MCP server (shipped S3)
+- `examples/mcp_auth_bridge/server.py`, `client.py`, `README.md` — reference protected stdio server + JWT flow
+- `docs/adapters/mcp-auth-bridge.md` — integration guide (shipped S3)
+- `tests/examples/test_mcp_auth_bridge_example.py` — example smoke test (shipped S3)
 
 ### Modify (expected)
 
 - `src/asap/mcp/server.py` — hook point for `tools/call` interception (if refactor needed)
 - `src/asap/mcp/protocol.py` — `_meta` on `CallToolRequestParams` if types need extension
-- `docs/mcp-integration.md` — Mode A vs Mode B
+- `docs/mcp-integration.md` — Mode A vs Mode B (updated S3)
+- `docs/index.md` — Adoption tools link to MCP auth bridge guide (updated S3)
 - `asap-compliance/` — release-gate `mcp_auth` profile for stdio MCP
 - `src/asap/testing/compliance.py` — unchanged unless shared HTTP harness support is explicitly needed
 - `AGENTS.md`, `CHANGELOG.md`, `pyproject.toml`
@@ -136,11 +139,11 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 
 ## Definition of Done (v2.5.0)
 
-- [ ] All parent tasks 1.0–5.0 complete
-- [ ] PRD requirements MCP-AUTH-001..007, MCP-MAP-001..003, MCP-DOC-001..004 satisfied
-- [ ] PRD discovery requirements MCP-DISC-001..003 satisfied or explicitly deferred with rationale
-- [ ] Unprotected `MCPServer` usage unchanged (opt-in via `protect_server`)
-- [ ] No wire-protocol breaking changes
+- [ ] All parent tasks 1.0–5.0 complete (1.0–4.0 ✅; 5.0 pending S4–S5)
+- [x] PRD requirements MCP-AUTH-001..006, MCP-MAP-001..003, MCP-DOC-001..004 satisfied (MCP-MAP-004 / `hide_unauthorized_tools` deferred per design lock §6)
+- [ ] PRD discovery requirements MCP-DISC-001..003 satisfied or explicitly deferred with rationale (MCP-DISC-001/002 ✅ in S3; MCP-DISC-003 → S4 compliance harness)
+- [x] Unprotected `MCPServer` usage unchanged (opt-in via `protect_server`)
+- [x] No wire-protocol breaking changes
 
 ## Estimated Effort
 
@@ -172,3 +175,4 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 | 2026-06-24 | S0 complete on `release/2.5.0`; S1 branch `feat/v2.5.0-s1-middleware` opened with parallel agent workstreams |
 | 2026-06-24 | S2 branch `feat/v2.5.0-s2-capability-map` opened; parallel workstreams documented in sprint-S2 |
 | 2026-06-24 | S2 merged on `release/2.5.0` (`8352936`); S3 branch `feat/v2.5.0-s3-docs-examples` opened with parallel workstreams |
+| 2026-06-24 | S1/S2 merge refs reconciled; S3 impl complete — [PR #232](https://github.com/adriannoes/asap-protocol/pull/232) open into `release/2.5.0`; parent tasks 1.0–4.0 marked done |

--- a/examples/mcp_auth_bridge/README.md
+++ b/examples/mcp_auth_bridge/README.md
@@ -1,0 +1,103 @@
+# MCP Auth Bridge reference example
+
+Runnable demo of **Mode A** native MCP protection via `asap.adapters.mcp.protect_server`:
+
+- **`echo`** — public tool (`public_tools`); no Agent JWT required.
+- **`secure_action`** — protected; requires a valid Agent JWT, matching `capabilities` claim, and an active registry grant.
+
+Keys and identities are generated **at runtime** (nothing committed to the repo).
+
+## Prerequisites
+
+- Python 3.13+
+- [uv](https://github.com/astral-sh/uv)
+
+From the repository root:
+
+```bash
+uv sync
+```
+
+## Run the server
+
+```bash
+uv run python examples/mcp_auth_bridge/server.py
+```
+
+On startup the server prints a **demo Agent JWT** and usage hints on **stderr** (stdout stays reserved for MCP JSON-RPC).
+
+Help (does not start the stdio loop):
+
+```bash
+uv run python examples/mcp_auth_bridge/server.py --help
+```
+
+## Agent JWT flow
+
+### 1. Host minting (production pattern)
+
+In production the **host** signs Agent JWTs with its Ed25519 private key after the agent session is registered. This example inlines that flow in `server.py` using the same APIs as `tests/adapters/mcp/conftest.py`:
+
+1. Register `HostIdentity` in `InMemoryHostStore`.
+2. Register `AgentSession` in `InMemoryAgentStore`.
+3. Mint with `create_agent_jwt(agent_sk, host_thumbprint=..., agent_id=..., aud=..., capabilities=[...])`.
+
+The demo server prints one minted token on stderr for local testing.
+
+### 2. Pass JWT on `tools/call`
+
+MCP clients should attach the token under `_meta`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "secure_action",
+    "arguments": {"action": "ping"},
+    "_meta": {"asap_agent_jwt": "<paste-token-from-stderr>"}
+  }
+}
+```
+
+`echo` ignores JWT even if present; `secure_action` rejects calls without a valid token (`asap:auth_required`).
+
+### 3. Dev env fallback
+
+When `MCPAuthConfig.allow_env_jwt_fallback=True` (enabled in this example for local docs only):
+
+```bash
+export ASAP_AGENT_JWT='<paste-token-from-stderr>'
+```
+
+The middleware reads `ASAP_AGENT_JWT` when `_meta.asap_agent_jwt` is absent. **Do not enable in production.**
+
+## Optional client
+
+Minimal stdio caller that lists tools, calls `echo`, then `secure_action` with `_meta`:
+
+```bash
+export ASAP_AGENT_JWT='<paste-token-from-server-stderr>'
+uv run python examples/mcp_auth_bridge/client.py
+```
+
+Or pass the token explicitly:
+
+```bash
+uv run python examples/mcp_auth_bridge/client.py --jwt '<token>'
+```
+
+## Reviewer checklist
+
+1. `uv run python examples/mcp_auth_bridge/server.py --help` → exit 0.
+2. Start server; copy demo JWT from stderr.
+3. Call `echo` without JWT → succeeds.
+4. Call `secure_action` without JWT → `asap:auth_required`.
+5. Call `secure_action` with `_meta.asap_agent_jwt` (or `ASAP_AGENT_JWT`) → `executed: ...`.
+
+## Related docs
+
+- Adapter guide: [`docs/adapters/mcp-auth-bridge.md`](../../docs/adapters/mcp-auth-bridge.md)
+- Mode B (MCP-over-ASAP envelope): `src/asap/examples/mcp_integration.py`
+- `initialize` session-token carriage: **deferred** (design-lock §3)

--- a/examples/mcp_auth_bridge/README.md
+++ b/examples/mcp_auth_bridge/README.md
@@ -75,17 +75,18 @@ The middleware reads `ASAP_AGENT_JWT` when `_meta.asap_agent_jwt` is absent. **D
 
 ## Optional client
 
-Minimal stdio caller that lists tools, calls `echo`, then `secure_action` with `_meta`:
+Minimal stdio caller that lists tools, calls `echo`, then `secure_action` with `_meta`.
+The client resolves `server.py` relative to its own file, so it works from the repo root
+or from this directory:
 
 ```bash
 export ASAP_AGENT_JWT='<paste-token-from-server-stderr>'
 uv run python examples/mcp_auth_bridge/client.py
 ```
 
-Or pass the token explicitly:
-
 ```bash
-uv run python examples/mcp_auth_bridge/client.py --jwt '<token>'
+cd examples/mcp_auth_bridge
+uv run python client.py --jwt '<token>'
 ```
 
 ## Reviewer checklist

--- a/examples/mcp_auth_bridge/client.py
+++ b/examples/mcp_auth_bridge/client.py
@@ -1,0 +1,116 @@
+"""Minimal MCP client for the MCP Auth Bridge example.
+
+Calls ``echo`` (no JWT) and ``secure_action`` (JWT via ``_meta.asap_agent_jwt``).
+
+Run (server prints JWT on stderr; or set ASAP_AGENT_JWT):
+    uv run python examples/mcp_auth_bridge/client.py --jwt '<token>'
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from typing import Any
+
+from asap.mcp.client import MCPClient
+
+
+async def _call_tool_with_meta(
+    client: MCPClient,
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    jwt: str | None = None,
+) -> dict[str, Any]:
+    """Invoke ``tools/call`` with optional ``_meta.asap_agent_jwt``."""
+    if not client._initialized:
+        raise RuntimeError("Not initialized; call connect() first")
+    params: dict[str, Any] = {"name": name, "arguments": arguments}
+    if jwt:
+        params["_meta"] = {"asap_agent_jwt": jwt}
+    req_id = client._next_id()
+    await client._send(
+        {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "method": "tools/call",
+            "params": params,
+        }
+    )
+    raw = await client._receive()
+    if raw is None:
+        raise RuntimeError("No response to tools/call")
+    if "error" in raw:
+        err = raw["error"]
+        return {
+            "content": [{"type": "text", "text": err.get("message", str(err))}],
+            "isError": True,
+        }
+    result = raw["result"]
+    if not isinstance(result, dict):
+        raise RuntimeError(f"Unexpected tools/call result: {result!r}")
+    return result
+
+
+def _text_content(result: dict[str, Any]) -> str:
+    """Extract text from a ``CallToolResult`` dict."""
+    parts: list[str] = []
+    for block in result.get("content", []):
+        if isinstance(block, dict) and block.get("type") == "text":
+            parts.append(str(block.get("text", "")))
+    return "".join(parts)
+
+
+async def _run(*, jwt: str | None) -> int:
+    server_command = [sys.executable, "examples/mcp_auth_bridge/server.py"]
+    client = MCPClient(
+        server_command,
+        allowed_binaries=frozenset({os.path.basename(sys.executable)}),
+    )
+
+    async with client:
+        tools = await client.list_tools()
+        print("Tools:", [t.name for t in tools])
+
+        echo = await client.call_tool("echo", {"message": "hello"})
+        if echo.is_error:
+            print("echo failed:", echo.content, file=sys.stderr)
+            return 1
+        print("echo:", _text_content(echo.model_dump()))
+
+        secure = await _call_tool_with_meta(
+            client,
+            "secure_action",
+            {"action": "demo"},
+            jwt=jwt,
+        )
+        if secure.get("isError"):
+            print("secure_action failed:", _text_content(secure), file=sys.stderr)
+            return 1
+        print("secure_action:", _text_content(secure))
+
+    return 0
+
+
+def main() -> None:
+    """Parse args and exercise public vs protected MCP tools."""
+    parser = argparse.ArgumentParser(description="MCP Auth Bridge example client")
+    parser.add_argument(
+        "--jwt",
+        default=os.environ.get("ASAP_AGENT_JWT"),
+        help="Agent JWT for secure_action (default: ASAP_AGENT_JWT env)",
+    )
+    args = parser.parse_args()
+    if not args.jwt:
+        print(
+            "Missing JWT: pass --jwt or set ASAP_AGENT_JWT (copy demo token from server stderr).",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    raise SystemExit(asyncio.run(_run(jwt=args.jwt)))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mcp_auth_bridge/client.py
+++ b/examples/mcp_auth_bridge/client.py
@@ -2,7 +2,7 @@
 
 Calls ``echo`` (no JWT) and ``secure_action`` (JWT via ``_meta.asap_agent_jwt``).
 
-Run (server prints JWT on stderr; or set ASAP_AGENT_JWT):
+Run from any directory (server path is resolved relative to this file):
     uv run python examples/mcp_auth_bridge/client.py --jwt '<token>'
 """
 
@@ -12,46 +12,12 @@ import argparse
 import asyncio
 import os
 import sys
+from pathlib import Path
 from typing import Any
 
 from asap.mcp.client import MCPClient
 
-
-async def _call_tool_with_meta(
-    client: MCPClient,
-    name: str,
-    arguments: dict[str, Any],
-    *,
-    jwt: str | None = None,
-) -> dict[str, Any]:
-    """Invoke ``tools/call`` with optional ``_meta.asap_agent_jwt``."""
-    if not client._initialized:
-        raise RuntimeError("Not initialized; call connect() first")
-    params: dict[str, Any] = {"name": name, "arguments": arguments}
-    if jwt:
-        params["_meta"] = {"asap_agent_jwt": jwt}
-    req_id = client._next_id()
-    await client._send(
-        {
-            "jsonrpc": "2.0",
-            "id": req_id,
-            "method": "tools/call",
-            "params": params,
-        }
-    )
-    raw = await client._receive()
-    if raw is None:
-        raise RuntimeError("No response to tools/call")
-    if "error" in raw:
-        err = raw["error"]
-        return {
-            "content": [{"type": "text", "text": err.get("message", str(err))}],
-            "isError": True,
-        }
-    result = raw["result"]
-    if not isinstance(result, dict):
-        raise RuntimeError(f"Unexpected tools/call result: {result!r}")
-    return result
+_SERVER_SCRIPT = Path(__file__).resolve().parent / "server.py"
 
 
 def _text_content(result: dict[str, Any]) -> str:
@@ -64,7 +30,7 @@ def _text_content(result: dict[str, Any]) -> str:
 
 
 async def _run(*, jwt: str | None) -> int:
-    server_command = [sys.executable, "examples/mcp_auth_bridge/server.py"]
+    server_command = [sys.executable, str(_SERVER_SCRIPT)]
     client = MCPClient(
         server_command,
         allowed_binaries=frozenset({os.path.basename(sys.executable)}),
@@ -80,16 +46,15 @@ async def _run(*, jwt: str | None) -> int:
             return 1
         print("echo:", _text_content(echo.model_dump()))
 
-        secure = await _call_tool_with_meta(
-            client,
+        secure = await client.call_tool(
             "secure_action",
             {"action": "demo"},
-            jwt=jwt,
+            meta={"asap_agent_jwt": jwt},
         )
-        if secure.get("isError"):
-            print("secure_action failed:", _text_content(secure), file=sys.stderr)
+        if secure.is_error:
+            print("secure_action failed:", _text_content(secure.model_dump()), file=sys.stderr)
             return 1
-        print("secure_action:", _text_content(secure))
+        print("secure_action:", _text_content(secure.model_dump()))
 
     return 0
 

--- a/examples/mcp_auth_bridge/server.py
+++ b/examples/mcp_auth_bridge/server.py
@@ -1,0 +1,210 @@
+"""MCP Auth Bridge reference example (v2.5.0).
+
+Protected MCP server with a public ``echo`` tool and a gated ``secure_action`` tool.
+Demonstrates ``protect_server``, in-memory identity stores, capability grants, and
+Agent JWT extraction from ``tools/call`` ``_meta.asap_agent_jwt``.
+
+Run:
+    uv run python examples/mcp_auth_bridge/server.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from asap.adapters.mcp import MCPAuthConfig, protect_server
+from asap.auth.agent_jwt import create_agent_jwt
+from asap.auth.capabilities import CapabilityDefinition, CapabilityRegistry
+from asap.auth.identity import (
+    AgentSession,
+    HostIdentity,
+    InMemoryAgentStore,
+    InMemoryHostStore,
+    jwk_thumbprint_sha256,
+)
+from asap.mcp.server import MCPServer
+
+DEMO_HOST_ID = "mcp-auth-bridge-host"
+DEMO_AGENT_ID = "urn:asap:agent:mcp-auth-bridge-demo"
+DEMO_AUDIENCE = "urn:asap:agent:mcp-auth-bridge"
+
+_ECHO_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"message": {"type": "string"}},
+    "additionalProperties": False,
+}
+
+_SECURE_ACTION_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"action": {"type": "string"}},
+    "additionalProperties": False,
+}
+
+
+def _ed25519_public_jwk(private_key: Ed25519PrivateKey) -> dict[str, str]:
+    """Derive a public JWK (OKP / Ed25519) from an Ed25519 private key."""
+    raw = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    x = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+    return {"kty": "OKP", "crv": "Ed25519", "x": x}
+
+
+@dataclass(frozen=True)
+class DemoIdentity:
+    """Runtime-generated host/agent keys and minted demo JWT."""
+
+    host_sk: Ed25519PrivateKey
+    agent_sk: Ed25519PrivateKey
+    host_identity: HostIdentity
+    agent_session: AgentSession
+    demo_jwt: str
+
+
+async def _seed_identity(
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+) -> DemoIdentity:
+    """Register host/agent identities, capability defs, and an active grant."""
+    host_sk = Ed25519PrivateKey.generate()
+    agent_sk = Ed25519PrivateKey.generate()
+    now = datetime.now(timezone.utc)
+
+    host_identity = HostIdentity(
+        host_id=DEMO_HOST_ID,
+        public_key=_ed25519_public_jwk(host_sk),
+        status="active",
+        created_at=now,
+        updated_at=now,
+    )
+    await host_store.save(host_identity)
+
+    agent_session = AgentSession(
+        agent_id=DEMO_AGENT_ID,
+        host_id=host_identity.host_id,
+        public_key=_ed25519_public_jwk(agent_sk),
+        mode="delegated",
+        status="active",
+        created_at=now,
+        activated_at=now,
+    )
+    await agent_store.save(agent_session)
+
+    capability_registry.register(
+        CapabilityDefinition(
+            name="secure_action",
+            description="Execute a protected MCP action",
+        )
+    )
+    capability_registry.grant(DEMO_AGENT_ID, "secure_action")
+
+    host_thumbprint = jwk_thumbprint_sha256(host_identity.public_key)
+    demo_jwt = create_agent_jwt(
+        agent_sk,
+        host_thumbprint=host_thumbprint,
+        agent_id=DEMO_AGENT_ID,
+        aud=DEMO_AUDIENCE,
+        capabilities=["secure_action"],
+    )
+
+    return DemoIdentity(
+        host_sk=host_sk,
+        agent_sk=agent_sk,
+        host_identity=host_identity,
+        agent_session=agent_session,
+        demo_jwt=demo_jwt,
+    )
+
+
+async def build_protected_server() -> tuple[MCPServer, DemoIdentity]:
+    """Wire in-memory stores, tools, and ``protect_server`` for the demo."""
+    agent_store = InMemoryAgentStore()
+    host_store = InMemoryHostStore(agent_store=agent_store)
+    capability_registry = CapabilityRegistry()
+    identity = await _seed_identity(host_store, agent_store, capability_registry)
+
+    base = MCPServer(
+        name="mcp-auth-bridge",
+        version="0.1.0",
+        description="ASAP MCP Auth Bridge reference example",
+    )
+    base.register_tool(
+        "echo",
+        lambda message="": message,
+        _ECHO_INPUT_SCHEMA,
+        description="Public echo tool (no JWT required)",
+    )
+    base.register_tool(
+        "secure_action",
+        lambda action="": f"executed: {action}",
+        _SECURE_ACTION_INPUT_SCHEMA,
+        description="Protected action (requires Agent JWT + grant)",
+    )
+
+    config = MCPAuthConfig(
+        host_store=host_store,
+        agent_store=agent_store,
+        capability_registry=capability_registry,
+        public_tools=frozenset({"echo"}),
+        enforce_grants=True,
+        allow_env_jwt_fallback=True,
+        expected_audience=DEMO_AUDIENCE,
+    )
+    protected = protect_server(base, config)
+    return protected, identity
+
+
+def _print_startup_instructions(identity: DemoIdentity) -> None:
+    """Print reviewer-facing JWT and ``tools/call`` guidance on stderr."""
+    lines = [
+        "",
+        "=== MCP Auth Bridge example ===",
+        f"Agent ID: {identity.agent_session.agent_id}",
+        f"Audience: {DEMO_AUDIENCE}",
+        "",
+        "Public tool: echo (no JWT)",
+        "Protected tool: secure_action (JWT + active grant required)",
+        "",
+        "Minted demo Agent JWT (60s TTL, capabilities=['secure_action']):",
+        identity.demo_jwt,
+        "",
+        "Pass JWT on tools/call:",
+        '  params._meta.asap_agent_jwt = "<token>"',
+        "",
+        "Dev-only env fallback (allow_env_jwt_fallback=True):",
+        "  export ASAP_AGENT_JWT='<token>'",
+        "",
+        "Listening on stdio (JSON-RPC, one message per line).",
+        "",
+    ]
+    print("\n".join(lines), file=sys.stderr, flush=True)
+
+
+async def _run_stdio() -> None:
+    server, identity = await build_protected_server()
+    _print_startup_instructions(identity)
+    await server.run_stdio()
+
+
+def main() -> None:
+    """Parse CLI args and start the protected MCP server over stdio."""
+    parser = argparse.ArgumentParser(
+        description="MCP Auth Bridge reference server (public echo + protected secure_action)",
+    )
+    parser.parse_args()
+    asyncio.run(_run_stdio())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/asap/adapters/mcp/__init__.py
+++ b/src/asap/adapters/mcp/__init__.py
@@ -5,26 +5,9 @@ Opt-in protection for native ``MCPServer`` via ``protect_server``.
 
 from __future__ import annotations
 
-from asap.adapters.mcp.auth_middleware import MCPAuthConfig, protect_server, resolve_jwt_extractor
-from asap.adapters.mcp.capability_map import resolve_capability
-from asap.adapters.mcp.errors import (
-    AUTH_REQUIRED,
-    CAPABILITY_DENIED,
-    CONSTRAINT_VIOLATION,
-    INVALID_TOKEN,
-    tool_error_result,
-)
-from asap.adapters.mcp.jwt_extractor import default_jwt_extractor
+from asap.adapters.mcp.auth_middleware import MCPAuthConfig, protect_server
 
 __all__ = [
-    "AUTH_REQUIRED",
-    "CAPABILITY_DENIED",
-    "CONSTRAINT_VIOLATION",
-    "INVALID_TOKEN",
     "MCPAuthConfig",
-    "default_jwt_extractor",
     "protect_server",
-    "resolve_capability",
-    "resolve_jwt_extractor",
-    "tool_error_result",
 ]

--- a/src/asap/mcp/client.py
+++ b/src/asap/mcp/client.py
@@ -175,12 +175,19 @@ class MCPClient:
         result = ListToolsResult(**raw["result"])
         return result.tools
 
-    async def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> CallToolResult:
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
         """Invoke a tool by name with the given arguments.
 
         Args:
             name: Tool name (as returned by list_tools).
             arguments: Tool arguments (keyword dict).
+            meta: Optional MCP ``_meta`` dict (e.g. ``{"asap_agent_jwt": "<token>"}``).
 
         Returns:
             CallToolResult with content and is_error.
@@ -188,7 +195,7 @@ class MCPClient:
         if not self._initialized:
             raise RuntimeError("Not initialized; call connect() first")
         req_id = self._next_id()
-        params = CallToolRequestParams(name=name, arguments=arguments or {})
+        params = CallToolRequestParams(name=name, arguments=arguments or {}, meta=meta)
         await self._send(
             {
                 "jsonrpc": "2.0",

--- a/tests/examples/test_mcp_auth_bridge_example.py
+++ b/tests/examples/test_mcp_auth_bridge_example.py
@@ -126,3 +126,30 @@ class TestMcpAuthBridgeProtectedTool:
         )
         assert result.get("isError") is not True
         assert "executed: env-demo" in str(result["content"][0]["text"])
+
+
+class TestMcpAuthBridgeClientSubprocess:
+    """Subprocess smoke for the optional example client."""
+
+    def test_client_subprocess_from_example_dir(self) -> None:
+        """``client.py`` resolves ``server.py`` relative to its file (any cwd)."""
+        client_dir = _REPO_ROOT / "examples" / "mcp_auth_bridge"
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                "client.py",
+                "--jwt",
+                "invalid-token-for-path-smoke",
+            ],
+            cwd=client_dir,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        # echo succeeds before secure_action auth fails — server subprocess was found
+        assert "echo:" in result.stdout
+        assert "secure_action failed" in result.stderr
+        assert result.returncode == 1

--- a/tests/examples/test_mcp_auth_bridge_example.py
+++ b/tests/examples/test_mcp_auth_bridge_example.py
@@ -1,0 +1,128 @@
+"""Smoke tests for examples/mcp_auth_bridge/server.py (S3).
+
+Verifies the reference MCP Auth Bridge example loads, exposes CLI help,
+and rejects protected tool calls without a JWT (in-process, no network).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from pytest import MonkeyPatch
+
+from asap.adapters.mcp.errors import AUTH_REQUIRED
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SERVER_SCRIPT = _REPO_ROOT / "examples" / "mcp_auth_bridge" / "server.py"
+
+
+def _load_server_module() -> ModuleType:
+    """Import the example server module from its file path."""
+    spec = importlib.util.spec_from_file_location(
+        "mcp_auth_bridge_server",
+        _SERVER_SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestMcpAuthBridgeExampleImport:
+    """Import smoke for the standalone example server module."""
+
+    def test_server_script_exists(self) -> None:
+        """Example server file is present in the repo."""
+        assert _SERVER_SCRIPT.is_file()
+
+    def test_server_module_loads(self) -> None:
+        """Server module imports and exposes build_protected_server and main."""
+        module = _load_server_module()
+        assert module.DEMO_HOST_ID == "mcp-auth-bridge-host"
+        assert module.DEMO_AUDIENCE == "urn:asap:agent:mcp-auth-bridge"
+        assert callable(module.build_protected_server)
+        assert callable(module.main)
+
+
+class TestMcpAuthBridgeExampleCli:
+    """CLI smoke for the example entrypoint."""
+
+    def test_help_exits_zero(self) -> None:
+        """``--help`` exits 0 without starting stdio transport."""
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                "examples/mcp_auth_bridge/server.py",
+                "--help",
+            ],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "MCP Auth Bridge" in result.stdout
+
+
+class TestMcpAuthBridgeProtectedTool:
+    """In-process auth path checks (no network)."""
+
+    @pytest.mark.asyncio
+    async def test_secure_action_without_jwt_returns_auth_required(self) -> None:
+        """Protected ``secure_action`` without JWT returns ``asap:auth_required``."""
+        module = _load_server_module()
+        server, _identity = await module.build_protected_server()
+        result = await server._handle_tools_call(
+            {"name": "secure_action", "arguments": {"action": "test"}},
+        )
+        assert result["isError"] is True
+        assert AUTH_REQUIRED in str(result["content"][0]["text"])
+
+    @pytest.mark.asyncio
+    async def test_echo_without_jwt_succeeds(self) -> None:
+        """Public ``echo`` tool runs without JWT."""
+        module = _load_server_module()
+        server, _identity = await module.build_protected_server()
+        result = await server._handle_tools_call(
+            {"name": "echo", "arguments": {"message": "hi"}},
+        )
+        assert result.get("isError") is not True
+        assert "hi" in str(result["content"][0]["text"])
+
+    @pytest.mark.asyncio
+    async def test_secure_action_with_jwt_succeeds(self) -> None:
+        """Protected ``secure_action`` succeeds with demo JWT in ``_meta``."""
+        module = _load_server_module()
+        server, identity = await module.build_protected_server()
+        result = await server._handle_tools_call(
+            {
+                "name": "secure_action",
+                "arguments": {"action": "test"},
+                "_meta": {"asap_agent_jwt": identity.demo_jwt},
+            },
+        )
+        assert result.get("isError") is not True
+        assert "executed: test" in str(result["content"][0]["text"])
+
+    @pytest.mark.asyncio
+    async def test_secure_action_with_env_jwt_succeeds(
+        self,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        """``ASAP_AGENT_JWT`` env fallback works when enabled in demo config."""
+        module = _load_server_module()
+        server, identity = await module.build_protected_server()
+        monkeypatch.setenv("ASAP_AGENT_JWT", identity.demo_jwt)
+        result = await server._handle_tools_call(
+            {"name": "secure_action", "arguments": {"action": "env-demo"}},
+        )
+        assert result.get("isError") is not True
+        assert "executed: env-demo" in str(result["content"][0]["text"])

--- a/tests/mcp/test_client.py
+++ b/tests/mcp/test_client.py
@@ -312,6 +312,28 @@ async def test_client_call_tool_success() -> None:
 
 
 @pytest.mark.asyncio
+async def test_client_call_tool_with_meta() -> None:
+    """call_tool forwards optional _meta (e.g. asap_agent_jwt) in tools/call params."""
+    client = _make_connected_client()
+    client._send = AsyncMock()
+    client._receive = AsyncMock(
+        return_value={
+            "result": {
+                "content": [{"type": "text", "text": "ok"}],
+                "isError": False,
+            }
+        }
+    )
+    await client.call_tool(
+        "secure_action",
+        {"action": "ping"},
+        meta={"asap_agent_jwt": "test-jwt"},
+    )
+    sent = client._send.await_args_list[-1][0][0]
+    assert sent["params"]["_meta"]["asap_agent_jwt"] == "test-jwt"
+
+
+@pytest.mark.asyncio
 async def test_client_disconnect() -> None:
     """disconnect closes stdin, terminates, and waits."""
     client = MCPClient(["true"], receive_timeout=1.0)


### PR DESCRIPTION
## Summary
- Add `examples/mcp_auth_bridge/` (protected MCP server demo, client JWT flow, README) with eight smoke tests in `tests/examples/test_mcp_auth_bridge_example.py`.
- Publish `docs/adapters/mcp-auth-bridge.md`; update `docs/mcp-integration.md` (Mode A vs Mode B, opt-in protection) and `docs/index.md`; extend `AGENTS.md` knowledge map for `asap.adapters.mcp`.
- Trim `asap.adapters.mcp` public `__all__` to `MCPAuthConfig` and `protect_server`; mark S3 sprint and v2.5.0 roadmap task 4.0 complete.

## Test plan
- [x] `uv run pytest tests/examples/test_mcp_auth_bridge_example.py --tb=short -q` (8 passed)
- [x] `python -c "from asap.adapters.mcp import protect_server, MCPAuthConfig"`
- [x] Review docs links: `docs/index.md` → auth bridge guide; `docs/mcp-integration.md` ↔ adapter guide
- [x] Optional manual: `uv run python examples/mcp_auth_bridge/server.py` (short run / documented JWT flow)