### PR TITLE
chore(v2.5.0): S5 release prep — version bump, changelog and docs sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 **ASAP Protocol** (Async Simple Agent Protocol) is a production-ready standard for agent-to-agent communication.
 - **Stack**: Python 3.13+, FastAPI, Pydantic v2.
 - **Transport**: JSON-RPC 2.0 over HTTP/WebSocket.
-- **Status**: v2.4.1 (released in tree; **PyPI** `asap-protocol` and **npm** `@asap-protocol/client` ship from maintainer tags + publish workflows).
+- **Status**: v2.5.0 in tree on `release/2.5.0` (MCP Auth Bridge); **PyPI** `asap-protocol` and **npm** `@asap-protocol/client` remain **2.4.1** until maintainer tag `v2.5.0` + publish workflows.
 - **Framework Integrations**: LangChain, CrewAI, PydanticAI, LlamaIndex, SmolAgents, Vercel AI SDK, MCP, OpenClaw, A2H.
 - **npm (TypeScript)**: The official client is **`@asap-protocol/client`** (scoped, **public** on npm for v2.4.x). Maintainer workflow: `.github/workflows/publish-typescript.yml`; context: `docs/maintainers/npm-publishing.md`.
 - **General contact** (humans coordinating on the protocol; not security): [info@asap-protocol.com](mailto:info@asap-protocol.com) — vulnerabilities: [SECURITY.md](SECURITY.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `extra="forbid"` on ingress payload models (`TaskRequestConfig`, `CommonMetadata`)
 - Opt-in protection for operator APIs (`/usage`, `/sla`, `/audit`)
 - Redis-backed `JtiReplayCache` and distributed Next.js rate limits
+- `@asap-protocol/mcp-auth` HTTP/SSE middleware (deferred from v2.5.0 — see [2.5.0] TypeScript note and [typescript-mcp-auth-spike.md](engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md))
 
 ### Fixed
 
 - **CI security (`pip-audit`)**: Raised `cryptography` to `>=48.0.1,<49` (GHSA-537c-gmf6-5ccf), `python-multipart>=0.0.31` (CVE-2026-53538–53540), and `starlette>=1.3.1` (CVE-2026-54282 / CVE-2026-54283) via `pyproject.toml` floors and `tool.uv.override-dependencies`.
 - **pydantic-ai (CVE-2026-46678)**: Optional `[pydanticai]` extra pins `pydantic-ai>=1.99.0`; removed obsolete `pip-audit` ignore from CI.
+
+---
+
+## [2.5.0] - 2026-06-24
+
+**MCP Auth Bridge** — ASAP Host/Agent JWT and capability grants as an **opt-in**
+authorization layer for native **stdio MCP** `tools/call` (Mode A). Unprotected
+`MCPServer` usage is unchanged. No wire-protocol or manifest schema breaking
+changes.
+
+### Added
+
+- **feat(adapters): MCP Auth Bridge (`asap.adapters.mcp`)**
+  - **`protect_server(server, config)`** — wraps `MCPServer` via
+    `ProtectedMCPServer`; intercepts `_handle_tools_call` only (MCP-AUTH-006).
+  - **`MCPAuthConfig`** (`config.py`) — `host_store`, `agent_store`,
+    `capability_registry`, `tool_capability_map`, `public_tools`,
+    `enforce_grants`, `jwt_extractor`, `jti_replay_cache`, `expected_audience`.
+  - **Token carriage (stdio)** — Agent JWT in `tools/call` params
+    `_meta.asap_agent_jwt`; optional dev-only `ASAP_AGENT_JWT` when
+    `allow_env_jwt_fallback=True`.
+  - **Grant enforcement** — `verify_agent_jwt` + `CapabilityRegistry.check_grant`
+    with constraint validation on tool arguments; MCP-safe `asap:*` error codes
+    (`asap:auth_required`, `asap:invalid_token`, `asap:capability_denied`,
+    `asap:constraint_violation`).
+  - **Tool → capability mapping** — explicit `tool_capability_map`, register-time
+    metadata, or default identity (tool name == capability); optional startup
+    validation (`validate_tools_at_startup`).
+  - **Reference example** — `examples/mcp_auth_bridge/` (protected stdio server +
+    client, smoke tests in `tests/examples/test_mcp_auth_bridge_example.py`).
+  - **Docs** — [MCP Auth Bridge adapter](docs/adapters/mcp-auth-bridge.md);
+    [MCP integration](docs/mcp-integration.md) distinguishes Mode A (native MCP +
+    bridge) vs Mode B (MCP-over-ASAP envelope).
+- **feat(compliance): `mcp-auth-bridge` profile** (`asap-compliance`) — stdio MCP
+  release gate: auth paths, grants, constraints, manifest tools ⊆ registered
+  tools (MCP-DISC-003). Requires `asap-protocol>=2.5.0`.
+- **test(adapters/mcp)** — unit, grant, startup, and stdio integration coverage
+  (≥90% on `asap.adapters.mcp`).
+
+### Deferred (not in v2.5.0)
+
+- **`hide_unauthorized_tools` / `tools/list` filtering** (MCP-MAP-004) — no
+  standard JWT carriage on stdio `tools/list` today; see
+  [design lock](engineering/tasks/v2.5.0/design-lock-mcp-auth-bridge.md).
+- **`initialize` session-token handshake** (PRD §4.3 SHOULD) — clients pass JWT
+  on each protected `tools/call` in v2.5.0.
+
+### TypeScript
+
+- **`@asap-protocol/mcp-auth` deferred to v2.5.0.1** — MCP-TS-001..003 (HTTP/SSE
+  Bearer middleware) are SHOULD-scope; v2.5.0 ships the Python stdio bridge as the
+  release gate. Rationale and implementation checklist:
+  [typescript-mcp-auth-spike.md](engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md);
+  carry-over tracked in
+  [PRD v2.5.1 §3](product/prd/prd-v2.5.1-adapter-lab-ii.md#3-carry-over-from-v250-asap-protocolmcp-auth).
+  Existing `@asap-protocol/*` npm packages remain at **2.4.1** until a separate
+  publish.
+
+### Migration
+
+- **v2.4.1 → v2.5.0**: **No breaking changes.** MCP servers without
+  `protect_server` behave as before. To enforce Agent JWT + capabilities on native
+  MCP, wrap your server with `protect_server` and configure grants — see
+  [MCP Auth Bridge adapter](docs/adapters/mcp-auth-bridge.md).
 
 ---
 

--- a/docs/adapters/mcp-auth-bridge.md
+++ b/docs/adapters/mcp-auth-bridge.md
@@ -6,6 +6,8 @@ The `asap.adapters.mcp` package adds **opt-in** Agent JWT and capability enforce
 
 **Out of scope (v2.5.0):** An `initialize` session-token handshake is **deferred** per the [design lock](../../engineering/tasks/v2.5.0/design-lock-mcp-auth-bridge.md) — not shipped in this release. Clients must pass the Agent JWT on each protected `tools/call` via `_meta.asap_agent_jwt`.
 
+**TypeScript (v2.5.0.1):** This guide covers the **Python stdio** bridge shipped in v2.5.0. HTTP/SSE middleware for `@asap-protocol/mcp-auth` (MCP-TS-001..003) is planned for **v2.5.0.1** — see the [TypeScript spike](../../engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md) for rationale and checklist. Existing `@asap-protocol/*` npm packages remain at 2.4.1 until that follow-up release.
+
 For MCP-over-ASAP envelopes (Mode B), see [MCP integration](../mcp-integration.md).
 
 ## Architecture

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -761,6 +761,47 @@ For deployments that enforce self-authorization prevention with real passkeys:
 See [Self-authorization prevention](security/self-authorization-prevention.md)
 (**Real WebAuthn**) for the threat model and ceremony flow.
 
+### Upgrading from v2.4.1 to v2.5.0
+
+v2.5.0 is an **additive, backward-compatible** minor release. JSON-RPC envelopes,
+OAuth2, capability grants, and existing manifests are unchanged. MCP servers
+without `protect_server` behave exactly as in v2.4.1.
+
+#### What changed
+
+- **MCP Auth Bridge (opt-in)**: `asap.adapters.mcp.protect_server` wraps a native
+  stdio `MCPServer` with Agent JWT verification and capability enforcement on
+  `tools/call`. Unprotected MCP usage remains valid (MCP-DOC-004).
+- **Compliance**: `asap-compliance` adds an `mcp-auth-bridge` profile for stdio
+  MCP auth, grants, constraints, and manifest alignment.
+- **Deferred**: `initialize` session-token handshake, `hide_unauthorized_tools`
+  (MAP-004), and `@asap-protocol/mcp-auth` HTTP/SSE middleware (v2.5.0.1).
+
+#### Upgrade steps
+
+1. **Bump Python dependency**:
+   ```bash
+   pip install --upgrade asap-protocol==2.5.0
+   # or
+   uv add asap-protocol==2.5.0
+   ```
+   TypeScript consumers: no npm bump required for v2.5.0 — `@asap-protocol/*`
+   packages remain at **2.4.1** until the v2.5.0.1 middleware release.
+
+2. **Optional — protect an MCP server**: See
+   [MCP Auth Bridge adapter](adapters/mcp-auth-bridge.md) and
+   `examples/mcp_auth_bridge/server.py`.
+
+3. **Re-run Compliance Harness v2** if you ship MCP tools
+   (`asap compliance-check --exit-on-fail`).
+
+#### Backward compatibility
+
+- **Wire protocol**: Unchanged from v2.4.1.
+- **Breaking changes**: None. `protect_server` is opt-in.
+
+---
+
 ### Upgrading from v2.4.0 to v2.4.1
 
 v2.4.1 is a **security-hardening patch**. JSON-RPC envelopes, capability grants,

--- a/engineering/tasks/v2.5.0/sprint-S5-release.md
+++ b/engineering/tasks/v2.5.0/sprint-S5-release.md
@@ -4,6 +4,8 @@
 **Branch**: `feat/v2.5.0-s5-release` → merge into **`release/2.5.0`**, then **`release/2.5.0` → `main`**
 **Depends on**: S0–S4 complete on `release/2.5.0`
 
+> **Status:** Branch `feat/v2.5.0-s5-release`. **1.0** ✅ · **2.0** ✅ — next sub-task: **3.1** PR `release/2.5.0` → `main`.
+
 **Trigger:** All sprint acceptance criteria met on integration branch.
 **Enables:** v2.5.1 Adapter Lab II.
 **Depends on:** Full CI green on `release/2.5.0`.
@@ -12,8 +14,17 @@
 
 ## Relevant Files
 
+### Sprint tracking (docs sync — pre-S5)
+- `engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md` — sprint index; S5 active
+- `engineering/tasks/v2.5.0/sprint-S5-release.md` — this file
+- `product/prd/prd-v2.5.0-mcp-auth-bridge.md` — DoD + deliverable status
+- `product/prd/prd-v2.5-roadmap.md` — train schedule status
+
 ### Version & changelog
-- `pyproject.toml` — version `2.5.0`
+- `pyproject.toml` — version `2.5.0` ✅
+- `src/asap/__init__.py` — `__version__` (must match metadata)
+- `uv.lock` — local package version pin
+- `CHANGELOG.md` — v2.5.0 section ✅
 - `CHANGELOG.md` — v2.5.0 section
 - `product/checkpoints.md` — post-release checkpoint
 - `AGENTS.md` — knowledge map and version context
@@ -30,9 +41,9 @@
 
 ## Tasks
 
-### 1.0 Pre-release verification
+### 1.0 Pre-release verification ✅
 
-- [ ] 1.1 Full local CI per `AGENTS.md` / `.cursor/rules/git-commits.mdc`
+- [x] 1.1 Full local CI per `AGENTS.md` / `.cursor/rules/git-commits.mdc`
   - **Commands**:
     - `uv run ruff check .`
     - `uv run ruff format --check .`
@@ -40,21 +51,25 @@
     - `uv run pytest --tb=short --cov=asap --cov-report=xml --cov-fail-under=85`
     - pip-audit per SECURITY.md
   - **Verify**: All pass on `release/2.5.0`
+  - **Result (2026-06-24, `feat/v2.5.0-s5-release`)**: ruff ✅ · format ✅ · mypy (437 files) ✅ · pytest **3614 passed**, coverage **93.08%** ✅ · pip-audit ✅
 
-- [ ] 1.2 Coverage gate on `asap.adapters.mcp`
+- [x] 1.2 Coverage gate on `asap.adapters.mcp`
   - **Verify**: ≥90% per PRD non-functional reqs
+  - **Result (2026-06-24)**: `uv run pytest tests/adapters/mcp/ --cov=asap.adapters.mcp --cov-fail-under=90` → **96.17%** (163 stmts; lowest file `jwt_extractor.py` 90.91%)
 
-### 2.0 Version bump & changelog
+### 2.0 Version bump & changelog ✅
 
-- [ ] 2.1 Bump to 2.5.0
+- [x] 2.1 Bump to 2.5.0
   - **File**: `pyproject.toml`
   - **What**: `[project].version = "2.5.0"`
   - **Verify**: `uv run python -c "import asap; print(asap.__version__)"` if exposed
+  - **Result (2026-06-24)**: `pyproject.toml` + `src/asap/__init__.py` → `2.5.0`; `uv.lock` refreshed; `asap.__version__` prints `2.5.0`; `tests/test_version.py` ✅
 
-- [ ] 2.2 CHANGELOG entry
+- [x] 2.2 CHANGELOG entry
   - **File**: `CHANGELOG.md`
   - **What**: MCP Auth Bridge features, migration note (opt-in `protect_server`), breaking: none, and TypeScript middleware status (shipped or deferred to v2.5.0.1 with rationale)
   - **Verify**: Links to `docs/adapters/mcp-auth-bridge.md`
+  - **Result (2026-06-24)**: `## [2.5.0] - 2026-06-24` — Added (bridge, compliance, tests), Deferred (MAP-004, initialize), TypeScript defer v2.5.0.1, Migration (no breaking); links to adapter guide + spike
 
 ### 3.0 Merge to main & tag
 

--- a/engineering/tasks/v2.5.0/sprint-S5-release.md
+++ b/engineering/tasks/v2.5.0/sprint-S5-release.md
@@ -4,7 +4,7 @@
 **Branch**: `feat/v2.5.0-s5-release` → merge into **`release/2.5.0`**, then **`release/2.5.0` → `main`**
 **Depends on**: S0–S4 complete on `release/2.5.0`
 
-> **Status:** Branch `feat/v2.5.0-s5-release`. **1.0** ✅ · **2.0** ✅ — next sub-task: **3.1** PR `release/2.5.0` → `main`.
+> **Status:** PR [#235](https://github.com/adriannoes/asap-protocol/pull/235) open (`feat/v2.5.0-s5-release` → `release/2.5.0`). **1.0** ✅ · **2.0** ✅ — awaiting review; then **3.1** PR `release/2.5.0` → `main` + tag on `main`.
 
 **Trigger:** All sprint acceptance criteria met on integration branch.
 **Enables:** v2.5.1 Adapter Lab II.

--- a/engineering/tasks/v2.5.0/sprint-S5-release.md
+++ b/engineering/tasks/v2.5.0/sprint-S5-release.md
@@ -25,9 +25,8 @@
 - `src/asap/__init__.py` — `__version__` (must match metadata)
 - `uv.lock` — local package version pin
 - `CHANGELOG.md` — v2.5.0 section ✅
-- `CHANGELOG.md` — v2.5.0 section
 - `product/checkpoints.md` — post-release checkpoint
-- `AGENTS.md` — knowledge map and version context
+- `AGENTS.md` — knowledge map and version context ✅
 
 ### Optional (SHOULD defer)
 - `packages/typescript/` — `@asap-protocol/mcp-auth` npm package (v2.5.0.1 if not ready)

--- a/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
+++ b/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
@@ -96,9 +96,10 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
     - [x] `asap-compliance` includes `mcp-auth-bridge` profile cases for stdio MCP, including manifest tools ⊆ registered tools (merged `4b67b50`, [PR #233](https://github.com/adriannoes/asap-protocol/pull/233))
     - [x] Post-S4 refactor: unified capability metadata, `MCPAuthConfig` in `config.py`, split adapter tests (merged `a60c1e9`, [PR #234](https://github.com/adriannoes/asap-protocol/pull/234))
     - [x] TS middleware: **deferred to v2.5.0.1** per [typescript-mcp-auth-spike.md](./typescript-mcp-auth-spike.md) (MCP-TS-001..003; not a release blocker)
-    - [ ] `pyproject.toml` → **2.5.0**; tag `v2.5.0` published (S5)
-    - [ ] `AGENTS.md` knowledge map updated; CHANGELOG `[2.5.0]` with TS defer subsection (S5)
-    - [ ] Pre-push CI suite green on `release/2.5.0` (ruff, mypy, pytest ≥85% cov, pip-audit) (S5)
+    - [x] `pyproject.toml` / `src/asap/__init__.py` / `uv.lock` → **2.5.0** (S5 — [PR #235](https://github.com/adriannoes/asap-protocol/pull/235))
+    - [x] `AGENTS.md` knowledge map updated; CHANGELOG `[2.5.0]` with TS defer subsection (S5 — PR #235)
+    - [x] Pre-push CI suite green on `release/2.5.0` (ruff, mypy, pytest ≥85% cov, pip-audit) — results in [sprint-S5-release.md](./sprint-S5-release.md) §1.0 (2026-06-24)
+    - [ ] Tag `v2.5.0` published (S5 §3.2)
     - [ ] `release/2.5.0` → `main` merge + maintainer PyPI publish (S5)
 
 ## Relevant Files (overview)

--- a/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
+++ b/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
@@ -183,3 +183,4 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 | 2026-06-24 | S4 acceptance gate green on `feat/v2.5.0-s4-compliance` (pytest + ruff + mypy); PR pending merge into `release/2.5.0` |
 | 2026-06-24 | S4 merged on `release/2.5.0` (`4b67b50`, [PR #233](https://github.com/adriannoes/asap-protocol/pull/233)); `mcp-auth-bridge` compliance profile, stdio integration tests, CI on `release/2.5.0`, TS `@asap-protocol/mcp-auth` defer to v2.5.0.1; S5 release pending |
 | 2026-06-24 | Post-S4 refactor merged (`a60c1e9`, [PR #234](https://github.com/adriannoes/asap-protocol/pull/234)); `MCPAuthConfig` → `config.py`, adapter tests split; branch synced with `origin/release/2.5.0`; S5 active |
+| 2026-06-24 | S5 release prep — [PR #235](https://github.com/adriannoes/asap-protocol/pull/235) (`feat/v2.5.0-s5-release` → `release/2.5.0`): version 2.5.0, CHANGELOG, docs sync; awaiting review |

--- a/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
+++ b/engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md
@@ -1,6 +1,6 @@
 # Tasks: v2.5.0 MCP Auth Bridge — Sprint Index
 
-**Status: 🟡 IN PROGRESS** — S0–S3 merged on **`release/2.5.0`** (`175ae02`); S4 gate green on **`feat/v2.5.0-s4-compliance`** (PR pending merge); S5 planned.
+**Status: 🟡 IN PROGRESS** — S0–S4 merged on **`release/2.5.0`** (`a60c1e9`, incl. post-S4 refactor [PR #234](https://github.com/adriannoes/asap-protocol/pull/234)); **S5 release** next ([sprint-S5-release.md](./sprint-S5-release.md)).
 
 Based on [PRD v2.5.0 MCP Auth Bridge](../../../product/prd/prd-v2.5.0-mcp-auth-bridge.md). Each sprint maps to a PR into **`release/2.5.0`** (see [BRANCHING.md](./BRANCHING.md)); merge to `main` only after S5.
 
@@ -20,10 +20,10 @@ Based on [PRD v2.5.0 MCP Auth Bridge](../../../product/prd/prd-v2.5.0-mcp-auth-b
 | **S1** | [Core auth middleware](./sprint-S1-core-middleware.md) | MCP-AUTH-001..004, 006 and auth portions of 007 | P0 | ✅ Done (merged `60e2e85`, PR #229) |
 | **S2** | [Capability mapping & errors](./sprint-S2-capability-mapping.md) | MCP-MAP-*, §4.5–4.6 | P0 | ✅ Done (merged `8352936`, PR #231; MCP-MAP-004 deferred) |
 | **S3** | [Docs, examples & discovery](./sprint-S3-docs-examples.md) | MCP-DISC-*, MCP-DOC-* | P0/P1 | ✅ Done (merged `175ae02`, PR #232) |
-| **S4** | [Compliance & integration tests](./sprint-S4-compliance.md) | MCP-DISC-003, harness | P1 | ✅ Ready — `feat/v2.5.0-s4-compliance` (gate green, PR pending merge) |
-| **S5** | [Release v2.5.0](./sprint-S5-release.md) | DoD, metrics | P0 | 🔵 Planned |
+| **S4** | [Compliance & integration tests](./sprint-S4-compliance.md) | MCP-DISC-003, harness | P1 | ✅ Done (merged `4b67b50`, [PR #233](https://github.com/adriannoes/asap-protocol/pull/233)) |
+| **S5** | [Release v2.5.0](./sprint-S5-release.md) | DoD, metrics | P0 | 🔵 **Active** — branch `feat/v2.5.0-s5-release` |
 
-> **Note:** `@asap-protocol/mcp-auth` (TypeScript, MCP-TS-*) is SHOULD. S4 runs a scoped feasibility spike; S5 either ships it or records an explicit v2.5.0.1 defer in CHANGELOG/backlog.
+> **Note:** `@asap-protocol/mcp-auth` (TypeScript, MCP-TS-*) is SHOULD. S4 spike **decided DEFER to v2.5.0.1** ([typescript-mcp-auth-spike.md](./typescript-mcp-auth-spike.md)); S5 records defer in CHANGELOG/backlog — does not block Python tag.
 
 ## Dependency Graph
 
@@ -93,23 +93,27 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
   - **Enables:** v2.5.1 Adapter Lab II (blocked until tag).
   - **Depends on:** Tasks 2.0–4.0.
   - **Acceptance criteria:**
-    - [x] `asap-compliance` includes `mcp_auth` profile cases for stdio MCP, including manifest tools ⊆ registered tools (green locally; CI on PR merge)
-    - [ ] `pyproject.toml` / npm → **2.5.0**; tag `v2.5.0` published
-    - [ ] `AGENTS.md` knowledge map updated; CHANGELOG `[2.5.0]`
-    - [ ] Pre-push CI suite green (ruff, mypy, pytest, TS if touched)
-    - [ ] TS middleware: shipped OR explicit defer note in CHANGELOG
+    - [x] `asap-compliance` includes `mcp-auth-bridge` profile cases for stdio MCP, including manifest tools ⊆ registered tools (merged `4b67b50`, [PR #233](https://github.com/adriannoes/asap-protocol/pull/233))
+    - [x] Post-S4 refactor: unified capability metadata, `MCPAuthConfig` in `config.py`, split adapter tests (merged `a60c1e9`, [PR #234](https://github.com/adriannoes/asap-protocol/pull/234))
+    - [x] TS middleware: **deferred to v2.5.0.1** per [typescript-mcp-auth-spike.md](./typescript-mcp-auth-spike.md) (MCP-TS-001..003; not a release blocker)
+    - [ ] `pyproject.toml` → **2.5.0**; tag `v2.5.0` published (S5)
+    - [ ] `AGENTS.md` knowledge map updated; CHANGELOG `[2.5.0]` with TS defer subsection (S5)
+    - [ ] Pre-push CI suite green on `release/2.5.0` (ruff, mypy, pytest ≥85% cov, pip-audit) (S5)
+    - [ ] `release/2.5.0` → `main` merge + maintainer PyPI publish (S5)
 
 ## Relevant Files (overview)
 
 ### New (expected)
 
-- `src/asap/adapters/mcp/__init__.py` — public exports (`protect_server`, `MCPAuthConfig`)
+- `src/asap/adapters/mcp/__init__.py` — public exports (`protect_server`, `MCPAuthConfig`, `ProtectedMCPServer`)
+- `src/asap/adapters/mcp/config.py` — `MCPAuthConfig`, `resolve_jwt_extractor` (extracted PR #234)
 - `src/asap/adapters/mcp/auth_middleware.py` — JWT extraction, `protect_server`, error mapping
 - `src/asap/adapters/mcp/capability_map.py` — tool → capability resolution; constraint violation formatting
 - `src/asap/adapters/mcp/protected_server.py` — bridge registry, startup validation, grant gate
 - `src/asap/adapters/mcp/errors.py` — ASAP MCP error code constants
-- `tests/adapters/mcp/test_auth_middleware.py` — auth path tests
+- `tests/adapters/mcp/test_jwt_gate.py`, `test_grant_enforcement.py`, `test_capability_startup.py` — auth path tests (split PR #234)
 - `tests/adapters/mcp/test_capability_map.py` — mapping + constraint tests
+- `tests/adapters/mcp/test_stdio_integration.py` — protected stdio MCP integration (S4)
 - `examples/mcp_auth_bridge/` — runnable protected MCP server (shipped S3)
 - `examples/mcp_auth_bridge/server.py`, `client.py`, `README.md` — reference protected stdio server + JWT flow
 - `docs/adapters/mcp-auth-bridge.md` — integration guide (shipped S3)
@@ -139,9 +143,9 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 
 ## Definition of Done (v2.5.0)
 
-- [ ] All parent tasks 1.0–5.0 complete (1.0–4.0 ✅; 5.0 pending S4–S5)
+- [ ] All parent tasks 1.0–5.0 complete (1.0–4.0 + S4 ✅; 5.0 pending S5 release)
 - [x] PRD requirements MCP-AUTH-001..006, MCP-MAP-001..003, MCP-DOC-001..004 satisfied (MCP-MAP-004 / `hide_unauthorized_tools` deferred per design lock §6)
-- [ ] PRD discovery requirements MCP-DISC-001..003 satisfied or explicitly deferred with rationale (MCP-DISC-001/002 ✅ in S3; MCP-DISC-003 ✅ in S4 compliance harness)
+- [x] PRD discovery requirements MCP-DISC-001..003 satisfied or explicitly deferred with rationale (MCP-DISC-001/002 ✅ in S3; MCP-DISC-003 ✅ in S4 `mcp-auth-bridge` harness, PR #233)
 - [x] Unprotected `MCPServer` usage unchanged (opt-in via `protect_server`)
 - [x] No wire-protocol breaking changes
 
@@ -177,3 +181,5 @@ Detailed sub-tasks live in per-sprint files (`sprint-S0` … `sprint-S5`).
 | 2026-06-24 | S2 merged on `release/2.5.0` (`8352936`); S3 branch `feat/v2.5.0-s3-docs-examples` opened with parallel workstreams |
 | 2026-06-24 | S1/S2 merge refs reconciled; S3 impl complete — [PR #232](https://github.com/adriannoes/asap-protocol/pull/232) open into `release/2.5.0`; parent tasks 1.0–4.0 marked done |
 | 2026-06-24 | S4 acceptance gate green on `feat/v2.5.0-s4-compliance` (pytest + ruff + mypy); PR pending merge into `release/2.5.0` |
+| 2026-06-24 | S4 merged on `release/2.5.0` (`4b67b50`, [PR #233](https://github.com/adriannoes/asap-protocol/pull/233)); `mcp-auth-bridge` compliance profile, stdio integration tests, CI on `release/2.5.0`, TS `@asap-protocol/mcp-auth` defer to v2.5.0.1; S5 release pending |
+| 2026-06-24 | Post-S4 refactor merged (`a60c1e9`, [PR #234](https://github.com/adriannoes/asap-protocol/pull/234)); `MCPAuthConfig` → `config.py`, adapter tests split; branch synced with `origin/release/2.5.0`; S5 active |

--- a/engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md
+++ b/engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md
@@ -209,8 +209,8 @@ Detail appended after `:` when present (e.g. `asap:invalid_token: expired`).
 
 ### 7.1 During S5 release (required)
 
-- [ ] **CHANGELOG.md** — Under v2.5.0, add subsection *TypeScript*: state MCP-TS-001..003 **deferred to v2.5.0.1** with link to this spike
-- [ ] **docs/adapters/mcp-auth-bridge.md** — One paragraph: Python stdio shipped; `@asap-protocol/mcp-auth` for HTTP/SSE planned v2.5.0.1 (link spike)
+- [x] **CHANGELOG.md** — Under v2.5.0, add subsection *TypeScript*: state MCP-TS-001..003 **deferred to v2.5.0.1** with link to this spike (S5 — PR #235)
+- [x] **docs/adapters/mcp-auth-bridge.md** — One paragraph: Python stdio shipped; `@asap-protocol/mcp-auth` for HTTP/SSE planned v2.5.0.1 (link spike) (S5 — PR #235)
 - [ ] **product/checkpoints.md** — Note TS middleware defer; not a v2.5.0 blocker
 - [ ] **Do not** add `packages/typescript/mcp-auth` or bump TS packages to 2.5.0 for this feature
 

--- a/product/prd/prd-v2.5-roadmap.md
+++ b/product/prd/prd-v2.5-roadmap.md
@@ -36,13 +36,15 @@ Between **v2.4.1** (security patch) and **v3.0** (economy), the project needs a 
 
 | Version | Codename | Primary outcome | PRD | Status |
 |---------|----------|-----------------|-----|--------|
-| **v2.5.0** | MCP Auth Bridge | ASAP Agent JWT + capabilities em MCP `tools/call` | [prd-v2.5.0-mcp-auth-bridge.md](./prd-v2.5.0-mcp-auth-bridge.md) | **READY FOR IMPLEMENTATION** — [tasks roadmap](../../engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md) |
+| **v2.5.0** | MCP Auth Bridge | ASAP Agent JWT + capabilities em MCP `tools/call` | [prd-v2.5.0-mcp-auth-bridge.md](./prd-v2.5.0-mcp-auth-bridge.md) | **S5 RELEASE PENDING** — S0–S4 on `release/2.5.0` (`a60c1e9`); [tasks roadmap](../../engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md) · [S5 sprint](../../engineering/tasks/v2.5.0/sprint-S5-release.md) |
 | **v2.5.1** | Adapter Lab II | Enterprise/workflow adapters (ex v2.3.2) | [prd-v2.5.1-adapter-lab-ii.md](./prd-v2.5.1-adapter-lab-ii.md) | Planned (after 2.5.0) |
 | **v2.5.2** | Distribution Loop | Homepage, templates, métricas (ex v2.3.3) | [prd-v2.5.2-distribution-loop.md](./prd-v2.5.2-distribution-loop.md) | Planned (after 2.5.1) |
 | **v2.5.3** | Formal Spec & Interop | RFC spec, introspection, privacy, cross-protocol | [prd-v2.5.3-formal-spec-interop.md](./prd-v2.5.3-formal-spec-interop.md) | Planned |
 | **v2.5.4** | Security Follow-up | `extra="forbid"`, operator API auth, Redis replay (ex v2.4.1 §8) | *(inline in train — patch PRD when triggered)* | Optional |
 
-**Execution rule:** v2.5.1 and v2.5.2 **do not start** until v2.5.0 ships. v2.5.3 may overlap planning/docs-only work but implementation waits for stable MCP Auth Bridge APIs.
+**Execution rule:** v2.5.1 and v2.5.2 **do not start** until v2.5.0 ships (S5: version bump, CHANGELOG, `release/2.5.0` → `main`, tag `v2.5.0`). v2.5.3 may overlap planning/docs-only work but implementation waits for stable MCP Auth Bridge APIs.
+
+**v2.5.0 release gate (S5):** Pre-push CI green on `release/2.5.0`; `@asap-protocol/mcp-auth` (TypeScript) **deferred to v2.5.0.1** — does not block Python PyPI publish.
 
 ---
 
@@ -67,7 +69,7 @@ Narrativa pública: **ASAP não substitui MCP** — fornece a camada de identida
 | Capability model stable (v2.2+) | ✅ |
 | Agent JWT + Host JWT (v2.2+) | ✅ |
 | MCP server/client in tree (`asap.mcp`) | ✅ stdio + tools |
-| Envelope MCP payloads (`McpToolCall`) | ✅ A2A path only — not native MCP auth |
+| Envelope MCP payloads (`McpToolCall`) | ✅ A2A path; native MCP auth via v2.5.0 bridge (S0–S4 complete, tag pending) |
 | OpenAPI Adapter (v2.3.0) | ✅ |
 
 ---
@@ -100,3 +102,4 @@ Narrativa pública: **ASAP não substitui MCP** — fornece a camada de identida
 |------|--------|
 | 2026-06-22 | Parent tasks 1.0–5.0 added to sprint index |
 | 2026-06-24 | Sprint sub-tasks S0–S5 finalized; v2.5.0 marked ready for implementation |
+| 2026-06-24 | v2.5.0 S0–S4 merged on `release/2.5.0` (`a60c1e9`, incl. PR #233 compliance + PR #234 refactor); status → **S5 RELEASE PENDING**; TS `@asap-protocol/mcp-auth` deferred to v2.5.0.1 |

--- a/product/prd/prd-v2.5.0-mcp-auth-bridge.md
+++ b/product/prd/prd-v2.5.0-mcp-auth-bridge.md
@@ -298,8 +298,8 @@ def default_jwt_extractor(params: CallToolRequestParams) -> str | None:
 - [x] Compliance harness includes `mcp-auth-bridge` profile cases for auth, grants, constraints, and manifest alignment (S4, [PR #233](https://github.com/adriannoes/asap-protocol/pull/233))
 - [x] Docs published; `AGENTS.md` knowledge map references MCP Auth Bridge (S3)
 - [x] No breaking change to unprotected `MCPServer` usage (opt-in `protect_server`)
-- [ ] Version bump `2.5.0`, CHANGELOG, `release/2.5.0` → `main`, tag `v2.5.0` (S5 — [sprint-S5-release.md](../../engineering/tasks/v2.5.0/sprint-S5-release.md))
-- [ ] CHANGELOG records TypeScript middleware defer to v2.5.0.1 (S5)
+- [x] Version bump `2.5.0` + CHANGELOG `[2.5.0]` with TypeScript defer to v2.5.0.1 (S5 — [PR #235](https://github.com/adriannoes/asap-protocol/pull/235))
+- [ ] `release/2.5.0` → `main`, tag `v2.5.0`, PyPI publish (S5 §3.0 — [sprint-S5-release.md](../../engineering/tasks/v2.5.0/sprint-S5-release.md))
 
 ---
 

--- a/product/prd/prd-v2.5.0-mcp-auth-bridge.md
+++ b/product/prd/prd-v2.5.0-mcp-auth-bridge.md
@@ -3,7 +3,7 @@
 > **Product Requirements Document**
 >
 > **Version**: 2.5.0
-> **Status**: READY FOR IMPLEMENTATION
+> **Status**: IMPLEMENTATION COMPLETE — **S5 RELEASE PENDING**
 > **Created**: 2026-03-20 (origin); **rescoped to v2.5.0**: 2026-06-22
 > **Last Updated**: 2026-06-24
 >
@@ -32,14 +32,14 @@ Today MCP has no standard auth story for per-agent, scoped tool access. ASAP alr
 
 ### 1.3 Deliverables
 
-| # | Deliverable | Package / surface |
-|---|-------------|-------------------|
-| 1 | Python auth middleware for `MCPServer` | `asap.adapters.mcp.auth_middleware` |
-| 2 | Tool → capability mapping + grant enforcement | `asap.adapters.mcp.capability_map` |
-| 3 | Discovery: well-known manifest alongside MCP | docs + optional `MCPAuthConfig.manifest_url` |
-| 4 | TypeScript middleware (SHOULD) | `@asap-protocol/mcp-auth` |
-| 5 | Reference server + compliance tests | `examples/mcp_auth_bridge/server.py`, harness cases |
-| 6 | Integration guide | `docs/adapters/mcp-auth-bridge.md` |
+| # | Deliverable | Package / surface | Status |
+|---|-------------|-------------------|--------|
+| 1 | Python auth middleware for `MCPServer` | `asap.adapters.mcp.auth_middleware` | ✅ Shipped (S1; refined PR #234) |
+| 2 | Tool → capability mapping + grant enforcement | `asap.adapters.mcp.capability_map` | ✅ Shipped (S2; unified metadata PR #234) |
+| 3 | Discovery: well-known manifest alongside MCP | docs + optional `MCPAuthConfig.manifest_url` | ✅ Shipped (S3 docs; S4 compliance) |
+| 4 | TypeScript middleware (SHOULD) | `@asap-protocol/mcp-auth` | ⏸ **Deferred to v2.5.0.1** ([spike](../../engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md)) |
+| 5 | Reference server + compliance tests | `examples/mcp_auth_bridge/server.py`, harness cases | ✅ Shipped (S3 example; S4 `mcp-auth-bridge` profile) |
+| 6 | Integration guide | `docs/adapters/mcp-auth-bridge.md` | ✅ Shipped (S3) |
 
 ### 1.4 Out of scope (v2.5.0)
 
@@ -239,7 +239,7 @@ That registry validates grant status, expiry, and constraints with `validate_con
 ### 6.1 Configuration
 
 ```python
-# asap/adapters/mcp/auth_middleware.py (new)
+# asap/adapters/mcp/config.py
 
 @dataclass
 class MCPAuthConfig:
@@ -293,11 +293,13 @@ def default_jwt_extractor(params: CallToolRequestParams) -> str | None:
 
 **Definition of Done (v2.5.0):**
 
-- [ ] `protect_server` passes unit + integration tests with mock Agent JWT
-- [ ] Example server runs: `uv run python examples/mcp_auth_bridge/server.py`
-- [ ] Compliance harness includes `mcp_auth` profile cases for auth, grants, constraints, and manifest alignment
-- [ ] Docs published; `AGENTS.md` knowledge map updated
-- [ ] No breaking change to unprotected `MCPServer` usage
+- [x] `protect_server` passes unit + integration tests with mock Agent JWT (S1–S2; tests split in PR #234)
+- [x] Example server runs: `uv run python examples/mcp_auth_bridge/server.py` (S3)
+- [x] Compliance harness includes `mcp-auth-bridge` profile cases for auth, grants, constraints, and manifest alignment (S4, [PR #233](https://github.com/adriannoes/asap-protocol/pull/233))
+- [x] Docs published; `AGENTS.md` knowledge map references MCP Auth Bridge (S3)
+- [x] No breaking change to unprotected `MCPServer` usage (opt-in `protect_server`)
+- [ ] Version bump `2.5.0`, CHANGELOG, `release/2.5.0` → `main`, tag `v2.5.0` (S5 — [sprint-S5-release.md](../../engineering/tasks/v2.5.0/sprint-S5-release.md))
+- [ ] CHANGELOG records TypeScript middleware defer to v2.5.0.1 (S5)
 
 ---
 
@@ -315,13 +317,13 @@ def default_jwt_extractor(params: CallToolRequestParams) -> str | None:
 
 ## 9. Success metrics
 
-| Metric | Target |
-|--------|--------|
-| Protected MCP example server | 1 runnable in repo |
-| Test coverage on `asap.adapters.mcp` | ≥ 90% |
-| External MCP servers adopting (post-release) | 3+ within 90 days (aspirational) |
-| Compliance harness | New `mcp_auth` module green in CI |
-| Time to ship from task kickoff | ≤ 3 weeks (solo maintainer estimate) |
+| Metric | Target | Status |
+|--------|--------|--------|
+| Protected MCP example server | 1 runnable in repo | ✅ `examples/mcp_auth_bridge/` |
+| Test coverage on `asap.adapters.mcp` | ≥ 90% | ✅ (verify in S5 pre-release gate) |
+| External MCP servers adopting (post-release) | 3+ within 90 days (aspirational) | — post-tag |
+| Compliance harness | `mcp-auth-bridge` profile green in CI | ✅ on `release/2.5.0` |
+| Time to ship from task kickoff | ≤ 3 weeks (solo maintainer estimate) | 🟡 S5 pending |
 
 ---
 
@@ -332,8 +334,9 @@ def default_jwt_extractor(params: CallToolRequestParams) -> str | None:
 | v2.4.1 shipped | ✅ |
 | `verify_agent_jwt` stable | ✅ |
 | `CapabilityRegistry.check_grant` + `validate_constraints` | ✅ |
-| `MCPServer` tools/call hook point | ✅ `_handle_tools_call` exists; S0 locks wrapper strategy |
-| v2.5.1+ adapter work | ❌ blocked until v2.5.0 ships |
+| `MCPServer` tools/call hook point | ✅ wrapper via `protect_server` (S1; `config.py` + `ProtectedMCPServer` PR #234) |
+| S0–S4 on `release/2.5.0` | ✅ (`a60c1e9`) |
+| v2.5.1+ adapter work | ❌ blocked until v2.5.0 tag (S5) |
 
 ---
 
@@ -357,3 +360,4 @@ def default_jwt_extractor(params: CallToolRequestParams) -> str | None:
 | 2026-06-22 | 1.0.0 | **Rescoped to v2.5.0**; full architecture, API, task breakdown; split from formal spec (→ v2.5.3) |
 | 2026-06-22 | 1.1.0 | Parent tasks 1.0–5.0 in [tasks-v2.5.0-roadmap.md](../../engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md) |
 | 2026-06-24 | 1.2.0 | Aligned task plan with repo APIs, canonical docs/example paths, grant registry config, and compliance/doc gaps |
+| 2026-06-24 | 1.3.0 | S0–S4 complete on `release/2.5.0` (`a60c1e9`); deliverables table + DoD updated; TS middleware deferred to v2.5.0.1; S5 release gate remains |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asap-protocol"
-version = "2.4.1"
+version = "2.5.0"
 description = "Async Simple Agent Protocol - A streamlined protocol for agent-to-agent communication"
 authors = [
     {name = "ASAP Protocol Contributors"}

--- a/src/asap/__init__.py
+++ b/src/asap/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-__version__ = "2.4.1"
+__version__ = "2.5.0"
 
 __all__ = ["__version__", "create_from_openapi"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "asap-protocol"
-version = "2.4.1"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Sprint **S5** release preparation for **v2.5.0 MCP Auth Bridge** on the integration branch (`release/2.5.0`).

- Bump `asap-protocol` to **2.5.0** (`pyproject.toml`, `src/asap/__init__.py`, `uv.lock`)
- Add `CHANGELOG.md` section `[2.5.0]` — MCP Auth Bridge features, opt-in migration, no breaking changes, `@asap-protocol/mcp-auth` **deferred to v2.5.0.1**
- Reconcile sprint index, PRD status, and `sprint-S5-release.md` (tasks **1.0** and **2.0** complete)

**Pre-release verification (S5 1.1–1.2, local on `release/2.5.0` base):**
- ruff, mypy, full pytest (**3614 passed**, **93.08%** cov), pip-audit ✅
- `asap.adapters.mcp` coverage **96.17%** (gate ≥90%) ✅

## Out of scope for this PR

- Tag `v2.5.0` and PyPI publish — **after** follow-up PR `release/2.5.0` → `main` (maintainer tags on `main` to trigger `release.yml`)
- `product/checkpoints.md` — post-tag (S5 task 3.3)
- npm `@asap-protocol/mcp-auth` — deferred per [typescript-mcp-auth-spike.md](engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md)

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src/ scripts/ tests/`
- [x] `uv run pytest --tb=short --cov=asap --cov-report=xml --cov-fail-under=85`
- [x] pip-audit per `SECURITY.md`
- [x] `uv run pytest tests/adapters/mcp/ --cov=asap.adapters.mcp --cov-fail-under=90`
- [x] `uv run python -c "import asap; print(asap.__version__)"` → `2.5.0`
- [ ] CI green on this PR

## Related

- Sprint: [sprint-S5-release.md](engineering/tasks/v2.5.0/sprint-S5-release.md)
- PRD: [prd-v2.5.0-mcp-auth-bridge.md](product/prd/prd-v2.5.0-mcp-auth-bridge.md)
- Adapter guide: [docs/adapters/mcp-auth-bridge.md](docs/adapters/mcp-auth-bridge.md)