### PR TITLE
feat(v2.5.0): S4 MCP auth compliance harness and integration gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - 'scripts/**'
       - 'tests/**'
       - 'asap-compliance/**'
+      - 'examples/**'
       - 'docs/**'
       - 'apps/web/**'
       - 'apps/example-agent/**'
@@ -25,6 +26,7 @@ on:
       - 'scripts/**'
       - 'tests/**'
       - 'asap-compliance/**'
+      - 'examples/**'
       - 'docs/**'
       - 'apps/web/**'
       - 'apps/example-agent/**'
@@ -102,7 +104,7 @@ jobs:
       - name: Run tests
         env:
           PYTHONPATH: ${{ github.workspace }}/src:${{ github.workspace }}
-        run: uv run pytest -n auto --tb=short
+        run: uv run pytest -n auto --tb=short --ignore=tests/adapters/mcp/
         timeout-minutes: 12
       - name: Run MCP adapter tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, release/2.5.0]
     paths:
       - 'src/**'
       - 'scripts/**'
@@ -19,7 +19,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
   pull_request:
-    branches: [main]
+    branches: [main, release/2.5.0]
     paths:
       - 'src/**'
       - 'scripts/**'
@@ -104,6 +104,10 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/src:${{ github.workspace }}
         run: uv run pytest -n auto --tb=short
         timeout-minutes: 12
+      - name: Run MCP adapter tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}/src:${{ github.workspace }}
+        run: uv run pytest tests/adapters/mcp/ -v --tb=short
       - name: Run compliance tests
         env:
           PYTHONPATH: ${{ github.workspace }}/src:${{ github.workspace }}:${{ github.workspace }}/asap-compliance

--- a/asap-compliance/asap_compliance/__init__.py
+++ b/asap-compliance/asap_compliance/__init__.py
@@ -4,4 +4,43 @@ Validates that ASAP implementations follow the protocol specification.
 Third parties can use this package to certify their agents are ASAP-compliant.
 """
 
+from asap_compliance.harness import (
+    ComplianceConfig,
+    HandshakeResult,
+    McpAuthComplianceConfig,
+    McpAuthResult,
+    SchemaResult,
+    SlaResult,
+    StateResult,
+    validate_handshake,
+    validate_handshake_async,
+    validate_mcp_auth,
+    validate_mcp_auth_async,
+    validate_schema,
+    validate_sla,
+    validate_sla_async,
+    validate_state_machine,
+    validate_state_machine_async,
+)
+
 __version__ = "1.2.0"
+
+__all__ = [
+    "ComplianceConfig",
+    "HandshakeResult",
+    "McpAuthComplianceConfig",
+    "McpAuthResult",
+    "SchemaResult",
+    "SlaResult",
+    "StateResult",
+    "validate_handshake",
+    "validate_handshake_async",
+    "validate_mcp_auth",
+    "validate_mcp_auth_async",
+    "validate_schema",
+    "validate_sla",
+    "validate_sla_async",
+    "validate_state_machine",
+    "validate_state_machine_async",
+    "__version__",
+]

--- a/asap-compliance/asap_compliance/config.py
+++ b/asap-compliance/asap_compliance/config.py
@@ -2,7 +2,90 @@
 
 from __future__ import annotations
 
+import os
+import sys
+from pathlib import Path
+
 from pydantic import BaseModel, Field
+
+MCP_AUTH_BRIDGE_PROFILE = "mcp-auth-bridge"
+COMPLIANCE_ENV_VAR = "ASAP_MCP_COMPLIANCE"
+
+
+def find_repo_root() -> Path:
+    """Locate the asap-protocol repository root from this package."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "examples" / "mcp_auth_bridge" / "server.py").is_file():
+            return parent
+    raise FileNotFoundError(
+        "Could not locate asap-protocol repo root (expected examples/mcp_auth_bridge/server.py)"
+    )
+
+
+def default_mcp_auth_server_command() -> list[str]:
+    """Default stdio subprocess command for the MCP Auth Bridge example."""
+    override = os.environ.get("ASAP_MCP_SERVER_COMMAND")
+    if override:
+        return override.split()
+    script = find_repo_root() / "examples" / "mcp_auth_bridge" / "server.py"
+    return ["uv", "run", "python", str(script)]
+
+
+def default_mcp_auth_manifest_fixture() -> Path:
+    """Default manifest fixture JSON for MCP-DISC-003 alignment checks."""
+    return (
+        find_repo_root()
+        / "asap-compliance"
+        / "tests"
+        / "fixtures"
+        / "mcp_auth_bridge_manifest.json"
+    )
+
+
+class McpAuthComplianceConfig(BaseModel):
+    """Configuration for the ``mcp-auth-bridge`` stdio MCP compliance profile."""
+
+    profile: str = Field(
+        default=MCP_AUTH_BRIDGE_PROFILE,
+        description="Compliance profile name (release gate for stdio MCP)",
+    )
+    server_command: list[str] = Field(
+        default_factory=default_mcp_auth_server_command,
+        description="Subprocess command for the MCP server under test (stdio JSON-RPC)",
+    )
+    timeout_seconds: float = Field(
+        default=60.0,
+        gt=0,
+        description="Per-request timeout when driving the MCP subprocess",
+    )
+    protected_tool: str = Field(
+        default="secure_action",
+        description="Protected MCP tool name (requires Agent JWT)",
+    )
+    public_tool: str = Field(
+        default="echo",
+        description="Public MCP tool name (no JWT required)",
+    )
+    manifest_fixture_path: Path | None = Field(
+        default_factory=default_mcp_auth_manifest_fixture,
+        description="Fixture manifest JSON when manifest_url is unavailable",
+    )
+    manifest_url: str | None = Field(
+        default=None,
+        description="Optional live manifest URL for MCP-DISC-003 alignment",
+    )
+    skip_checks: list[str] = Field(
+        default_factory=list,
+        description="Check names to skip (e.g. 'manifest_alignment')",
+    )
+    compliance_env: bool = Field(
+        default=True,
+        description="Set ASAP_MCP_COMPLIANCE=1 on subprocess for probe JWT emission",
+    )
+    allowed_binaries: frozenset[str] | None = Field(
+        default_factory=lambda: frozenset({"uv", "python", Path(sys.executable).name}),
+        description="Allowed server_command binaries for MCPClient validation",
+    )
 
 
 class ComplianceConfig(BaseModel):

--- a/asap-compliance/asap_compliance/harness.py
+++ b/asap-compliance/asap_compliance/harness.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
-from asap_compliance.config import ComplianceConfig
+from asap_compliance.config import ComplianceConfig, McpAuthComplianceConfig
 from asap_compliance.validators.handshake import (
     HandshakeResult,
     validate_handshake,
     validate_handshake_async,
+)
+from asap_compliance.validators.mcp_auth import (
+    McpAuthResult,
+    validate_mcp_auth,
+    validate_mcp_auth_async,
 )
 from asap_compliance.validators.schema import SchemaResult, validate_schema
 from asap_compliance.validators.sla import SlaResult, validate_sla, validate_sla_async
@@ -19,11 +24,15 @@ from asap_compliance.validators.state import (
 __all__ = [
     "ComplianceConfig",
     "HandshakeResult",
+    "McpAuthComplianceConfig",
+    "McpAuthResult",
     "SchemaResult",
     "SlaResult",
     "StateResult",
     "validate_handshake",
     "validate_handshake_async",
+    "validate_mcp_auth",
+    "validate_mcp_auth_async",
     "validate_schema",
     "validate_sla",
     "validate_sla_async",

--- a/asap-compliance/asap_compliance/validators/__init__.py
+++ b/asap-compliance/asap_compliance/validators/__init__.py
@@ -8,6 +8,13 @@ from asap_compliance.validators.handshake import (
     validate_handshake,
     validate_handshake_async,
 )
+from asap_compliance.validators.mcp_auth import (
+    McpAuthProbeTokens,
+    McpAuthResult,
+    MockMcpTransport,
+    validate_mcp_auth,
+    validate_mcp_auth_async,
+)
 from asap_compliance.validators.schema import (
     SchemaResult,
     validate_envelope,
@@ -28,11 +35,16 @@ from asap_compliance.validators.state import (
 __all__ = [
     "CheckResult",
     "HandshakeResult",
+    "McpAuthProbeTokens",
+    "McpAuthResult",
+    "MockMcpTransport",
     "SchemaResult",
     "StateResult",
     "validate_envelope",
     "validate_handshake",
     "validate_handshake_async",
+    "validate_mcp_auth",
+    "validate_mcp_auth_async",
     "validate_payload",
     "validate_schema",
     "validate_sla",

--- a/asap-compliance/asap_compliance/validators/__init__.py
+++ b/asap-compliance/asap_compliance/validators/__init__.py
@@ -11,7 +11,9 @@ from asap_compliance.validators.handshake import (
 from asap_compliance.validators.mcp_auth import (
     McpAuthProbeTokens,
     McpAuthResult,
+    McpAuthTransport,
     MockMcpTransport,
+    SubprocessMcpTransport,
     validate_mcp_auth,
     validate_mcp_auth_async,
 )
@@ -37,7 +39,9 @@ __all__ = [
     "HandshakeResult",
     "McpAuthProbeTokens",
     "McpAuthResult",
+    "McpAuthTransport",
     "MockMcpTransport",
+    "SubprocessMcpTransport",
     "SchemaResult",
     "StateResult",
     "validate_envelope",

--- a/asap-compliance/asap_compliance/validators/mcp_auth.py
+++ b/asap-compliance/asap_compliance/validators/mcp_auth.py
@@ -4,11 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
-import re
-from contextlib import suppress
 from dataclasses import dataclass, field
-from typing import Any, Protocol, cast
+from typing import Any, cast
 
 import httpx
 
@@ -17,7 +14,6 @@ from asap.adapters.mcp.errors import (
     CAPABILITY_DENIED,
     CONSTRAINT_VIOLATION,
 )
-from asap.mcp.client import MCPClient
 from asap.mcp.protocol import CallToolResult
 
 from asap_compliance.config import (
@@ -26,21 +22,22 @@ from asap_compliance.config import (
     McpAuthComplianceConfig,
 )
 from asap_compliance.validators.handshake import CheckResult
-
-_COMPLIANCE_JSON_PREFIX = "ASAP_COMPLIANCE_JSON:"
-_STDERR_JWT_PATTERN = re.compile(
-    r"Minted demo Agent JWT.*?:\s*(\S+)",
-    re.DOTALL,
+from asap_compliance.validators.mcp_auth_transport import (
+    McpAuthProbeTokens,
+    McpAuthTransport,
+    MockMcpTransport,
+    SubprocessMcpTransport,
 )
 
-
-@dataclass
-class McpAuthProbeTokens:
-    """JWT probe tokens parsed from a compliance-enabled MCP server."""
-
-    valid_jwt: str
-    wrong_capability_jwt: str
-    constraint_violation_action: str = "forbidden-action"
+__all__ = [
+    "McpAuthProbeTokens",
+    "McpAuthResult",
+    "McpAuthTransport",
+    "MockMcpTransport",
+    "SubprocessMcpTransport",
+    "validate_mcp_auth",
+    "validate_mcp_auth_async",
+]
 
 
 @dataclass
@@ -53,6 +50,7 @@ class McpAuthResult:
     wrong_capability_ok: bool
     constraint_violation_ok: bool
     manifest_alignment_ok: bool
+    public_tool_ok: bool
     checks: list[CheckResult] = field(default_factory=list)
 
     @property
@@ -63,25 +61,8 @@ class McpAuthResult:
             and self.wrong_capability_ok
             and self.constraint_violation_ok
             and self.manifest_alignment_ok
+            and self.public_tool_ok
         )
-
-
-class McpAuthTransport(Protocol):
-    """Black-box MCP transport for compliance checks."""
-
-    async def connect(self) -> McpAuthProbeTokens: ...
-
-    async def list_tool_names(self) -> list[str]: ...
-
-    async def call_tool(
-        self,
-        name: str,
-        arguments: dict[str, Any] | None = None,
-        *,
-        jwt: str | None = None,
-    ) -> CallToolResult: ...
-
-    async def disconnect(self) -> None: ...
 
 
 def _tool_error_text(result: CallToolResult) -> str:
@@ -94,154 +75,6 @@ def _tool_error_text(result: CallToolResult) -> str:
             if text is not None:
                 parts.append(str(text))
     return "".join(parts)
-
-
-def _parse_probe_tokens(stderr_text: str, fallback_jwt: str | None) -> McpAuthProbeTokens:
-    """Parse compliance probe JWTs emitted on server stderr."""
-    for line in stderr_text.splitlines():
-        if line.startswith(_COMPLIANCE_JSON_PREFIX):
-            payload = json.loads(line.removeprefix(_COMPLIANCE_JSON_PREFIX))
-            return McpAuthProbeTokens(
-                valid_jwt=str(payload["valid_jwt"]),
-                wrong_capability_jwt=str(payload["wrong_capability_jwt"]),
-                constraint_violation_action=str(
-                    payload.get("constraint_violation_action", "forbidden-action")
-                ),
-            )
-
-    if fallback_jwt:
-        return McpAuthProbeTokens(
-            valid_jwt=fallback_jwt,
-            wrong_capability_jwt="",
-            constraint_violation_action="forbidden-action",
-        )
-
-    raise RuntimeError(
-        "MCP server stderr did not include compliance probe tokens; "
-        f"set {COMPLIANCE_ENV_VAR}=1 on the server subprocess"
-    )
-
-
-def _extract_demo_jwt(stderr_text: str) -> str | None:
-    match = _STDERR_JWT_PATTERN.search(stderr_text)
-    return match.group(1) if match else None
-
-
-class SubprocessMcpTransport:
-    """Drive an MCP server subprocess over stdio (JSON-RPC one line per message)."""
-
-    def __init__(self, config: McpAuthComplianceConfig) -> None:
-        self._config = config
-        self._client: MCPClient | None = None
-        self._stderr_chunks: list[bytes] = []
-        self._stderr_task: asyncio.Task[None] | None = None
-        self._tokens: McpAuthProbeTokens | None = None
-
-    async def _drain_stderr(self) -> None:
-        assert self._client is not None
-        process = self._client._process
-        if process is None or process.stderr is None:
-            return
-        while True:
-            chunk = await process.stderr.readline()
-            if not chunk:
-                break
-            self._stderr_chunks.append(chunk)
-
-    async def connect(self) -> McpAuthProbeTokens:
-        env = os.environ.copy()
-        if self._config.compliance_env:
-            env[COMPLIANCE_ENV_VAR] = "1"
-        # Stdio MCP uses stdout for JSON-RPC; suppress INFO logs that would corrupt the stream.
-        env.setdefault("ASAP_LOG_LEVEL", "CRITICAL")
-
-        self._client = MCPClient(
-            list(self._config.server_command),
-            receive_timeout=self._config.timeout_seconds,
-            allowed_binaries=self._config.allowed_binaries,
-            subprocess_env=env,
-        )
-        connect_task = asyncio.create_task(self._client.connect())
-        while self._client._process is None:
-            await asyncio.sleep(0.01)
-            if connect_task.done():
-                break
-        self._stderr_task = asyncio.create_task(self._drain_stderr())
-        await connect_task
-
-        await asyncio.sleep(0.3)
-        stderr_text = b"".join(self._stderr_chunks).decode("utf-8", errors="replace")
-        fallback = _extract_demo_jwt(stderr_text)
-        self._tokens = _parse_probe_tokens(stderr_text, fallback)
-        return self._tokens
-
-    async def list_tool_names(self) -> list[str]:
-        assert self._client is not None
-        tools = await self._client.list_tools()
-        return [tool.name for tool in tools]
-
-    async def call_tool(
-        self,
-        name: str,
-        arguments: dict[str, Any] | None = None,
-        *,
-        jwt: str | None = None,
-    ) -> CallToolResult:
-        assert self._client is not None
-        meta = {"asap_agent_jwt": jwt} if jwt is not None else None
-        return await self._client.call_tool(name, arguments, meta=meta)
-
-    async def disconnect(self) -> None:
-        if self._stderr_task is not None:
-            self._stderr_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await self._stderr_task
-            self._stderr_task = None
-        if self._client is not None:
-            await self._client.disconnect()
-            self._client = None
-
-
-class MockMcpTransport:
-    """In-memory MCP transport for unit tests (predetermined responses)."""
-
-    def __init__(
-        self,
-        *,
-        tool_names: list[str],
-        responses: dict[tuple[str, str | None], CallToolResult],
-        tokens: McpAuthProbeTokens,
-    ) -> None:
-        self._tool_names = tool_names
-        self._responses = responses
-        self._tokens = tokens
-        self._connected = False
-
-    async def connect(self) -> McpAuthProbeTokens:
-        self._connected = True
-        return self._tokens
-
-    async def list_tool_names(self) -> list[str]:
-        if not self._connected:
-            raise RuntimeError("Not connected")
-        return list(self._tool_names)
-
-    async def call_tool(
-        self,
-        name: str,
-        arguments: dict[str, Any] | None = None,
-        *,
-        jwt: str | None = None,
-    ) -> CallToolResult:
-        if not self._connected:
-            raise RuntimeError("Not connected")
-        key = (name, jwt)
-        if key not in self._responses:
-            raise KeyError(f"No mock response for tool={name!r} jwt={jwt!r}")
-        return self._responses[key]
-
-    async def disconnect(self) -> None:
-        self._connected = False
 
 
 def _load_manifest_data(config: McpAuthComplianceConfig) -> dict[str, Any]:
@@ -355,6 +188,24 @@ def _check_manifest_alignment(
         )
     )
     return results
+
+
+async def _check_public_tool(
+    config: McpAuthComplianceConfig,
+    transport: McpAuthTransport,
+) -> CheckResult:
+    result = await transport.call_tool(config.public_tool, {}, jwt=None)
+    text = _tool_error_text(result)
+    passed = result.is_error is not True
+    return CheckResult(
+        name="public_tool",
+        passed=passed,
+        message=(
+            f"Public tool {config.public_tool!r} succeeded without JWT"
+            if passed
+            else f"Public tool call failed: {text!r}"
+        ),
+    )
 
 
 async def _check_unauthenticated_protected_tool(
@@ -483,6 +334,12 @@ async def validate_mcp_auth_async(
         tokens = await session.connect()
         tool_names = await session.list_tool_names()
 
+        if "public_tool" not in config.skip_checks:
+            public_check = await _check_public_tool(config, session)
+            checks.append(public_check)
+        else:
+            public_check = CheckResult("public_tool", True, "skipped")
+
         if "auth_required" not in config.skip_checks:
             auth_check = await _check_unauthenticated_protected_tool(config, session)
             checks.append(auth_check)
@@ -522,6 +379,7 @@ async def validate_mcp_auth_async(
         wrong_capability_ok=wrong_check.passed,
         constraint_violation_ok=constraint_check.passed,
         manifest_alignment_ok=manifest_alignment_ok,
+        public_tool_ok=public_check.passed,
         checks=checks,
     )
 

--- a/asap-compliance/asap_compliance/validators/mcp_auth.py
+++ b/asap-compliance/asap_compliance/validators/mcp_auth.py
@@ -1,0 +1,542 @@
+"""MCP Auth Bridge compliance validation (profile ``mcp-auth-bridge``)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Any, Protocol, cast
+
+import httpx
+
+from asap.adapters.mcp.errors import (
+    AUTH_REQUIRED,
+    CAPABILITY_DENIED,
+    CONSTRAINT_VIOLATION,
+)
+from asap.mcp.client import MCPClient
+from asap.mcp.protocol import CallToolResult
+
+from asap_compliance.config import (
+    COMPLIANCE_ENV_VAR,
+    MCP_AUTH_BRIDGE_PROFILE,
+    McpAuthComplianceConfig,
+)
+from asap_compliance.validators.handshake import CheckResult
+
+_COMPLIANCE_JSON_PREFIX = "ASAP_COMPLIANCE_JSON:"
+_STDERR_JWT_PATTERN = re.compile(
+    r"Minted demo Agent JWT.*?:\s*(\S+)",
+    re.DOTALL,
+)
+
+
+@dataclass
+class McpAuthProbeTokens:
+    """JWT probe tokens parsed from a compliance-enabled MCP server."""
+
+    valid_jwt: str
+    wrong_capability_jwt: str
+    constraint_violation_action: str = "forbidden-action"
+
+
+@dataclass
+class McpAuthResult:
+    """Summary for the ``mcp-auth-bridge`` compliance profile."""
+
+    profile: str
+    auth_required_ok: bool
+    valid_jwt_ok: bool
+    wrong_capability_ok: bool
+    constraint_violation_ok: bool
+    manifest_alignment_ok: bool
+    checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.auth_required_ok
+            and self.valid_jwt_ok
+            and self.wrong_capability_ok
+            and self.constraint_violation_ok
+            and self.manifest_alignment_ok
+        )
+
+
+class McpAuthTransport(Protocol):
+    """Black-box MCP transport for compliance checks."""
+
+    async def connect(self) -> McpAuthProbeTokens: ...
+
+    async def list_tool_names(self) -> list[str]: ...
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        jwt: str | None = None,
+    ) -> CallToolResult: ...
+
+    async def disconnect(self) -> None: ...
+
+
+def _tool_error_text(result: CallToolResult) -> str:
+    parts: list[str] = []
+    for block in result.content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            parts.append(str(block.get("text", "")))
+        else:
+            text = getattr(block, "text", None)
+            if text is not None:
+                parts.append(str(text))
+    return "".join(parts)
+
+
+def _parse_probe_tokens(stderr_text: str, fallback_jwt: str | None) -> McpAuthProbeTokens:
+    """Parse compliance probe JWTs emitted on server stderr."""
+    for line in stderr_text.splitlines():
+        if line.startswith(_COMPLIANCE_JSON_PREFIX):
+            payload = json.loads(line.removeprefix(_COMPLIANCE_JSON_PREFIX))
+            return McpAuthProbeTokens(
+                valid_jwt=str(payload["valid_jwt"]),
+                wrong_capability_jwt=str(payload["wrong_capability_jwt"]),
+                constraint_violation_action=str(
+                    payload.get("constraint_violation_action", "forbidden-action")
+                ),
+            )
+
+    if fallback_jwt:
+        return McpAuthProbeTokens(
+            valid_jwt=fallback_jwt,
+            wrong_capability_jwt="",
+            constraint_violation_action="forbidden-action",
+        )
+
+    raise RuntimeError(
+        "MCP server stderr did not include compliance probe tokens; "
+        f"set {COMPLIANCE_ENV_VAR}=1 on the server subprocess"
+    )
+
+
+def _extract_demo_jwt(stderr_text: str) -> str | None:
+    match = _STDERR_JWT_PATTERN.search(stderr_text)
+    return match.group(1) if match else None
+
+
+class SubprocessMcpTransport:
+    """Drive an MCP server subprocess over stdio (JSON-RPC one line per message)."""
+
+    def __init__(self, config: McpAuthComplianceConfig) -> None:
+        self._config = config
+        self._client: MCPClient | None = None
+        self._stderr_chunks: list[bytes] = []
+        self._stderr_task: asyncio.Task[None] | None = None
+        self._tokens: McpAuthProbeTokens | None = None
+
+    async def _drain_stderr(self) -> None:
+        assert self._client is not None
+        process = self._client._process
+        if process is None or process.stderr is None:
+            return
+        while True:
+            chunk = await process.stderr.readline()
+            if not chunk:
+                break
+            self._stderr_chunks.append(chunk)
+
+    async def connect(self) -> McpAuthProbeTokens:
+        env = os.environ.copy()
+        if self._config.compliance_env:
+            env[COMPLIANCE_ENV_VAR] = "1"
+        # Stdio MCP uses stdout for JSON-RPC; suppress INFO logs that would corrupt the stream.
+        env.setdefault("ASAP_LOG_LEVEL", "CRITICAL")
+
+        self._client = MCPClient(
+            list(self._config.server_command),
+            receive_timeout=self._config.timeout_seconds,
+            allowed_binaries=self._config.allowed_binaries,
+            subprocess_env=env,
+        )
+        connect_task = asyncio.create_task(self._client.connect())
+        while self._client._process is None:
+            await asyncio.sleep(0.01)
+            if connect_task.done():
+                break
+        self._stderr_task = asyncio.create_task(self._drain_stderr())
+        await connect_task
+
+        await asyncio.sleep(0.3)
+        stderr_text = b"".join(self._stderr_chunks).decode("utf-8", errors="replace")
+        fallback = _extract_demo_jwt(stderr_text)
+        self._tokens = _parse_probe_tokens(stderr_text, fallback)
+        return self._tokens
+
+    async def list_tool_names(self) -> list[str]:
+        assert self._client is not None
+        tools = await self._client.list_tools()
+        return [tool.name for tool in tools]
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        jwt: str | None = None,
+    ) -> CallToolResult:
+        assert self._client is not None
+        meta = {"asap_agent_jwt": jwt} if jwt is not None else None
+        return await self._client.call_tool(name, arguments, meta=meta)
+
+    async def disconnect(self) -> None:
+        if self._stderr_task is not None:
+            self._stderr_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._stderr_task
+            self._stderr_task = None
+        if self._client is not None:
+            await self._client.disconnect()
+            self._client = None
+
+
+class MockMcpTransport:
+    """In-memory MCP transport for unit tests (predetermined responses)."""
+
+    def __init__(
+        self,
+        *,
+        tool_names: list[str],
+        responses: dict[tuple[str, str | None], CallToolResult],
+        tokens: McpAuthProbeTokens,
+    ) -> None:
+        self._tool_names = tool_names
+        self._responses = responses
+        self._tokens = tokens
+        self._connected = False
+
+    async def connect(self) -> McpAuthProbeTokens:
+        self._connected = True
+        return self._tokens
+
+    async def list_tool_names(self) -> list[str]:
+        if not self._connected:
+            raise RuntimeError("Not connected")
+        return list(self._tool_names)
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        jwt: str | None = None,
+    ) -> CallToolResult:
+        if not self._connected:
+            raise RuntimeError("Not connected")
+        key = (name, jwt)
+        if key not in self._responses:
+            raise KeyError(f"No mock response for tool={name!r} jwt={jwt!r}")
+        return self._responses[key]
+
+    async def disconnect(self) -> None:
+        self._connected = False
+
+
+def _load_manifest_data(config: McpAuthComplianceConfig) -> dict[str, Any]:
+    if config.manifest_url:
+        response = httpx.get(config.manifest_url, timeout=config.timeout_seconds)
+        return cast(dict[str, Any], response.json())
+
+    fixture = config.manifest_fixture_path
+    if fixture is None or not fixture.is_file():
+        raise FileNotFoundError(
+            f"Manifest fixture not found: {fixture}; set manifest_fixture_path or manifest_url"
+        )
+    return cast(dict[str, Any], json.loads(fixture.read_text(encoding="utf-8")))
+
+
+def _check_manifest_alignment(
+    config: McpAuthComplianceConfig,
+    registered_tools: list[str],
+) -> list[CheckResult]:
+    results: list[CheckResult] = []
+    if "manifest_alignment" in config.skip_checks:
+        return results
+
+    try:
+        manifest = _load_manifest_data(config)
+    except (httpx.HTTPError, OSError, json.JSONDecodeError, FileNotFoundError) as exc:
+        results.append(
+            CheckResult(
+                name="manifest_alignment_load",
+                passed=False,
+                message=f"Could not load manifest: {exc}",
+            )
+        )
+        return results
+
+    capabilities = manifest.get("capabilities", {})
+    if not isinstance(capabilities, dict):
+        results.append(
+            CheckResult(
+                name="manifest_alignment_schema",
+                passed=False,
+                message="Manifest capabilities must be an object",
+            )
+        )
+        return results
+
+    mcp_tools = capabilities.get("mcp_tools", [])
+    skills = capabilities.get("skills", [])
+    skill_ids: list[str] = []
+    if isinstance(skills, list):
+        for skill in skills:
+            if isinstance(skill, dict) and isinstance(skill.get("id"), str):
+                skill_ids.append(skill["id"])
+
+    registered = set(registered_tools)
+    unknown_tools: list[str] = []
+    if isinstance(mcp_tools, list):
+        for tool_name in mcp_tools:
+            if isinstance(tool_name, str) and tool_name not in registered:
+                unknown_tools.append(tool_name)
+
+    if unknown_tools:
+        results.append(
+            CheckResult(
+                name="manifest_mcp_tools_subset",
+                passed=False,
+                message=(
+                    f"Manifest mcp_tools not registered on server: {sorted(unknown_tools)}; "
+                    f"registered={sorted(registered)}"
+                ),
+            )
+        )
+    else:
+        results.append(
+            CheckResult(
+                name="manifest_mcp_tools_subset",
+                passed=True,
+                message="Manifest mcp_tools ⊆ registered MCP tools",
+            )
+        )
+
+    unknown_skills = [skill_id for skill_id in skill_ids if skill_id not in registered]
+    if unknown_skills:
+        results.append(
+            CheckResult(
+                name="manifest_skills_subset",
+                passed=False,
+                message=(
+                    f"Manifest skills[].id not registered as MCP tools/capabilities: "
+                    f"{sorted(unknown_skills)}; registered={sorted(registered)}"
+                ),
+            )
+        )
+    else:
+        results.append(
+            CheckResult(
+                name="manifest_skills_subset",
+                passed=True,
+                message="Manifest skills[].id ⊆ registered MCP tools / mapped capabilities",
+            )
+        )
+
+    alignment_ok = all(r.passed for r in results)
+    results.append(
+        CheckResult(
+            name="manifest_alignment",
+            passed=alignment_ok,
+            message="Manifest alignment (MCP-DISC-003) passed"
+            if alignment_ok
+            else "Manifest alignment (MCP-DISC-003) failed",
+        )
+    )
+    return results
+
+
+async def _check_unauthenticated_protected_tool(
+    config: McpAuthComplianceConfig,
+    transport: McpAuthTransport,
+) -> CheckResult:
+    result = await transport.call_tool(
+        config.protected_tool,
+        {"action": "probe"},
+        jwt=None,
+    )
+    text = _tool_error_text(result)
+    passed = result.is_error is True and AUTH_REQUIRED in text
+    return CheckResult(
+        name="auth_required",
+        passed=passed,
+        message=(
+            f"Unauthenticated {config.protected_tool!r} returned {AUTH_REQUIRED}"
+            if passed
+            else f"Expected {AUTH_REQUIRED} for unauthenticated protected tool, got: {text!r}"
+        ),
+    )
+
+
+async def _check_valid_jwt(
+    config: McpAuthComplianceConfig,
+    transport: McpAuthTransport,
+    tokens: McpAuthProbeTokens,
+) -> CheckResult:
+    result = await transport.call_tool(
+        config.protected_tool,
+        {"action": "compliance-ok"},
+        jwt=tokens.valid_jwt,
+    )
+    text = _tool_error_text(result)
+    passed = result.is_error is not True
+    return CheckResult(
+        name="valid_jwt",
+        passed=passed,
+        message=(
+            f"Protected {config.protected_tool!r} succeeded with valid JWT"
+            if passed
+            else f"Valid JWT call failed: {text!r}"
+        ),
+    )
+
+
+async def _check_wrong_capability(
+    config: McpAuthComplianceConfig,
+    transport: McpAuthTransport,
+    tokens: McpAuthProbeTokens,
+) -> CheckResult:
+    if not tokens.wrong_capability_jwt:
+        return CheckResult(
+            name="wrong_capability",
+            passed=False,
+            message=(
+                "Missing wrong_capability_jwt probe token; "
+                f"enable {COMPLIANCE_ENV_VAR}=1 on the MCP server"
+            ),
+        )
+
+    result = await transport.call_tool(
+        config.protected_tool,
+        {"action": "probe"},
+        jwt=tokens.wrong_capability_jwt,
+    )
+    text = _tool_error_text(result)
+    passed = result.is_error is True and CAPABILITY_DENIED in text
+    return CheckResult(
+        name="wrong_capability",
+        passed=passed,
+        message=(
+            f"Wrong capability JWT returned {CAPABILITY_DENIED}"
+            if passed
+            else f"Expected {CAPABILITY_DENIED}, got: {text!r}"
+        ),
+    )
+
+
+async def _check_constraint_violation(
+    config: McpAuthComplianceConfig,
+    transport: McpAuthTransport,
+    tokens: McpAuthProbeTokens,
+) -> CheckResult:
+    result = await transport.call_tool(
+        config.protected_tool,
+        {"action": tokens.constraint_violation_action},
+        jwt=tokens.valid_jwt,
+    )
+    text = _tool_error_text(result)
+    passed = result.is_error is True and CONSTRAINT_VIOLATION in text
+    return CheckResult(
+        name="constraint_violation",
+        passed=passed,
+        message=(
+            f"Constraint violation returned {CONSTRAINT_VIOLATION}"
+            if passed
+            else f"Expected {CONSTRAINT_VIOLATION}, got: {text!r}"
+        ),
+    )
+
+
+async def validate_mcp_auth_async(
+    config: McpAuthComplianceConfig,
+    *,
+    transport: McpAuthTransport | None = None,
+) -> McpAuthResult:
+    """Run the ``mcp-auth-bridge`` compliance profile against an MCP server.
+
+    Args:
+        config: MCP auth compliance configuration (stdio subprocess by default).
+        transport: Optional transport override (mock/in-process) for unit tests.
+
+    Returns:
+        Aggregated pass/fail result with per-check ``CheckResult`` entries.
+    """
+    if config.profile != MCP_AUTH_BRIDGE_PROFILE:
+        raise ValueError(f"Expected profile {MCP_AUTH_BRIDGE_PROFILE!r}, got {config.profile!r}")
+
+    owns_transport = transport is None
+    session: McpAuthTransport = transport or SubprocessMcpTransport(config)
+    checks: list[CheckResult] = []
+
+    try:
+        tokens = await session.connect()
+        tool_names = await session.list_tool_names()
+
+        if "auth_required" not in config.skip_checks:
+            auth_check = await _check_unauthenticated_protected_tool(config, session)
+            checks.append(auth_check)
+        else:
+            auth_check = CheckResult("auth_required", True, "skipped")
+
+        if "valid_jwt" not in config.skip_checks:
+            valid_check = await _check_valid_jwt(config, session, tokens)
+            checks.append(valid_check)
+        else:
+            valid_check = CheckResult("valid_jwt", True, "skipped")
+
+        if "wrong_capability" not in config.skip_checks:
+            wrong_check = await _check_wrong_capability(config, session, tokens)
+            checks.append(wrong_check)
+        else:
+            wrong_check = CheckResult("wrong_capability", True, "skipped")
+
+        if "constraint_violation" not in config.skip_checks:
+            constraint_check = await _check_constraint_violation(config, session, tokens)
+            checks.append(constraint_check)
+        else:
+            constraint_check = CheckResult("constraint_violation", True, "skipped")
+
+        manifest_checks = _check_manifest_alignment(config, tool_names)
+        checks.extend(manifest_checks)
+        manifest_alignment_ok = all(c.passed for c in manifest_checks) if manifest_checks else True
+
+    finally:
+        if owns_transport:
+            await session.disconnect()
+
+    return McpAuthResult(
+        profile=config.profile,
+        auth_required_ok=auth_check.passed,
+        valid_jwt_ok=valid_check.passed,
+        wrong_capability_ok=wrong_check.passed,
+        constraint_violation_ok=constraint_check.passed,
+        manifest_alignment_ok=manifest_alignment_ok,
+        checks=checks,
+    )
+
+
+def validate_mcp_auth(
+    config: McpAuthComplianceConfig,
+    *,
+    transport: McpAuthTransport | None = None,
+) -> McpAuthResult:
+    """Sync wrapper for :func:`validate_mcp_auth_async`."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(validate_mcp_auth_async(config, transport=transport))
+    raise RuntimeError(
+        "Cannot call sync validate_mcp_auth from inside a running event loop. "
+        "Use validate_mcp_auth_async."
+    )

--- a/asap-compliance/asap_compliance/validators/mcp_auth_transport.py
+++ b/asap-compliance/asap_compliance/validators/mcp_auth_transport.py
@@ -1,0 +1,198 @@
+"""MCP Auth Bridge compliance transports (stdio subprocess and mocks)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from asap.mcp.client import MCPClient
+from asap.mcp.protocol import CallToolResult
+
+from asap_compliance.config import COMPLIANCE_ENV_VAR, McpAuthComplianceConfig
+
+_COMPLIANCE_JSON_PREFIX = "ASAP_COMPLIANCE_JSON:"
+
+
+@dataclass
+class McpAuthProbeTokens:
+    """JWT probe tokens parsed from a compliance-enabled MCP server."""
+
+    valid_jwt: str
+    wrong_capability_jwt: str
+    constraint_violation_action: str = "forbidden-action"
+
+
+class McpAuthTransport(Protocol):
+    """Black-box MCP transport for compliance checks."""
+
+    async def connect(self) -> McpAuthProbeTokens: ...
+
+    async def list_tool_names(self) -> list[str]: ...
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        jwt: str | None = None,
+    ) -> CallToolResult: ...
+
+    async def disconnect(self) -> None: ...
+
+
+def _parse_probe_tokens(stderr_text: str) -> McpAuthProbeTokens:
+    """Parse compliance probe JWTs emitted on server stderr."""
+    for line in stderr_text.splitlines():
+        if line.startswith(_COMPLIANCE_JSON_PREFIX):
+            payload = json.loads(line.removeprefix(_COMPLIANCE_JSON_PREFIX))
+            return McpAuthProbeTokens(
+                valid_jwt=str(payload["valid_jwt"]),
+                wrong_capability_jwt=str(payload["wrong_capability_jwt"]),
+                constraint_violation_action=str(
+                    payload.get("constraint_violation_action", "forbidden-action")
+                ),
+            )
+
+    raise RuntimeError(
+        "MCP server stderr did not include compliance probe tokens; "
+        f"set {COMPLIANCE_ENV_VAR}=1 on the server subprocess"
+    )
+
+
+class SubprocessMcpTransport:
+    """Drive an MCP server subprocess over stdio (JSON-RPC one line per message)."""
+
+    def __init__(self, config: McpAuthComplianceConfig) -> None:
+        self._config = config
+        self._client: MCPClient | None = None
+        self._stderr_chunks: list[bytes] = []
+        self._stderr_task: asyncio.Task[None] | None = None
+        self._tokens: McpAuthProbeTokens | None = None
+
+    def _stderr_text(self) -> str:
+        return b"".join(self._stderr_chunks).decode("utf-8", errors="replace")
+
+    def _has_compliance_probe(self) -> bool:
+        return any(
+            line.startswith(_COMPLIANCE_JSON_PREFIX) for line in self._stderr_text().splitlines()
+        )
+
+    async def _drain_stderr(self) -> None:
+        assert self._client is not None
+        stderr = self._client.stderr
+        if stderr is None:
+            return
+        while True:
+            chunk = await stderr.readline()
+            if not chunk:
+                break
+            self._stderr_chunks.append(chunk)
+
+    async def _await_compliance_probe(self) -> str:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._config.timeout_seconds
+        while loop.time() < deadline:
+            if self._has_compliance_probe():
+                return self._stderr_text()
+            await asyncio.sleep(0.05)
+        raise RuntimeError(
+            "MCP server stderr did not include compliance probe tokens within "
+            f"{self._config.timeout_seconds}s; set {COMPLIANCE_ENV_VAR}=1 on the server subprocess"
+        )
+
+    async def connect(self) -> McpAuthProbeTokens:
+        env = os.environ.copy()
+        if self._config.compliance_env:
+            env[COMPLIANCE_ENV_VAR] = "1"
+        # Stdio MCP uses stdout for JSON-RPC; suppress INFO logs that would corrupt the stream.
+        env.setdefault("ASAP_LOG_LEVEL", "CRITICAL")
+
+        self._client = MCPClient(
+            list(self._config.server_command),
+            receive_timeout=self._config.timeout_seconds,
+            allowed_binaries=self._config.allowed_binaries,
+            subprocess_env=env,
+        )
+        connect_task = asyncio.create_task(self._client.connect())
+        while self._client.stderr is None:
+            await asyncio.sleep(0.01)
+            if connect_task.done():
+                break
+        self._stderr_task = asyncio.create_task(self._drain_stderr())
+        await connect_task
+
+        stderr_text = await self._await_compliance_probe()
+        self._tokens = _parse_probe_tokens(stderr_text)
+        return self._tokens
+
+    async def list_tool_names(self) -> list[str]:
+        assert self._client is not None
+        tools = await self._client.list_tools()
+        return [tool.name for tool in tools]
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        jwt: str | None = None,
+    ) -> CallToolResult:
+        assert self._client is not None
+        meta = {"asap_agent_jwt": jwt} if jwt is not None else None
+        return await self._client.call_tool(name, arguments, meta=meta)
+
+    async def disconnect(self) -> None:
+        if self._stderr_task is not None:
+            self._stderr_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._stderr_task
+            self._stderr_task = None
+        if self._client is not None:
+            await self._client.disconnect()
+            self._client = None
+
+
+class MockMcpTransport:
+    """In-memory MCP transport for unit tests (predetermined responses)."""
+
+    def __init__(
+        self,
+        *,
+        tool_names: list[str],
+        responses: dict[tuple[str, str | None], CallToolResult],
+        tokens: McpAuthProbeTokens,
+    ) -> None:
+        self._tool_names = tool_names
+        self._responses = responses
+        self._tokens = tokens
+        self._connected = False
+
+    async def connect(self) -> McpAuthProbeTokens:
+        self._connected = True
+        return self._tokens
+
+    async def list_tool_names(self) -> list[str]:
+        if not self._connected:
+            raise RuntimeError("Not connected")
+        return list(self._tool_names)
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        jwt: str | None = None,
+    ) -> CallToolResult:
+        if not self._connected:
+            raise RuntimeError("Not connected")
+        key = (name, jwt)
+        if key not in self._responses:
+            raise KeyError(f"No mock response for tool={name!r} jwt={jwt!r}")
+        return self._responses[key]
+
+    async def disconnect(self) -> None:
+        self._connected = False

--- a/asap-compliance/tests/fixtures/mcp_auth_bridge_manifest.json
+++ b/asap-compliance/tests/fixtures/mcp_auth_bridge_manifest.json
@@ -1,0 +1,25 @@
+{
+  "id": "urn:asap:agent:mcp-auth-bridge-demo",
+  "name": "MCP Auth Bridge Demo",
+  "version": "1.0.0",
+  "description": "Native stdio MCP with ASAP capability grants (compliance fixture)",
+  "capabilities": {
+    "asap_version": "2.5",
+    "skills": [
+      {
+        "id": "echo",
+        "description": "Public echo tool (no JWT required)"
+      },
+      {
+        "id": "secure_action",
+        "description": "Protected tool; requires Agent JWT + grant"
+      }
+    ],
+    "state_persistence": false,
+    "streaming": false,
+    "mcp_tools": ["echo", "secure_action"]
+  },
+  "endpoints": {
+    "asap": "https://example.test/asap"
+  }
+}

--- a/asap-compliance/tests/test_mcp_auth.py
+++ b/asap-compliance/tests/test_mcp_auth.py
@@ -50,9 +50,10 @@ def _build_mock_transport(
         wrong_capability_jwt=_WRONG_JWT,
         constraint_violation_action="forbidden-action",
     )
+    all_responses = {("echo", None): _success_result("echo"), **responses}
     return MockMcpTransport(
         tool_names=["echo", "secure_action"],
-        responses=responses,
+        responses=all_responses,
         tokens=tokens,
     )
 
@@ -68,7 +69,7 @@ class _ArgumentAwareMockTransport(MockMcpTransport):
     ) -> None:
         super().__init__(
             tool_names=["echo", "secure_action"],
-            responses=responses,
+            responses={("echo", None): _success_result("echo"), **responses},
             tokens=McpAuthProbeTokens(
                 valid_jwt=_VALID_JWT,
                 wrong_capability_jwt=_WRONG_JWT,
@@ -188,6 +189,7 @@ class TestMcpAuthResult:
             wrong_capability_ok=True,
             constraint_violation_ok=True,
             manifest_alignment_ok=True,
+            public_tool_ok=True,
         )
         assert ok.passed
 
@@ -198,6 +200,7 @@ class TestMcpAuthResult:
             wrong_capability_ok=True,
             constraint_violation_ok=True,
             manifest_alignment_ok=True,
+            public_tool_ok=True,
         )
         assert not bad.passed
 

--- a/asap-compliance/tests/test_mcp_auth.py
+++ b/asap-compliance/tests/test_mcp_auth.py
@@ -1,0 +1,235 @@
+"""Tests for the ``mcp-auth-bridge`` compliance profile."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from asap.adapters.mcp.errors import (
+    AUTH_REQUIRED,
+    CAPABILITY_DENIED,
+    CONSTRAINT_VIOLATION,
+)
+from asap.mcp.protocol import CallToolResult
+
+from asap_compliance.config import (
+    MCP_AUTH_BRIDGE_PROFILE,
+    McpAuthComplianceConfig,
+    default_mcp_auth_manifest_fixture,
+)
+from asap_compliance.validators.mcp_auth import (
+    McpAuthProbeTokens,
+    McpAuthResult,
+    MockMcpTransport,
+    validate_mcp_auth,
+    validate_mcp_auth_async,
+)
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+_VALID_JWT = "valid-jwt-token"
+_WRONG_JWT = "wrong-capability-jwt"
+
+
+def _error_result(code: str, detail: str | None = None) -> CallToolResult:
+    text = code if detail is None else f"{code}: {detail}"
+    return CallToolResult(content=[{"type": "text", "text": text}], isError=True)
+
+
+def _success_result(message: str) -> CallToolResult:
+    return CallToolResult(content=[{"type": "text", "text": message}], isError=False)
+
+
+def _build_mock_transport(
+    responses: dict[tuple[str, str | None], CallToolResult],
+) -> MockMcpTransport:
+    tokens = McpAuthProbeTokens(
+        valid_jwt=_VALID_JWT,
+        wrong_capability_jwt=_WRONG_JWT,
+        constraint_violation_action="forbidden-action",
+    )
+    return MockMcpTransport(
+        tool_names=["echo", "secure_action"],
+        responses=responses,
+        tokens=tokens,
+    )
+
+
+class _ArgumentAwareMockTransport(MockMcpTransport):
+    """Mock transport that branches on tool arguments for constraint checks."""
+
+    def __init__(
+        self,
+        responses: dict[tuple[str, str | None], CallToolResult],
+        *,
+        constraint_action: str = "forbidden-action",
+    ) -> None:
+        super().__init__(
+            tool_names=["echo", "secure_action"],
+            responses=responses,
+            tokens=McpAuthProbeTokens(
+                valid_jwt=_VALID_JWT,
+                wrong_capability_jwt=_WRONG_JWT,
+                constraint_violation_action=constraint_action,
+            ),
+        )
+        self._constraint_action = constraint_action
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        jwt: str | None = None,
+    ) -> CallToolResult:
+        if (
+            name == "secure_action"
+            and jwt == _VALID_JWT
+            and arguments
+            and arguments.get("action") == self._constraint_action
+        ):
+            return _error_result(CONSTRAINT_VIOLATION, "action forbidden")
+        return await super().call_tool(name, arguments, jwt=jwt)
+
+
+class TestMcpAuthProfile:
+    """Profile metadata and config defaults."""
+
+    def test_profile_name_is_mcp_auth_bridge(self) -> None:
+        """Release gate profile is ``mcp-auth-bridge`` (not ``mcp_auth``)."""
+        config = McpAuthComplianceConfig()
+        assert config.profile == MCP_AUTH_BRIDGE_PROFILE
+        assert config.profile == "mcp-auth-bridge"
+
+    def test_default_manifest_fixture_exists(self) -> None:
+        """Default MCP-DISC-003 fixture is bundled with compliance tests."""
+        path = default_mcp_auth_manifest_fixture()
+        assert path.is_file()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "capabilities" in data
+        assert "secure_action" in data["capabilities"]["mcp_tools"]
+
+
+class TestMcpAuthMockedChecks:
+    """Unit tests with mocked MCP transport responses."""
+
+    @pytest.mark.asyncio
+    async def test_all_checks_pass_with_mock_transport(self) -> None:
+        """Mocked server passes auth, JWT, capability, constraint, and manifest checks."""
+        transport = _ArgumentAwareMockTransport(
+            {
+                ("secure_action", None): _error_result(AUTH_REQUIRED),
+                ("secure_action", _VALID_JWT): _success_result("executed: ok"),
+                ("secure_action", _WRONG_JWT): _error_result(CAPABILITY_DENIED),
+            },
+        )
+        config = McpAuthComplianceConfig(
+            manifest_fixture_path=_FIXTURES / "mcp_auth_bridge_manifest.json",
+        )
+        result = await validate_mcp_auth_async(config, transport=transport)
+        assert result.passed, result.checks
+        assert result.profile == "mcp-auth-bridge"
+
+    @pytest.mark.asyncio
+    async def test_auth_required_fails_when_mock_allows_unauthenticated(self) -> None:
+        """Validator fails when unauthenticated protected call succeeds."""
+        transport = _build_mock_transport(
+            {
+                ("secure_action", None): _success_result("should not succeed"),
+                ("secure_action", _VALID_JWT): _success_result("executed: ok"),
+                ("secure_action", _WRONG_JWT): _error_result(CAPABILITY_DENIED),
+            },
+        )
+        config = McpAuthComplianceConfig(
+            manifest_fixture_path=_FIXTURES / "mcp_auth_bridge_manifest.json",
+        )
+        result = await validate_mcp_auth_async(config, transport=transport)
+        assert not result.passed
+        assert not result.auth_required_ok
+
+    @pytest.mark.asyncio
+    async def test_manifest_alignment_fails_unknown_tool(self, tmp_path: Path) -> None:
+        """Manifest alignment fails when manifest declares an unknown MCP tool."""
+        bad_manifest = {
+            "capabilities": {
+                "mcp_tools": ["echo", "secure_action", "phantom_tool"],
+                "skills": [{"id": "echo"}, {"id": "secure_action"}],
+            }
+        }
+        manifest_path = tmp_path / "bad_manifest.json"
+        manifest_path.write_text(json.dumps(bad_manifest), encoding="utf-8")
+
+        transport = _ArgumentAwareMockTransport(
+            {
+                ("secure_action", None): _error_result(AUTH_REQUIRED),
+                ("secure_action", _VALID_JWT): _success_result("executed: ok"),
+                ("secure_action", _WRONG_JWT): _error_result(CAPABILITY_DENIED),
+            },
+        )
+        config = McpAuthComplianceConfig(manifest_fixture_path=manifest_path)
+        result = await validate_mcp_auth_async(config, transport=transport)
+        assert not result.manifest_alignment_ok
+        subset_check = next(c for c in result.checks if c.name == "manifest_mcp_tools_subset")
+        assert not subset_check.passed
+        assert "phantom_tool" in subset_check.message
+
+
+class TestMcpAuthResult:
+    """McpAuthResult aggregate behavior."""
+
+    def test_passed_requires_all_categories(self) -> None:
+        """``passed`` is False when any auth category fails."""
+        ok = McpAuthResult(
+            profile="mcp-auth-bridge",
+            auth_required_ok=True,
+            valid_jwt_ok=True,
+            wrong_capability_ok=True,
+            constraint_violation_ok=True,
+            manifest_alignment_ok=True,
+        )
+        assert ok.passed
+
+        bad = McpAuthResult(
+            profile="mcp-auth-bridge",
+            auth_required_ok=True,
+            valid_jwt_ok=False,
+            wrong_capability_ok=True,
+            constraint_violation_ok=True,
+            manifest_alignment_ok=True,
+        )
+        assert not bad.passed
+
+
+class TestMcpAuthSyncWrapper:
+    """Sync API behavior."""
+
+    def test_validate_mcp_auth_sync_with_mock(self) -> None:
+        """Sync wrapper runs mocked validation outside a running loop."""
+        transport = _ArgumentAwareMockTransport(
+            {
+                ("secure_action", None): _error_result(AUTH_REQUIRED),
+                ("secure_action", _VALID_JWT): _success_result("executed: ok"),
+                ("secure_action", _WRONG_JWT): _error_result(CAPABILITY_DENIED),
+            },
+        )
+        config = McpAuthComplianceConfig(
+            manifest_fixture_path=_FIXTURES / "mcp_auth_bridge_manifest.json",
+        )
+        result = validate_mcp_auth(config, transport=transport)
+        assert result.valid_jwt_ok
+        assert result.passed
+
+
+@pytest.mark.asap_compliance
+class TestMcpAuthSubprocessIntegration:
+    """Subprocess integration against examples/mcp_auth_bridge/server.py."""
+
+    @pytest.mark.asyncio
+    async def test_subprocess_example_server_passes_profile(self) -> None:
+        """Full ``mcp-auth-bridge`` profile passes against the S3 example server."""
+        config = McpAuthComplianceConfig()
+        result = await validate_mcp_auth_async(config)
+        assert result.profile == "mcp-auth-bridge"
+        assert result.passed, [c for c in result.checks if not c.passed]

--- a/asap-compliance/uv.lock
+++ b/asap-compliance/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "asap-compliance"
-version = "0.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "asap-protocol" },
@@ -61,7 +61,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asap-protocol", specifier = ">=1.1.0" },
+    { name = "asap-protocol", specifier = ">=1.2.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pytest", specifier = ">=8.0" },
@@ -73,14 +73,16 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "asap-protocol"
-version = "1.1.0"
+version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "authlib" },
     { name = "brotli" },
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx", extra = ["http2"] },
+    { name = "jcs" },
     { name = "joserfc" },
     { name = "jsonschema" },
     { name = "limits" },
@@ -98,9 +100,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/c2/e6d6a798e53d3bd1f398b94d87704ed51e211af9647d604889b5a5998d5f/asap_protocol-1.1.0.tar.gz", hash = "sha256:923e1c87abaaeac0565f85d62291f4d9ed6eb2a142d2c478542b7a896f50814c", size = 1023410, upload-time = "2026-02-11T01:13:29.285Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/05/ffdcc67f2749222b46d427e9bbdfea78e504eb820430ea37f85201ef5c51/asap_protocol-2.4.1.tar.gz", hash = "sha256:3bd04c580c2b82362ad54ebb620f7b82f06b7b28a81705c9a81663e7044d9804", size = 343948, upload-time = "2026-06-15T01:22:49.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/a4/63dbfa69c86e2e4835c8445a773b358c7d0c69aabe064a57a16b00b2cd17/asap_protocol-1.1.0-py3-none-any.whl", hash = "sha256:3fac5976e8c48d411016f4dd39f9824a1876c6868fe0e76e49011e772903489e", size = 219409, upload-time = "2026-02-11T01:13:27.809Z" },
+    { url = "https://files.pythonhosted.org/packages/55/48/b7c2f2c87105f0c366f1bd109178cf62d59c700ce6947742bc23c7df2442/asap_protocol-2.4.1-py3-none-any.whl", hash = "sha256:4e7fbbec4edd929c7a8cb9cdbcc06b8239d1d633fb21d10531eb46cfb54feca5", size = 397463, upload-time = "2026-06-15T01:22:47.646Z" },
 ]
 
 [[package]]
@@ -123,14 +125,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.8"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/6c/c88eac87468c607f88bc24df1f3b31445ee6fc9ba123b09e666adf687cd9/authlib-1.6.8.tar.gz", hash = "sha256:41ae180a17cf672bc784e4a518e5c82687f1fe1e98b0cafaeda80c8e4ab2d1cb", size = 165074, upload-time = "2026-02-14T04:02:17.941Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/73/f7084bf12755113cd535ae586782ff3a6e710bfbe6a0d13d1c2f81ffbbfa/authlib-1.6.8-py2.py3-none-any.whl", hash = "sha256:97286fd7a15e6cfefc32771c8ef9c54f0ed58028f1322de6a2a7c969c3817888", size = 244116, upload-time = "2026-02-14T04:02:15.579Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -307,55 +310,55 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.5"
+version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289, upload-time = "2026-02-10T19:17:08.274Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
-    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
-    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
-    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
-    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230, upload-time = "2026-02-10T19:17:30.518Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909, upload-time = "2026-02-10T19:17:32.083Z" },
-    { url = "https://files.pythonhosted.org/packages/00/13/3d278bfa7a15a96b9dc22db5a12ad1e48a9eb3d40e1827ef66a5df75d0d0/cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2", size = 7119287, upload-time = "2026-02-10T19:17:33.801Z" },
-    { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728, upload-time = "2026-02-10T19:17:35.569Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287, upload-time = "2026-02-10T19:17:36.938Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291, upload-time = "2026-02-10T19:17:38.748Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539, upload-time = "2026-02-10T19:17:40.241Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199, upload-time = "2026-02-10T19:17:41.789Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131, upload-time = "2026-02-10T19:17:43.379Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072, upload-time = "2026-02-10T19:17:45.481Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170, upload-time = "2026-02-10T19:17:46.997Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741, upload-time = "2026-02-10T19:17:48.661Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728, upload-time = "2026-02-10T19:17:50.058Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001, upload-time = "2026-02-10T19:17:51.54Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ef/5d00ef966ddd71ac2e6951d278884a84a40ffbd88948ef0e294b214ae9e4/cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a", size = 3003637, upload-time = "2026-02-10T19:17:52.997Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/57/f3f4160123da6d098db78350fdfd9705057aad21de7388eacb2401dceab9/cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4", size = 3469487, upload-time = "2026-02-10T19:17:54.549Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514, upload-time = "2026-02-10T19:17:56.267Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
-    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
-    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
-    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
-    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
-    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
-    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
-    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
-    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
 ]
 
 [[package]]
@@ -372,7 +375,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.129.0"
+version = "0.138.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -381,9 +384,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/47/75f6bea02e797abff1bca968d5997793898032d9923c1935ae2efdece642/fastapi-0.129.0.tar.gz", hash = "sha256:61315cebd2e65df5f97ec298c888f9de30430dd0612d59d6480beafbc10655af", size = 375450, upload-time = "2026-02-12T13:54:52.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/58/ff455d9fe47c60abadb34b9e05a304b1f05f5ab8000ac01565156b6f5e43/fastapi-0.138.0.tar.gz", hash = "sha256:d445a4877636ad191e7053e08c9bf98cb921a6756776848400bb773d1740c061", size = 419240, upload-time = "2026-06-20T01:18:05.259Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/dd/d0ee25348ac58245ee9f90b6f3cbb666bf01f69be7e0911f9851bddbda16/fastapi-0.129.0-py3-none-any.whl", hash = "sha256:b4946880e48f462692b31c083be0432275cbfb6e2274566b1be91479cc1a84ec", size = 102950, upload-time = "2026-02-12T13:54:54.528Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ff/8496d9847a5fedae775eb49460722d3efaa80487854273e9647ae876218c/fastapi-0.138.0-py3-none-any.whl", hash = "sha256:b6f54fd1bd72c80b0f899f172c61a600f6f7af9b43d4d772a018f35624048cb0", size = 126779, upload-time = "2026-06-20T01:18:03.483Z" },
 ]
 
 [[package]]
@@ -533,15 +536,24 @@ wheels = [
 ]
 
 [[package]]
+name = "jcs"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/e5/9d547f0d42ba00f68eec773aa7b2145e0c0335eb632cbaf519f480a429af/jcs-0.2.1.tar.gz", hash = "sha256:9f20360b2f3b0a410d65493b448f96306d80e37fb46283f3f4aa5db2c7c1472b", size = 6886, upload-time = "2022-04-10T14:41:24.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/d4/9a99bc15266a842bd14a1913afdb05182888ebab035666c1ce8a64537ca2/jcs-0.2.1-py3-none-any.whl", hash = "sha256:e23a3e1de60f832d33cd811bb9c3b3be79219cdf95f63b88f0972732c3fa8476", size = 7603, upload-time = "2022-04-10T14:41:23.207Z" },
+]
+
+[[package]]
 name = "joserfc"
-version = "1.6.1"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/3d/82375487dcc2bcdf136a68e1a8543165feccbbc8833dfc451f87a5f83b81/joserfc-1.6.1.tar.gz", hash = "sha256:7759a14d732d93503317468c0dd258510c4f64b30759cf42e96016c97b38c4b7", size = 226277, upload-time = "2025-12-30T08:45:07.289Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/01/9674cc6d478406ae61d910cb16ca8b5699a8a9e6a2019987ebe5a5957d1d/joserfc-1.6.1-py3-none-any.whl", hash = "sha256:74d158c9d56be54c710cdcb2a0741372254b682ad2101a0f72e5bd0e925695f0", size = 70349, upload-time = "2025-12-30T08:45:05.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
 ]
 
 [[package]]

--- a/engineering/tasks/v2.5.0/sprint-S4-compliance.md
+++ b/engineering/tasks/v2.5.0/sprint-S4-compliance.md
@@ -10,13 +10,85 @@
 
 ---
 
+## Parallel Execution (Agent Workstreams)
+
+> **Status:** S4 gate green on `feat/v2.5.0-s4-compliance` — acceptance criteria satisfied locally; PR into `release/2.5.0` pending merge.
+> **Branch:** `feat/v2.5.0-s4-compliance` → PR into `release/2.5.0`.
+> **Rule:** Interactive dev in this chat — one sub-task at a time; parallel agents only where noted below.
+> **Commits:** Hold until user approves a batch (no drive-by commits on this branch).
+
+### Dependency phases
+
+```text
+Phase 1 (parallel)                 Phase 2 (parallel)              Phase 3 (gate)
+──────────────────                 ──────────────────              ──────────────
+A: 1.1 lock gate          ──────►  A: 1.2 + 1.3 + 2.1            Final verify + acceptance
+C: 3.2 stdio integration           B: 2.2 README (draft → final)
+D: 3.1 CI release/2.5.0            (B finalizes after 2.1 command)
+E: 4.1 TS spike doc
+```
+
+### Agent boundaries
+
+| Agent | Owns | Tasks | Depends on | Can parallelize with |
+|-------|------|-------|------------|----------------------|
+| **A — Compliance validator** | `asap-compliance/asap_compliance/validators/mcp_auth.py`, `config.py`, `harness.py`, `validators/__init__.py`, `asap-compliance/tests/test_mcp_auth.py` | 1.1 → 1.2 → 1.3 → 2.1 | S3 example on `release/2.5.0`; `CheckResult` from `handshake.py` | C, D, E (Phase 1) |
+| **B — Example docs** | `examples/mcp_auth_bridge/README.md` | 2.2 | 2.1 CLI/profile command locked | E anytime; finalize after A Phase 2 |
+| **C — Stdio integration test** | `tests/adapters/mcp/test_stdio_integration.py` (or extend `test_auth_middleware.py`) | 3.2 | S1–S2 middleware; `tests/adapters/mcp/conftest.py` | A, D, E (Phase 1) |
+| **D — CI gate** | `.github/workflows/ci.yml` (and siblings if needed) | 3.1 | None | A, C, E (Phase 1) |
+| **E — TypeScript spike** | `engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md` | 4.1 | None | A, B (draft), C, D (all phases) |
+
+### Sequential vs parallel summary
+
+| Must be sequential | Safe to parallelize |
+|--------------------|---------------------|
+| **1.1 → 1.2 → 1.3 → 2.1** (single validator module + harness wire-up) | **C ∥ D ∥ E** from day one |
+| **2.1 → 2.2 finalize** (README documents exact compliance command) | **A (1.1) ∥ C ∥ D ∥ E** on Phase 1 |
+| **All → acceptance** (profile green against example + pytest suite) | **B draft ∥ A Phase 2** (placeholder command OK until 2.1 lands) |
+
+### Notes for sub-agents
+
+- **Release gate:** Profile name is **`mcp-auth-bridge`** (not `mcp_auth`). Implement in `asap-compliance`, not `src/asap/testing/compliance.py` (HTTP/ASGI harness v2 stays unchanged unless S4 explicitly adds shared support).
+- **Black-box checks (MCP-AUTH-007):** (a) unauthenticated `tools/call` on protected tool → error; (b) valid JWT → success; (c) wrong capability → denied; (d) constraint violation → `asap:constraint_violation`. Start with **mocked** MCP responses in unit tests; add subprocess driver against `examples/mcp_auth_bridge/server.py` in 2.1 verify.
+- **Manifest alignment (MCP-DISC-003):** manifest-declared tools/capabilities ⊆ registered MCP tools / mapped capabilities; use fixture JSON when live `manifest_url` unavailable.
+- **Stdio driver pattern:** subprocess `uv run python examples/mcp_auth_bridge/server.py`, JSON-RPC on stdin/stdout; mirror JWT minting from `tests/adapters/mcp/conftest.py` (copy setup, do not import test modules from example code).
+- **Example tools:** `echo` = public; `secure_action` = protected — same as S3 example.
+- **CI gap:** `ci.yml` currently triggers only on `main`; task 3.1 adds `release/2.5.0` (and optionally `release/**`) so PRs into the integration branch run `tests/adapters/mcp/`. Full suite already includes them via `uv run pytest -n auto`; explicit step is optional but documents the gate.
+- **TS spike (SHOULD):** Survey `packages/typescript/` layout, `@modelcontextprotocol/sdk` version/compatibility, package name `@asap-protocol/mcp-auth`; record **ship vs defer** for S5 with minimum scope (Bearer extraction + error mapping).
+- **No secrets:** Generate keys at runtime in tests; never commit JWTs or private keys.
+- **Verify gate:** `uv run pytest asap-compliance/tests/test_mcp_auth.py -v`; `uv run pytest tests/adapters/mcp/ -v`; compliance profile against example documented in README.
+
+### Sub-agent prompt templates
+
+**Agent A (1.1 → 2.1):**
+> Create `asap-compliance/asap_compliance/validators/mcp_auth.py` with profile **`mcp-auth-bridge`**: reuse `CheckResult` from `validators/handshake.py`; add `McpAuthResult` summary if needed. Implement checks (a)–(d) and manifest alignment (MCP-DISC-003). Extend `ComplianceConfig` (or sibling config) for stdio subprocess command defaulting to `examples/mcp_auth_bridge/server.py`. Wire `validate_mcp_auth` / `validate_mcp_auth_async` into `validators/__init__.py` and `harness.py`. Add `asap-compliance/tests/test_mcp_auth.py` with mocked responses first, then subprocess integration. Do **not** modify `src/asap/testing/compliance.py` unless stdio needs explicit shared helper.
+
+**Agent B (2.2):**
+> Add § **Compliance** to `examples/mcp_auth_bridge/README.md`: document `uv run` command for `mcp-auth-bridge` profile, list expected pass/fail checks, link to `docs/adapters/mcp-auth-bridge.md`. Draft with placeholder until Agent A locks CLI; finalize command string after 2.1.
+
+**Agent C (3.2):**
+> Add `tests/adapters/mcp/test_stdio_integration.py`: subprocess or in-process stdio exercise of protected `MCPServer` with real Agent JWT in `_meta.asap_agent_jwt` — one success (`secure_action` + grant) and one denied (missing JWT or wrong capability). Headless, no network. Reuse `conftest.py` fixtures; follow `tests/examples/test_mcp_auth_bridge_example.py` subprocess patterns if present.
+
+**Agent D (3.1):**
+> Update `.github/workflows/ci.yml` `on.push` and `on.pull_request` `branches` to include `release/2.5.0`. Optionally add explicit `uv run pytest tests/adapters/mcp/ -v --tb=short` step in `test-python` job for visibility. Confirm PRs targeting `release/2.5.0` run adapter MCP tests.
+
+**Agent E (4.1):**
+> Create `engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md`: inventory `packages/typescript/client` and SDK deps; assess `@modelcontextprotocol/sdk` for HTTP/SSE Bearer middleware; define minimum `@asap-protocol/mcp-auth` scope or document defer to v2.5.0.1 with rationale for S5 CHANGELOG/backlog.
+
+---
+
 ## Relevant Files
 
 ### New / modify
-- `asap-compliance/asap_compliance/validators/mcp_auth.py` — MCP auth bridge checks
-- `asap-compliance/tests/test_mcp_auth.py`
-- `examples/mcp_auth_bridge/` — ensure stdio subprocess or script hook can be driven by `asap-compliance`
+- `asap-compliance/asap_compliance/validators/mcp_auth.py` — MCP auth bridge checks (profile `mcp-auth-bridge`)
+- `asap-compliance/asap_compliance/config.py` — `McpAuthComplianceConfig` + stdio subprocess defaults
+- `asap-compliance/asap_compliance/harness.py` — exports `validate_mcp_auth` / `validate_mcp_auth_async`
 - `asap-compliance/asap_compliance/validators/__init__.py` — export new validator
+- `asap-compliance/tests/test_mcp_auth.py` — mocked + subprocess integration tests
+- `asap-compliance/tests/fixtures/mcp_auth_bridge_manifest.json` — MCP-DISC-003 fixture
+- `examples/mcp_auth_bridge/server.py` — `ASAP_MCP_COMPLIANCE=1` probe JWT emission on stderr
+- `src/asap/mcp/client.py` — optional `subprocess_env` for compliance driver
+- `tests/adapters/mcp/test_stdio_integration.py` — end-to-end stdio protected MCPServer integration (task 3.2)
 - `engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md` — spike result or defer rationale
 
 ### Reference
@@ -29,20 +101,20 @@
 
 ### 1.0 Validator design
 
-- [ ] 1.1 Lock compliance gate
+- [x] 1.1 Lock compliance gate
   - **File**: `asap-compliance/asap_compliance/validators/mcp_auth.py` (create)
   - **What**: Treat `asap-compliance` profile `mcp-auth-bridge` as the release gate for stdio MCP. Do not rely on `src/asap/testing/compliance.py` unless S4 explicitly adds shared HTTP/ASGI support.
   - **Why**: v2.5.0 validates native MCP stdio auth, while the existing harness v2 is HTTP/ASGI-focused.
   - **Verify**: S4 README or test output names `mcp-auth-bridge` as the gate.
 
-- [ ] 1.2 Define MCP auth compliance checks
+- [x] 1.2 Define MCP auth compliance checks
   - **File**: `asap-compliance/asap_compliance/validators/mcp_auth.py` (create)
   - **What**: Black-box checks: (a) unauthenticated `tools/call` on protected tool returns error; (b) valid JWT succeeds; (c) wrong capability denied; (d) constraint violation returns `asap:constraint_violation`. Config: stdio subprocess or test server URL.
   - **Why**: MCP-AUTH-007
   - **Pattern**: Reuse the `CheckResult` shape from `validators/handshake.py`; wrap checks in an MCP-specific result object if the CLI needs summary metadata.
   - **Verify**: Unit tests with mocked server responses first
 
-- [ ] 1.3 Define manifest alignment compliance check
+- [x] 1.3 Define manifest alignment compliance check
   - **File**: `asap-compliance/asap_compliance/validators/mcp_auth.py` (create)
   - **What**: Validate manifest-declared tool/capability names are a subset of registered MCP tools or mapped capabilities, using example fixture data when a live manifest URL is unavailable.
   - **Why**: MCP-DISC-003
@@ -50,24 +122,24 @@
 
 ### 2.0 Integration with harness
 
-- [ ] 2.1 Wire validator into compliance CLI
+- [x] 2.1 Wire validator into compliance CLI
   - **File**: `asap-compliance/asap_compliance/validators/__init__.py` + main runner if exists
   - **What**: Optional profile `mcp-auth-bridge` targeting the stdio example server. If shared `src/asap/testing/compliance.py` support is needed, add it explicitly rather than assuming the HTTP harness covers stdio MCP.
   - **Verify**: `uv run` compliance against `examples/mcp_auth_bridge` passes required checks
 
-- [ ] 2.2 Example compliance script or README section
+- [x] 2.2 Example compliance script or README section
   - **File**: `examples/mcp_auth_bridge/README.md`
   - **What**: Document command to run the `asap-compliance` `mcp-auth-bridge` profile and expected pass/fail checks.
   - **Verify**: CI or local script passes
 
 ### 3.0 Regression tests
 
-- [ ] 3.1 Full adapter test suite in CI
+- [x] 3.1 Full adapter test suite in CI
   - **File**: root CI workflow or existing pytest job
   - **What**: Ensure `tests/adapters/mcp/` runs on every PR to `release/2.5.0`
   - **Verify**: PR check green
 
-- [ ] 3.2 End-to-end stdio integration test
+- [x] 3.2 End-to-end stdio integration test
   - **File**: `tests/adapters/mcp/test_auth_middleware.py` or `tests/adapters/mcp/test_stdio_integration.py`
   - **What**: Exercise protected `MCPServer` over stdio/subprocess with a real Agent JWT in `_meta.asap_agent_jwt`, including one success and one denied call.
   - **Why**: PRD DoD requires unit + integration tests with mock Agent JWT.
@@ -75,7 +147,7 @@
 
 ### 4.0 TypeScript middleware spike
 
-- [ ] 4.1 Decide ship vs defer for `@asap-protocol/mcp-auth`
+- [x] 4.1 Decide ship vs defer for `@asap-protocol/mcp-auth`
   - **File**: `engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md` (create)
   - **What**: Check current `packages/typescript/` layout, `@modelcontextprotocol/sdk` compatibility, package naming, and minimum implementation needed for Bearer extraction + error mapping.
   - **Why**: MCP-TS-001..003 are SHOULD, but the release must record a deliberate ship/defer decision.
@@ -85,10 +157,10 @@
 
 ## Acceptance Criteria (S4)
 
-- [ ] MCP auth validator returns pass/fail `CheckResult` for auth required, valid JWT, wrong capability, and constraint violation paths
-- [ ] Manifest alignment check covers manifest tools/capabilities ⊆ registered MCP tools/mapped capabilities
-- [ ] `asap-compliance` `mcp-auth-bridge` profile is the documented release gate for stdio MCP
-- [ ] Protected stdio MCP integration test passes in pytest
-- [ ] TypeScript middleware spike has a recorded ship/defer decision
-- [ ] Example passes the documented MCP auth compliance profile
-- [ ] `pytest asap-compliance/tests/test_mcp_auth.py -v` green
+- [x] MCP auth validator returns pass/fail `CheckResult` for auth required, valid JWT, wrong capability, and constraint violation paths
+- [x] Manifest alignment check covers manifest tools/capabilities ⊆ registered MCP tools/mapped capabilities
+- [x] `asap-compliance` `mcp-auth-bridge` profile is the documented release gate for stdio MCP
+- [x] Protected stdio MCP integration test passes in pytest
+- [x] TypeScript middleware spike has a recorded ship/defer decision
+- [x] Example passes the documented MCP auth compliance profile
+- [x] `pytest asap-compliance/tests/test_mcp_auth.py -v` green

--- a/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
+++ b/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
@@ -1,6 +1,6 @@
 # Tasks: v2.5.0 MCP Auth Bridge — Sprint Index
 
-**Status: 🟡 IN PROGRESS** — S0–S2 merged on **`release/2.5.0`**; S3 complete on **`feat/v2.5.0-s3-docs-examples`** ([PR #232](https://github.com/adriannoes/asap-protocol/pull/232) open); S4–S5 planned.
+**Status: 🟡 IN PROGRESS** — S0–S3 merged on **`release/2.5.0`** (`175ae02`); S4 gate green on **`feat/v2.5.0-s4-compliance`** (PR pending merge); S5 planned.
 
 Based on [PRD v2.5.0 MCP Auth Bridge](../../../product/prd/prd-v2.5.0-mcp-auth-bridge.md). Each sprint maps to a PR into **`release/2.5.0`** (see [BRANCHING.md](./BRANCHING.md)); merge to `main` only after S5.
 
@@ -19,8 +19,8 @@ Based on [PRD v2.5.0 MCP Auth Bridge](../../../product/prd/prd-v2.5.0-mcp-auth-b
 | **S0** | [Design lock & scaffold](./sprint-S0-design-lock.md) | §6 API, MCP-AUTH-005 | P0 | ✅ Done |
 | **S1** | [Core auth middleware](./sprint-S1-core-middleware.md) | MCP-AUTH-001..004, 006 and auth portions of 007 | P0 | ✅ Done (merged `60e2e85`, PR #229) |
 | **S2** | [Capability mapping & errors](./sprint-S2-capability-mapping.md) | MCP-MAP-*, §4.5–4.6 | P0 | ✅ Done (merged `8352936`, PR #231; MCP-MAP-004 deferred) |
-| **S3** | [Docs, examples & discovery](./sprint-S3-docs-examples.md) | MCP-DISC-*, MCP-DOC-* | P0/P1 | 🟡 PR open ([#232](https://github.com/adriannoes/asap-protocol/pull/232) → `release/2.5.0`) |
-| **S4** | [Compliance & integration tests](./sprint-S4-compliance.md) | MCP-DISC-003, harness | P1 | 🔵 Planned |
+| **S3** | [Docs, examples & discovery](./sprint-S3-docs-examples.md) | MCP-DISC-*, MCP-DOC-* | P0/P1 | ✅ Done (merged `175ae02`, PR #232) |
+| **S4** | [Compliance & integration tests](./sprint-S4-compliance.md) | MCP-DISC-003, harness | P1 | ✅ Ready — `feat/v2.5.0-s4-compliance` (gate green, PR pending merge) |
 | **S5** | [Release v2.5.0](./sprint-S5-release.md) | DoD, metrics | P0 | 🔵 Planned |
 
 > **Note:** `@asap-protocol/mcp-auth` (TypeScript, MCP-TS-*) is SHOULD. S4 runs a scoped feasibility spike; S5 either ships it or records an explicit v2.5.0.1 defer in CHANGELOG/backlog.
@@ -93,7 +93,7 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
   - **Enables:** v2.5.1 Adapter Lab II (blocked until tag).
   - **Depends on:** Tasks 2.0–4.0.
   - **Acceptance criteria:**
-    - [ ] `asap-compliance` includes `mcp_auth` profile cases for stdio MCP, including manifest tools ⊆ registered tools (green in CI)
+    - [x] `asap-compliance` includes `mcp_auth` profile cases for stdio MCP, including manifest tools ⊆ registered tools (green locally; CI on PR merge)
     - [ ] `pyproject.toml` / npm → **2.5.0**; tag `v2.5.0` published
     - [ ] `AGENTS.md` knowledge map updated; CHANGELOG `[2.5.0]`
     - [ ] Pre-push CI suite green (ruff, mypy, pytest, TS if touched)
@@ -141,7 +141,7 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 
 - [ ] All parent tasks 1.0–5.0 complete (1.0–4.0 ✅; 5.0 pending S4–S5)
 - [x] PRD requirements MCP-AUTH-001..006, MCP-MAP-001..003, MCP-DOC-001..004 satisfied (MCP-MAP-004 / `hide_unauthorized_tools` deferred per design lock §6)
-- [ ] PRD discovery requirements MCP-DISC-001..003 satisfied or explicitly deferred with rationale (MCP-DISC-001/002 ✅ in S3; MCP-DISC-003 → S4 compliance harness)
+- [ ] PRD discovery requirements MCP-DISC-001..003 satisfied or explicitly deferred with rationale (MCP-DISC-001/002 ✅ in S3; MCP-DISC-003 ✅ in S4 compliance harness)
 - [x] Unprotected `MCPServer` usage unchanged (opt-in via `protect_server`)
 - [x] No wire-protocol breaking changes
 
@@ -176,3 +176,4 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 | 2026-06-24 | S2 branch `feat/v2.5.0-s2-capability-map` opened; parallel workstreams documented in sprint-S2 |
 | 2026-06-24 | S2 merged on `release/2.5.0` (`8352936`); S3 branch `feat/v2.5.0-s3-docs-examples` opened with parallel workstreams |
 | 2026-06-24 | S1/S2 merge refs reconciled; S3 impl complete — [PR #232](https://github.com/adriannoes/asap-protocol/pull/232) open into `release/2.5.0`; parent tasks 1.0–4.0 marked done |
+| 2026-06-24 | S4 acceptance gate green on `feat/v2.5.0-s4-compliance` (pytest + ruff + mypy); PR pending merge into `release/2.5.0` |

--- a/engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md
+++ b/engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md
@@ -1,0 +1,259 @@
+# Spike: `@asap-protocol/mcp-auth` (S4 Task 4.1)
+
+> **Status**: COMPLETE (S4)
+> **PRD**: [MCP-TS-001..003](../../../product/prd/prd-v2.5.0-mcp-auth-bridge.md#54-typescript-should)
+> **Sprint**: [sprint-S4-compliance.md](./sprint-S4-compliance.md) task 4.1
+> **Decision**: **DEFER to v2.5.0.1** (see §6; durable record in [PRD v2.5.1 §3](../../../product/prd/prd-v2.5.1-adapter-lab-ii.md#3-carry-over-from-v250-asap-protocolmcp-auth))
+
+---
+
+## 1. Executive summary
+
+| Question | Answer |
+|----------|--------|
+| Ship `@asap-protocol/mcp-auth` in v2.5.0? | **No — defer to v2.5.0.1** |
+| Block v2.5.0 Python release? | **No** — MCP-TS-* are SHOULD; Python stdio bridge is the release gate |
+| Minimum viable scope (when shipped) | Bearer extraction + ASAP Agent JWT verify + `asap:*` error mapping on `tools/call` |
+| Estimated effort (v2.5.0.1) | ~3–5 maintainer days (package scaffold, verifier, middleware hook, tests, publish CI) |
+
+---
+
+## 2. Current TypeScript package layout
+
+### 2.1 Monorepo structure
+
+```text
+packages/typescript/
+├── client/           → @asap-protocol/client
+├── mastra/           → @asap-protocol/mastra
+└── openai-agents/    → @asap-protocol/openai-agents
+```
+
+Registered in `pnpm-workspace.yaml` as `packages/typescript/*` plus explicit adapter paths.
+
+### 2.2 Naming and publishing conventions
+
+| Convention | Value in repo |
+|------------|---------------|
+| Scope | `@asap-protocol/*` (public npm) |
+| Multi-word packages | kebab-case (`mcp-auth` fits) |
+| Version (current) | `2.4.1` on all three packages |
+| License | Apache-2.0 |
+| Node | `>=18` |
+| Module system | `"type": "module"` + **tshy** dual ESM/CJS (`dist/esm`, `dist/commonjs`) |
+| Tests | vitest + coverage |
+| Lint | eslint 9 + typescript-eslint |
+| Adapter pattern | `peerDependencies` on framework SDK + `workspace:*` devDep on `@asap-protocol/client` |
+| Publish | `.github/workflows/publish-typescript.yml` — tags `v2.3.*` / `v2.4.*` only; syncs version from tag to all three packages |
+
+### 2.3 `@asap-protocol/client` relevance
+
+The client is the natural foundation for JWT crypto:
+
+- **Has**: `jose` (^6.0.10), Ed25519 keygen (`ed25519-keypair.ts`), Host/Agent JWT **minting** (`identity.ts`), Bearer header helper in `capabilities.ts`
+- **Lacks**: public `verifyAgentJwt()` API (only test-side `jwtVerify` usage); no `CapabilityRegistry` / grant-check port; no MCP `CallToolResult` helpers
+
+A v2.5.0.1 `@asap-protocol/mcp-auth` would depend on `@asap-protocol/client` for shared JWT types/constants and likely add verification there or in `mcp-auth` directly.
+
+### 2.4 No existing MCP auth surface
+
+- No `packages/typescript/mcp-auth/` directory
+- No `createMcpAuthMiddleware` symbol anywhere in the repo
+- `docs/adapters/mcp-auth-bridge.md` documents **Python stdio only** (no HTTP/SSE TS section)
+- v2.5.0 example is `examples/mcp_auth_bridge/server.py` (stdio)
+
+---
+
+## 3. `@modelcontextprotocol/sdk` dependency survey
+
+### 3.1 Where it appears
+
+| Location | Version | Direct? |
+|----------|---------|---------|
+| Root `pnpm-lock.yaml` | **1.29.0** | Transitive (via `@mastra/core`) |
+| `apps/web/package-lock.json` | 1.26.0 | Transitive |
+| `packages/typescript/*/package.json` | — | **Not declared** |
+
+None of the published ASAP TypeScript packages list `@modelcontextprotocol/sdk` as a direct or peer dependency today.
+
+### 3.2 SDK stack (lockfile resolution for 1.29.0)
+
+- Runtime: `hono`, `express` 5.x, `jose` 6.2.x, `zod` 3.x or 4.x (peer)
+- Transports: stdio, SSE, Streamable HTTP (modern path per MCP TS SDK docs)
+
+### 3.3 Compatibility assessment for HTTP/SSE Bearer middleware
+
+**Feasible, but not drop-in for ASAP semantics.**
+
+The MCP SDK ships OAuth-oriented HTTP middleware (`requireBearerAuth`) that:
+
+1. Validates `Authorization: Bearer <token>` via an `OAuthTokenVerifier` callback
+2. Attaches `AuthInfo` to the HTTP request (`req.auth` / `ctx.http.authInfo`)
+3. On failure returns **HTTP 401/403** with `WWW-Authenticate` OAuth challenge JSON — not MCP `CallToolResult` with `isError: true`
+
+ASAP MCP Auth Bridge (Python reference) instead:
+
+1. Intercepts **`tools/call`** (not only the HTTP handshake)
+2. Verifies **Agent JWT** (EdDSA, `typ: agent+jwt`, `capabilities` claim, JTI replay)
+3. Checks **capability grants** per tool + argument constraints
+4. Returns **`CallToolResult`** text codes: `asap:auth_required`, `asap:invalid_token`, `asap:capability_denied`, `asap:constraint_violation`
+
+**Gap:** SDK Bearer middleware covers transport-level OAuth; ASAP needs a **tool-dispatch wrapper** analogous to Python `ProtectedMCPServer._handle_tools_call`. The SDK does not expose a single `createMcpAuthMiddleware` hook — integration is compose-your-own: `requireBearerAuth` + custom tool handler wrapper + grant store injection.
+
+**Version pin recommendation (v2.5.0.1):** `peerDependency` on `@modelcontextprotocol/sdk` `^1.29.0` (align with lockfile; test against zod 3 and 4 peer variants).
+
+**Risk:** SDK auth APIs evolved across 1.26 → 1.29; pin and test on upgrade. MCP OAuth middleware ≠ ASAP Agent JWT — document clearly in package README.
+
+---
+
+## 4. Minimum implementation scope (MCP-TS-001..003)
+
+If shipped in **v2.5.0.1**, the smallest useful package:
+
+### 4.1 Package scaffold
+
+```text
+packages/typescript/mcp-auth/
+├── package.json          # name: @asap-protocol/mcp-auth
+├── src/
+│   ├── index.ts
+│   ├── middleware.ts     # createMcpAuthMiddleware
+│   ├── bearer.ts         # extractBearerToken(req)
+│   ├── errors.ts         # ASAP_* constants + toolErrorResult()
+│   ├── verify.ts         # verifyAgentJwt wrapper (jose)
+│   └── types.ts          # McpAuthConfig, re-exports from SDK where needed
+└── test/
+    └── middleware.test.ts
+```
+
+### 4.2 Public API (locked for spike)
+
+```typescript
+export interface McpAuthConfig {
+  /** Host/agent public keys or stores — mirror Python MCPAuthConfig subset */
+  verifyAgentJwt: (token: string) => Promise<VerifiedAgent>;
+  toolCapabilityMap?: Record<string, string>;
+  publicTools?: ReadonlySet<string>;
+  checkGrant?: (
+    agentId: string,
+    capability: string,
+    args: Record<string, unknown>,
+  ) => Promise<GrantCheckResult>;
+  expectedAudience?: string | string[];
+}
+
+/** Wrap SDK HTTP/SSE server tool dispatch with ASAP auth + grant checks. */
+export function createMcpAuthMiddleware(
+  config: McpAuthConfig,
+): McpAuthMiddleware;
+```
+
+### 4.3 MUST behaviors (parity with Python)
+
+| # | Behavior | Python reference |
+|---|----------|------------------|
+| 1 | Extract Bearer from `Authorization` header on HTTP/SSE requests | PRD §4.3; opposite of stdio `_meta.asap_agent_jwt` |
+| 2 | Map missing token → `asap:auth_required` in `CallToolResult` | `asap.adapters.mcp.errors.AUTH_REQUIRED` |
+| 3 | Map invalid/expired JWT → `asap:invalid_token` | `INVALID_TOKEN` |
+| 4 | Map missing grant / capability → `asap:capability_denied` | `CAPABILITY_DENIED` |
+| 5 | Map constraint fail → `asap:constraint_violation` | `CONSTRAINT_VIOLATION` |
+| 6 | Re-export SDK types used by middleware signatures | MCP-TS-003 |
+
+### 4.4 Explicitly out of minimum scope
+
+- Full in-memory `CapabilityRegistry` port (inject `checkGrant` callback; operators bring store)
+- `initialize` session-token handshake (deferred repo-wide)
+- `hide_unauthorized_tools` / `tools/list` filtering
+- Runnable HTTP/SSE example server (nice-to-have for v2.5.0.1 docs)
+- stdio `_meta.asap_agent_jwt` in TS (Python-only carriage for v2.5.0)
+
+### 4.5 Error payload shape (must match Python)
+
+```json
+{
+  "content": [{"type": "text", "text": "asap:auth_required"}],
+  "isError": true
+}
+```
+
+Detail appended after `:` when present (e.g. `asap:invalid_token: expired`).
+
+---
+
+## 5. Why not ship in v2.5.0
+
+| Factor | Assessment |
+|--------|------------|
+| PRD priority | MCP-TS-001..003 are **SHOULD**; Python MCP-AUTH-* / MCP-DOC-* are **MUST** |
+| Release focus | v2.5.0 PRD §1.4: stdio first; HTTP/SSE MCP in Python core **out of scope** |
+| S4/S5 scope | S4 = compliance gate (Python `mcp-auth-bridge` profile); S5 = version bump + tag — not greenfield npm package |
+| Implementation gap | No package, no verifier API, no HTTP MCP example, no compliance harness for TS |
+| Architectural mismatch | SDK `requireBearerAuth` = OAuth HTTP errors; ASAP = per-`tools/call` grant checks + `CallToolResult` codes — needs careful wrapper, not a afternoon spike |
+| CI / publish | `publish-typescript.yml` triggers on `v2.3.*` / `v2.4.*` only; adding a fourth package + `v2.5.*` tags is S5-adjacent work |
+| Release train note | [tasks-v2.5.0-roadmap.md](./tasks-v2.5.0-roadmap.md) already states S4 spike → S5 ship **or** v2.5.0.1 defer |
+| User value | v2.5.0 delivers complete stdio story (`protect_server`, example, compliance); TS HTTP adopters are secondary and can wait one patch |
+
+**Conclusion:** Deferring does not block PRD Definition of Done for v2.5.0 Python deliverables or the `mcp-auth-bridge` compliance profile.
+
+---
+
+## 6. Recommendation
+
+### **DEFER `@asap-protocol/mcp-auth` to v2.5.0.1**
+
+**Rationale (one line):** v2.5.0 ships the Python stdio MCP Auth Bridge as the release gate; TypeScript HTTP/SSE middleware is SHOULD-scope work that needs a new package, JWT verifier port, and SDK integration testing — better as a focused v2.5.0.1 patch than a risk to the v2.5.0 tag.
+
+---
+
+## 7. S5 actions (based on DEFER decision)
+
+### 7.1 During S5 release (required)
+
+- [ ] **CHANGELOG.md** — Under v2.5.0, add subsection *TypeScript*: state MCP-TS-001..003 **deferred to v2.5.0.1** with link to this spike
+- [ ] **docs/adapters/mcp-auth-bridge.md** — One paragraph: Python stdio shipped; `@asap-protocol/mcp-auth` for HTTP/SSE planned v2.5.0.1 (link spike)
+- [ ] **product/checkpoints.md** — Note TS middleware defer; not a v2.5.0 blocker
+- [ ] **Do not** add `packages/typescript/mcp-auth` or bump TS packages to 2.5.0 for this feature
+
+### 7.2 S5 task 4.1 (post-release backlog)
+
+- [ ] Create GitHub issue or `engineering/tasks/v2.5.0/backlog-mcp-auth-typescript.md` tracking:
+  - MCP-TS-001: `createMcpAuthMiddleware`
+  - MCP-TS-002: Bearer + error mapping parity
+  - MCP-TS-003: SDK type re-exports
+  - Target: **v2.5.0.1** npm + docs
+- [ ] Link issue from CHANGELOG defer note
+
+### 7.3 v2.5.0.1 implementation checklist (future sprint)
+
+| Task | Owner hint |
+|------|------------|
+| Add `verifyAgentJwt` to `@asap-protocol/client` (or `mcp-auth`) | Port Python `verify_agent_jwt` semantics |
+| Scaffold `packages/typescript/mcp-auth` | Mirror mastra/openai-agents layout |
+| Implement `createMcpAuthMiddleware` | Compose SDK HTTP transport + tools/call wrapper |
+| vitest: Bearer extract, four error codes, success path | Mock grant callback |
+| Extend `publish-typescript.yml` | `v2.5.*` tags + fourth package dry-run/publish |
+| `docs/integrations/mcp-auth-typescript.md` | HTTP/SSE setup guide |
+| Optional: minimal Express/Hono example | `apps/example-mcp-auth/` or docs snippet |
+
+### 7.4 If decision had been SHIP (not chosen)
+
+S5 would additionally require: implement minimum scope §4, extend publish workflow, bump all `@asap-protocol/*` to 2.5.0 on tag, and document in CHANGELOG as shipped. **Rejected** for v2.5.0 timeline.
+
+---
+
+## 8. References
+
+- [PRD v2.5.1 — §3 carry-over (durable defer record)](../../../product/prd/prd-v2.5.1-adapter-lab-ii.md#3-carry-over-from-v250-asap-protocolmcp-auth)
+- [PRD v2.5.0 MCP Auth Bridge — §5.4 TypeScript](../../../product/prd/prd-v2.5.0-mcp-auth-bridge.md)
+- [Python errors module](../../../src/asap/adapters/mcp/errors.py)
+- [Adapter guide (stdio)](../../../docs/adapters/mcp-auth-bridge.md)
+- [S5 release tasks](./sprint-S5-release.md)
+- [MCP TS SDK `requireBearerAuth`](https://github.com/modelcontextprotocol/typescript-sdk/tree/main/packages/middleware/express/src/auth) — OAuth transport middleware (reference only)
+
+---
+
+## Change log
+
+| Date | Change |
+|------|--------|
+| 2026-06-24 | S4 Agent E spike — **DEFER to v2.5.0.1** |

--- a/examples/mcp_auth_bridge/README.md
+++ b/examples/mcp_auth_bridge/README.md
@@ -97,6 +97,44 @@ uv run python client.py --jwt '<token>'
 4. Call `secure_action` without JWT → `asap:auth_required`.
 5. Call `secure_action` with `_meta.asap_agent_jwt` (or `ASAP_AGENT_JWT`) → `executed: ...`.
 
+## Compliance
+
+The **`mcp-auth-bridge`** profile in [`asap-compliance`](../../asap-compliance/) is the **v2.5.0 release gate** for stdio MCP auth. It black-boxes this example server (subprocess `uv run python examples/mcp_auth_bridge/server.py`) and asserts:
+
+| Check | What it verifies |
+|-------|------------------|
+| `auth_required` | Unauthenticated `secure_action` → `asap:auth_required` |
+| `valid_jwt` | Valid Agent JWT on `secure_action` succeeds |
+| `wrong_capability` | JWT without the mapped capability → `asap:capability_denied` |
+| `constraint_violation` | Grant constraint breach → `asap:constraint_violation` |
+| `manifest_alignment` | Manifest-declared tools/capabilities ⊆ registered MCP surface (MCP-DISC-003) |
+
+There is no dedicated `python -m` CLI for this profile yet — use pytest or the programmatic one-liner below.
+
+**Recommended gate** (from the repository root):
+
+```bash
+uv run pytest asap-compliance/tests/test_mcp_auth.py -v
+```
+
+**Programmatic one-liner:**
+
+```bash
+PYTHONPATH=asap-compliance:src uv run python -c "
+from asap_compliance.harness import McpAuthComplianceConfig, validate_mcp_auth
+import sys
+result = validate_mcp_auth(McpAuthComplianceConfig())
+for check in result.checks:
+    if not check.passed:
+        print(f'FAIL: {check.name}: {check.message}')
+sys.exit(0 if result.passed else 1)
+"
+```
+
+The subprocess driver sets `ASAP_MCP_COMPLIANCE=1` on the server automatically so probe JWTs (wrong capability, constraint action) are emitted on stderr — you do not need to export it manually.
+
+Adapter semantics and error codes: [`docs/adapters/mcp-auth-bridge.md`](../../docs/adapters/mcp-auth-bridge.md).
+
 ## Related docs
 
 - Adapter guide: [`docs/adapters/mcp-auth-bridge.md`](../../docs/adapters/mcp-auth-bridge.md)

--- a/examples/mcp_auth_bridge/server.py
+++ b/examples/mcp_auth_bridge/server.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import argparse
 import asyncio
 import base64
+import json
+import os
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -36,6 +38,8 @@ from asap.mcp.server import MCPServer
 DEMO_HOST_ID = "mcp-auth-bridge-host"
 DEMO_AGENT_ID = "urn:asap:agent:mcp-auth-bridge-demo"
 DEMO_AUDIENCE = "urn:asap:agent:mcp-auth-bridge"
+COMPLIANCE_ENV_VAR = "ASAP_MCP_COMPLIANCE"
+_COMPLIANCE_FORBIDDEN_ACTION = "forbidden-action"
 
 _ECHO_INPUT_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -107,7 +111,15 @@ async def _seed_identity(
             description="Execute a protected MCP action",
         )
     )
-    capability_registry.grant(DEMO_AGENT_ID, "secure_action")
+    compliance_mode = os.environ.get(COMPLIANCE_ENV_VAR) == "1"
+    if compliance_mode:
+        capability_registry.grant(
+            DEMO_AGENT_ID,
+            "secure_action",
+            constraints={"action": {"not_in": [_COMPLIANCE_FORBIDDEN_ACTION]}},
+        )
+    else:
+        capability_registry.grant(DEMO_AGENT_ID, "secure_action")
 
     host_thumbprint = jwk_thumbprint_sha256(host_identity.public_key)
     demo_jwt = create_agent_jwt(
@@ -189,6 +201,22 @@ def _print_startup_instructions(identity: DemoIdentity) -> None:
         "",
     ]
     print("\n".join(lines), file=sys.stderr, flush=True)
+    if os.environ.get(COMPLIANCE_ENV_VAR) == "1":
+        host_thumbprint = jwk_thumbprint_sha256(identity.host_identity.public_key)
+        wrong_jwt = create_agent_jwt(
+            identity.agent_sk,
+            host_thumbprint=host_thumbprint,
+            agent_id=DEMO_AGENT_ID,
+            aud=DEMO_AUDIENCE,
+            capabilities=["unrelated_capability"],
+        )
+        payload = {
+            "profile": "mcp-auth-bridge",
+            "valid_jwt": identity.demo_jwt,
+            "wrong_capability_jwt": wrong_jwt,
+            "constraint_violation_action": _COMPLIANCE_FORBIDDEN_ACTION,
+        }
+        print(f"ASAP_COMPLIANCE_JSON:{json.dumps(payload)}", file=sys.stderr, flush=True)
 
 
 async def _run_stdio() -> None:

--- a/product/prd/prd-v2.5.1-adapter-lab-ii.md
+++ b/product/prd/prd-v2.5.1-adapter-lab-ii.md
@@ -33,7 +33,43 @@ v2.5.1 expands adoption testing into **enterprise and workflow-heavy ecosystems*
 
 ---
 
-## 3. Requirements
+## 3. Carry-over from v2.5.0: `@asap-protocol/mcp-auth`
+
+> **Decision (2026-06-24, S4 spike):** Ship `@asap-protocol/mcp-auth` in **v2.5.0.1** (patch on the v2.5.0 train), **not** in v2.5.0 and **not** as part of v2.5.1 Adapter Lab II scope.
+>
+> **Spike:** [typescript-mcp-auth-spike.md](../../engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md)
+> **Source requirements:** [prd-v2.5.0-mcp-auth-bridge.md §5.4](./prd-v2.5.0-mcp-auth-bridge.md#54-typescript-should) (MCP-TS-001..003)
+
+### 3.1 Rationale
+
+| Factor | Detail |
+|--------|--------|
+| PRD priority | MCP-TS-001..003 are **SHOULD**; Python MCP-AUTH-* / MCP-DOC-* are **MUST** for v2.5.0 |
+| Release gate | v2.5.0 ships the Python stdio MCP Auth Bridge (`protect_server`, example, compliance profile) |
+| Implementation gap | No `packages/typescript/mcp-auth/`, no public `verifyAgentJwt()` on `@asap-protocol/client`, no HTTP/SSE MCP example or publish CI for a fourth npm package |
+| SDK fit | `@modelcontextprotocol/sdk` Bearer middleware targets OAuth transport errors; ASAP needs per-`tools/call` grant checks and `CallToolResult` codes — requires a composed wrapper, not a drop-in |
+
+Deferring does **not** block v2.5.0 Definition of Done or v2.5.1 planning. v2.5.0.1 may ship between v2.5.0 and v2.5.1 without delaying Adapter Lab II.
+
+### 3.2 Minimum scope (v2.5.0.1)
+
+When implemented, the package MUST satisfy MCP-TS-001..003 at minimum:
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| MCP-TS-001 | Publish `@asap-protocol/mcp-auth` with `createMcpAuthMiddleware(config)` for HTTP/SSE MCP servers | SHOULD (carried from v2.5.0) |
+| MCP-TS-002 | Bearer extraction from `Authorization` header + same `asap:*` error mapping as Python (`asap:auth_required`, `asap:invalid_token`, `asap:capability_denied`, `asap:constraint_violation`) on `tools/call` | SHOULD (carried from v2.5.0) |
+| MCP-TS-003 | Re-export types compatible with `@modelcontextprotocol/sdk` middleware signatures | SHOULD (carried from v2.5.0) |
+
+**Explicitly out of minimum v2.5.0.1 scope:** stdio `_meta.asap_agent_jwt` in TypeScript (Python-only for v2.5.0), full `CapabilityRegistry` port (inject `checkGrant` callback), `hide_unauthorized_tools` / `tools/list` filtering.
+
+### 3.3 Relation to v2.5.1 (LAB2-006)
+
+LAB2-006 applies to **Python Auth Bridge patterns** where Adapter Lab II work exposes MCP. It does not require shipping `@asap-protocol/mcp-auth`; HTTP/SSE TypeScript adopters should wait for v2.5.0.1 or use Python reference semantics manually until the npm package ships.
+
+---
+
+## 4. Requirements
 
 | ID | Requirement | Priority |
 |----|-------------|----------|
@@ -46,7 +82,7 @@ v2.5.1 expands adoption testing into **enterprise and workflow-heavy ecosystems*
 
 ---
 
-## 4. Open Core notes
+## 5. Open Core notes
 
 **Likely public:** SDK adapter interfaces, connector examples, Compliance Harness guidance.
 
@@ -54,7 +90,7 @@ v2.5.1 expands adoption testing into **enterprise and workflow-heavy ecosystems*
 
 ---
 
-## 5. Success metrics
+## 6. Success metrics
 
 | Metric | Target |
 |--------|--------|
@@ -64,7 +100,7 @@ v2.5.1 expands adoption testing into **enterprise and workflow-heavy ecosystems*
 
 ---
 
-## 6. Related documents
+## 7. Related documents
 
 - **v2.3.1 (shipped)**: `product/prd/private/prd-v2.3.1-adapter-lab.md`
 - **Adoption foundation**: [prd-v2.3-scale.md](./prd-v2.3-scale.md)
@@ -75,4 +111,5 @@ v2.5.1 expands adoption testing into **enterprise and workflow-heavy ecosystems*
 
 | Date | Change |
 |------|--------|
+| 2026-06-24 | §3: Record S4 defer of `@asap-protocol/mcp-auth` to v2.5.0.1 (MCP-TS-001..003) |
 | 2026-06-22 | Renumbered v2.3.2 → v2.5.1; blocked on v2.5.0 |

--- a/src/asap/mcp/client.py
+++ b/src/asap/mcp/client.py
@@ -68,6 +68,13 @@ class MCPClient:
         self._request_id += 1
         return str(self._request_id) if self._use_str_ids else self._request_id
 
+    @property
+    def stderr(self) -> asyncio.StreamReader | None:
+        """Server subprocess stderr stream (``None`` when disconnected)."""
+        if self._process is None:
+            return None
+        return self._process.stderr
+
     async def _send(self, payload: dict[str, Any]) -> None:
         """Send one JSON-RPC message (request or notification) to server stdin."""
         if self._process is None or self._process.stdin is None:

--- a/src/asap/mcp/client.py
+++ b/src/asap/mcp/client.py
@@ -45,6 +45,7 @@ class MCPClient:
         receive_timeout: float | None = 60.0,
         request_id_type: Literal["int", "str"] = "str",
         allowed_binaries: frozenset[str] | None = None,
+        subprocess_env: dict[str, str] | None = None,
     ) -> None:
         if allowed_binaries is not None and server_command:
             binary = os.path.basename(server_command[0])
@@ -61,6 +62,7 @@ class MCPClient:
         self._request_id = 0
         self._use_str_ids = request_id_type == "str"
         self._init_result: InitializeResult | None = None
+        self._subprocess_env = subprocess_env
 
     def _next_id(self) -> str | int:
         self._request_id += 1
@@ -116,6 +118,7 @@ class MCPClient:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=self._subprocess_env,
         )
         if self._process.stdin is None or self._process.stdout is None:
             raise RuntimeError("Failed to get server stdin/stdout")
@@ -195,7 +198,7 @@ class MCPClient:
         if not self._initialized:
             raise RuntimeError("Not initialized; call connect() first")
         req_id = self._next_id()
-        params = CallToolRequestParams(name=name, arguments=arguments or {}, meta=meta)
+        params = CallToolRequestParams(name=name, arguments=arguments or {}, _meta=meta)
         await self._send(
             {
                 "jsonrpc": "2.0",

--- a/tests/adapters/mcp/test_stdio_integration.py
+++ b/tests/adapters/mcp/test_stdio_integration.py
@@ -227,7 +227,7 @@ async def test_subprocess_example_server_secure_action_denied_without_jwt() -> N
     server_command = ["uv", "run", "python", str(_EXAMPLE_SERVER)]
     client = MCPClient(
         server_command,
-        allowed_binaries=frozenset({"uv", "python", sys.executable}),
+        allowed_binaries=frozenset({"uv", "python", Path(sys.executable).name}),
     )
 
     async with client:

--- a/tests/adapters/mcp/test_stdio_integration.py
+++ b/tests/adapters/mcp/test_stdio_integration.py
@@ -1,0 +1,237 @@
+"""End-to-end stdio integration tests for protected MCPServer (S4 task 3.2).
+
+Exercises the full JSON-RPC stdio path (initialize → tools/call) against a
+``protect_server``-wrapped server using runtime-minted Agent JWTs in
+``params._meta.asap_agent_jwt``. Headless, no network, no committed secrets.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from asap.adapters.mcp.auth_middleware import MCPAuthConfig, protect_server
+from asap.adapters.mcp.errors import AUTH_REQUIRED, CAPABILITY_DENIED
+from asap.auth.capabilities import CapabilityDefinition, CapabilityGrant, CapabilityRegistry
+from asap.auth.identity import (
+    AgentSession,
+    HostIdentity,
+    InMemoryAgentStore,
+    InMemoryHostStore,
+)
+from asap.mcp.client import MCPClient
+from asap.mcp.server import MCPServer
+from tests.adapters.mcp.conftest import MCP_TEST_AUDIENCE
+
+pytestmark = pytest.mark.filterwarnings("ignore:EdDSA is deprecated:UserWarning")
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_EXAMPLE_SERVER = _REPO_ROOT / "examples" / "mcp_auth_bridge" / "server.py"
+
+_SECURE_ACTION_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"action": {"type": "string"}},
+    "additionalProperties": False,
+}
+
+_ECHO_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"message": {"type": "string"}},
+    "additionalProperties": False,
+}
+
+
+def _build_protected_secure_action_server(
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    register_capability: Callable[..., CapabilityDefinition],
+) -> MCPServer:
+    """Protected server with public ``echo`` and gated ``secure_action`` tools."""
+    register_capability("secure_action", description="Protected MCP action")
+    base = MCPServer(name="mcp-stdio-integration", version="0.1.0")
+    base.register_tool(
+        "echo",
+        lambda message="": message,
+        _ECHO_INPUT_SCHEMA,
+        description="Public echo (no JWT)",
+    )
+    base.register_tool(
+        "secure_action",
+        lambda action="": f"executed: {action}",
+        _SECURE_ACTION_INPUT_SCHEMA,
+        description="Protected action (JWT + grant)",
+    )
+    config = MCPAuthConfig(
+        host_store=host_store,
+        agent_store=agent_store,
+        capability_registry=capability_registry,
+        public_tools=frozenset({"echo"}),
+        enforce_grants=True,
+        expected_audience=MCP_TEST_AUDIENCE,
+    )
+    return protect_server(base, config)
+
+
+def _tool_call_params(
+    name: str,
+    *,
+    arguments: dict[str, Any] | None = None,
+    jwt: str | None = None,
+) -> dict[str, Any]:
+    """Build ``tools/call`` params with optional Agent JWT in ``_meta``."""
+    params: dict[str, Any] = {"name": name, "arguments": arguments or {}}
+    if jwt is not None:
+        params["_meta"] = {"asap_agent_jwt": jwt}
+    return params
+
+
+async def _stdio_tools_call(
+    server: MCPServer,
+    params: dict[str, Any],
+    *,
+    request_id: int = 3,
+) -> dict[str, Any]:
+    """Drive initialize handshake and one ``tools/call`` over injected stdio."""
+    lines = [
+        '{"jsonrpc":"2.0","id":1,"method":"initialize","params":'
+        '{"protocolVersion":"2025-11-25","capabilities":{},'
+        '"clientInfo":{"name":"stdio-test","version":"0"}}}\n',
+        '{"jsonrpc":"2.0","method":"notifications/initialized"}\n',
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "tools/call",
+                "params": params,
+            }
+        )
+        + "\n",
+        "\n",
+    ]
+    stdin = io.StringIO("".join(lines))
+    stdout = io.StringIO()
+    await server.run_stdio(stdin=stdin, stdout=stdout)
+    out_lines = [json.loads(ln) for ln in stdout.getvalue().strip().split("\n") if ln.strip()]
+    assert out_lines, "expected at least one JSON-RPC response on stdout"
+    return out_lines[-1]
+
+
+def _call_tool_result_text(response: dict[str, Any]) -> str:
+    """Extract text from a ``tools/call`` JSON-RPC result payload."""
+    result = response.get("result", {})
+    content = result.get("content", [])
+    if not content:
+        return ""
+    return str(content[0].get("text", ""))
+
+
+@pytest.mark.asyncio
+async def test_stdio_secure_action_succeeds_with_jwt_and_grant(
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+    register_capability: Callable[..., CapabilityDefinition],
+    grant_capability: Callable[..., CapabilityGrant],
+) -> None:
+    """Valid JWT + active grant on ``secure_action`` succeeds over stdio JSON-RPC."""
+    server = _build_protected_secure_action_server(
+        host_store,
+        agent_store,
+        capability_registry,
+        register_capability,
+    )
+    grant_capability(agent_session.agent_id, "secure_action")
+    token = mint_agent_jwt(capabilities=["secure_action"])
+
+    response = await _stdio_tools_call(
+        server,
+        _tool_call_params("secure_action", arguments={"action": "stdio-ok"}, jwt=token),
+    )
+
+    assert "result" in response
+    assert response["result"].get("isError") is not True
+    assert _call_tool_result_text(response) == "executed: stdio-ok"
+
+
+@pytest.mark.asyncio
+async def test_stdio_secure_action_denied_without_jwt(
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    register_capability: Callable[..., CapabilityDefinition],
+) -> None:
+    """Protected ``secure_action`` without JWT returns ``asap:auth_required`` over stdio."""
+    server = _build_protected_secure_action_server(
+        host_store,
+        agent_store,
+        capability_registry,
+        register_capability,
+    )
+
+    response = await _stdio_tools_call(
+        server,
+        _tool_call_params("secure_action", arguments={"action": "denied"}),
+    )
+
+    assert "result" in response
+    assert response["result"]["isError"] is True
+    assert AUTH_REQUIRED in _call_tool_result_text(response)
+
+
+@pytest.mark.asyncio
+async def test_stdio_secure_action_denied_wrong_capability_in_jwt(
+    host_store: InMemoryHostStore,
+    agent_store: InMemoryAgentStore,
+    capability_registry: CapabilityRegistry,
+    host_identity: HostIdentity,
+    agent_session: AgentSession,
+    mint_agent_jwt: Callable[..., str],
+    register_capability: Callable[..., CapabilityDefinition],
+    grant_capability: Callable[..., CapabilityGrant],
+) -> None:
+    """JWT missing ``secure_action`` capability claim is denied over stdio."""
+    server = _build_protected_secure_action_server(
+        host_store,
+        agent_store,
+        capability_registry,
+        register_capability,
+    )
+    grant_capability(agent_session.agent_id, "secure_action")
+    token = mint_agent_jwt(capabilities=["echo"])
+
+    response = await _stdio_tools_call(
+        server,
+        _tool_call_params("secure_action", arguments={"action": "nope"}, jwt=token),
+    )
+
+    assert "result" in response
+    assert response["result"]["isError"] is True
+    assert CAPABILITY_DENIED in _call_tool_result_text(response)
+
+
+@pytest.mark.asyncio
+async def test_subprocess_example_server_secure_action_denied_without_jwt() -> None:
+    """Subprocess smoke: protected tool without JWT fails on example stdio server."""
+    server_command = ["uv", "run", "python", str(_EXAMPLE_SERVER)]
+    client = MCPClient(
+        server_command,
+        allowed_binaries=frozenset({"uv", "python", sys.executable}),
+    )
+
+    async with client:
+        secure = await client.call_tool("secure_action", {"action": "denied"})
+        assert secure.is_error is True
+        text = "".join(c.get("text", "") for c in secure.content if c.get("type") == "text")
+        assert AUTH_REQUIRED in text


### PR DESCRIPTION
## Summary

- Add `mcp-auth-bridge` compliance profile in `asap-compliance` with MCP-AUTH-007 and MCP-DISC-003 checks over stdio subprocess transport.
- Extend `examples/mcp_auth_bridge/server.py` with compliance probe support for harness-driven validation.
- Add stdio integration tests for protected MCP (JWT + capability grant success and denial paths) and `subprocess_env` on `MCPClient`.
- Enable CI compliance gate on `release/2.5.0` and document S4 sprint deliverables.
- **@asap-protocol/mcp-auth** (TypeScript) is deferred to **v2.5.0.1** per PRD and spike note.

## Test plan

- [x] `uv run ruff check .` and `uv run ruff format --check .`
- [x] `uv run mypy src/ scripts/ tests/`
- [x] `uv run pytest asap-compliance/tests/test_mcp_auth.py -v --tb=short`
- [x] `uv run pytest tests/adapters/mcp/ -v --tb=short`
- [ ] Full CI on PR (coverage gate)

## Sprint tracking

[engineering/tasks/v2.5.0/sprint-S4-compliance.md](engineering/tasks/v2.5.0/sprint-S4-compliance.md)