### PR TITLE
Sprint S0: P0 correctness & security fixes (v2.5.1 thermo-nuclear patch)

### DIFF
--- a/engineering/code-review/v2.5.1/review-v2.4-v2.5-diff.md
+++ b/engineering/code-review/v2.5.1/review-v2.4-v2.5-diff.md
@@ -1,0 +1,417 @@
+# Formal Code Review: v2.4.0 + v2.5.0 Diff (`v2.3.0..HEAD`)
+
+**Review Date:** 2026-06-25
+**Reviewer:** AI-assisted review (Cursor agent, GLM 5.2)
+**Diff Range:** `v2.3.0` (commit `96201c6`, 2026-05-06) → `HEAD` (commit `4c367e0`, 2026-06-24)
+**Commit Count in Range:** 275 commits (`git log --oneline v2.3.0..HEAD | wc -l`)
+**Releases Covered:** v2.4.0 (Edge AI Discovery, tag `v2.4.0` → `d7958d8`, 2026-05-24) and v2.5.0 (MCP Auth Bridge, tag `v2.5.0` → `1c5027c`, 2026-06-24; follow-up `v2.5.0.1` → `0ecb39f`, 2026-06-24)
+**Scope of Source Changes:** 29 source files changed, +1040 / −176 (src tree only); 377 files changed overall including tests/docs (+38,325 / −9,197)
+**Reference Structure:** `engineering/code-review/v1.3.0/PR-48-REVIEW.md`
+**Sprint Cross-Reference:** `engineering/tasks/private/v2.5.1/sprint-S0-p0-correctness-security.md`
+
+---
+
+## Executive Summary
+
+Two production releases — **v2.4.0 (Edge AI Discovery)** and **v2.5.0 (MCP Auth Bridge)** — shipped on `main` without a recorded formal code review (the last review in `engineering/code-review/` is `v2.3.0/`). This review retrospectively covers the `v2.3.0..HEAD` diff and records the resolution status of the correctness/security defects uncovered by the v2.5.1 Thermo-Nuclear Patch bug-hunt (Sprint S0, bugs B1–B6).
+
+The diff is broadly well-structured: the v2.4.0 edge/hardware manifest extension is additive and backward-compatible (all new manifest fields are optional), and the v2.5.0 MCP Auth Bridge is a clean opt-in adapter layer (`protect_server`) that reuses the canonical `verify_agent_jwt`/`verify_host_jwt` verifiers and the existing `CapabilityRegistry` grant machinery. JWT claim validation was correctly centralized into `asap/auth/claims.py` and threaded into both `OAuth2Middleware` and `validate_jwt` (iss/aud enforcement that was previously missing).
+
+However, the review confirms **six P0 defects** (B1–B6) that span the v2.4.0/v2.5.0 range — three of them security-relevant (B3 revoked-host bypass, B4 WebSocket OAuth2 bypass, B1 non-atomic cascade revocation). All six are identified and scheduled for remediation in Sprint S0 with a failing-test-first policy. Two additional findings (M-1, M-2) are recorded below that are not in the S0 list but surfaced during this read.
+
+| Severity | Count | Notes |
+|----------|-------|-------|
+| 🔴 CRITICAL | 3 | B3 (revoked-host bypass), B4 (WS OAuth2 bypass), B1 (non-atomic cascade + missing InMemory lock) |
+| 🟠 HIGH | 2 | B6 (client correlation_id not bound), B2 (divergent usage_events DDL) |
+| 🟡 MEDIUM | 3 | B5 (OpenAPI handler dead path / pre-v2.3.0 carry-over), M-1 (MCP env-JWT fallback posture), M-2 (hide_unauthorized_tools silent no-op) |
+| 🔵 LOW / NITPICK | 2 | L-1 (wellknown alias change is behaviorally correct but unflagged for cache impact), L-2 (from_server shallow tool-dict copy) |
+
+> **Verdict:** REQUEST CHANGES — the three Critical findings (B1/B3/B4) are security-relevant and are being remediated in Sprint S0. This review exists to *record* that those defects were present in the shipped v2.4.0/v2.5.0 range and to track their remediation; it does not block any already-shipped release.
+
+---
+
+## 🔴 CRITICAL Findings
+
+### C-1 (S0 B3 / BUG #1): Divergent Host-JWT verifiers — revoked-host bypass on capability routes
+
+**Severity:** CRITICAL (security)
+**Location:** `src/asap/transport/capability_routes.py:60-83` vs `src/asap/transport/agent_routes.py:239-282`
+**Status:** Identified; **Remediated in S0** (Task 3.0 — unify verifier into `_auth_helpers.py`)
+
+Two independent Host-JWT verifiers exist in the transport package, with divergent strictness:
+
+- `agent_routes._verify_host_bearer_identity` (the strict one) inspects `result.host.status` and rejects with **403** when the host is revoked (`agent_routes.py:278-280`).
+- `capability_routes._verify_host_bearer` (the weak one) **omits the host-status check entirely** — it only checks `result.ok` and returns the result (`capability_routes.py:81-83`).
+
+**Evidence** (`capability_routes.py:60-83`):
+
+```60:83:src/asap/transport/capability_routes.py
+async def _verify_host_bearer(
+    request: Request,
+    *,
+    jti_replay_cache: JtiReplayCache | None = None,
+) -> tuple[JwtVerifyResult | None, JSONResponse | None]:
+    """Verify a Host JWT Bearer token."""
+    token = bearer_token_from_request(request)
+    if not token:
+        return None, JSONResponse(
+            status_code=401,
+            content={"detail": "Authentication required"},
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    host_store: HostStore = request.app.state.identity_host_store
+    audience = request.app.state.identity_jwt_audience
+    result = await verify_host_jwt(
+        token,
+        host_store,
+        expected_audience=audience,
+        jti_replay_cache=jti_replay_cache,
+    )
+    if not result.ok:
+        return None, JSONResponse(status_code=401, content={"detail": result.error})
+    return result, None
+```
+
+Contrast with the strict verifier in `agent_routes.py`:
+
+```278:282:src/asap/transport/agent_routes.py
+    host = result.host
+    if host is not None and host.status == "revoked":
+        return None, JSONResponse(status_code=403, content={"detail": "host revoked"})
+
+    return result, None
+```
+
+**Impact:** A revoked **host** can still authenticate against capability routes (e.g. `POST /asap/agent/reactivate` routed through `capability_routes`). The existing test `test_reactivate_revoked_agent_returns_403` revokes the **agent**, not the host, so it exercises the agent-status check inside `reactivate_agent` and does **not** cover this gap.
+
+**S0 Remediation (Task 3.0):** Promote a single canonical `verify_host_bearer(request, *, jti_replay_cache, require_active_host=True)` into `src/asap/transport/_auth_helpers.py` (currently only holds `bearer_token_from_request`). Delete both local copies; both route modules import and call the canonical one. A new failing test revokes the **host** and asserts 403 on `/reactivate`. *Status: in progress on `feat/v2.5.1-s0-p0-fixes`.*
+
+---
+
+### C-2 (S0 B4 / BUG #4): WebSocket path bypasses `OAuth2Middleware`
+
+**Severity:** CRITICAL (security — authentication evasion in OAuth2-only deployments)
+**Location:** `src/asap/transport/websocket.py:761-786` (`_make_fake_request`), invoked at `websocket.py:1017` and `1024`; `src/asap/transport/server.py:2141-2152` (`websocket_asap`); `src/asap/auth/middleware.py:135` (`OAuth2Middleware`)
+**Status:** Identified; **Remediated in S0** (Task 4.0 — enforce auth on the WS path)
+
+`OAuth2Middleware` is a `BaseHTTPMiddleware` (`auth/middleware.py:135`) that only executes on the Starlette HTTP middleware stack via its `dispatch` method. The WebSocket handler does **not** run through that stack. Instead, `handle_websocket_connection` synthesizes an HTTP `Request` from the WS frame and calls the request handler directly:
+
+```761:786:src/asap/transport/websocket.py
+async def _make_fake_request(body: str, websocket: WebSocket) -> Request:
+    body_bytes = body.encode("utf-8")
+    headers = list(websocket.scope.get("headers", []))
+    headers.append((b"content-length", str(len(body_bytes)).encode()))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": headers,
+        "path": websocket.scope.get("path", "/asap"),
+        "root_path": "",
+        "query_string": b"",
+        "server": websocket.scope.get("server", ("localhost", 8000)),
+    }
+    first_receive = True
+
+    async def receive() -> dict[str, Any]:
+        nonlocal first_receive
+        if first_receive:
+            first_receive = False
+            return {"type": "http.request", "body": body_bytes, "more_body": False}
+        return {"type": "http.disconnect"}
+
+    async def send(_: MutableMapping[str, Any]) -> None:
+        pass
+
+    return Request(scope, receive, send)
+```
+
+Invocation sites:
+
+```1017:1024:src/asap/transport/websocket.py
+                request = await _make_fake_request(raw, websocket)
+                ...
+                    response = await request_handler.handle_message(request)
+```
+
+The `websocket_asap` route (`server.py:2141-2152`) calls `handle_websocket_connection` with no auth gate.
+
+**Impact:** In an OAuth2-only deployment (`oauth2_config` set, `manifest.auth`/`token_validator` absent), `POST /asap` is JWT-protected but `WS /asap/ws` is **unauthenticated** — a client can connect and dispatch `task.request` envelopes without a valid Bearer token.
+
+**S0 Remediation (Task 4.0):** Enforce OAuth2/identity auth explicitly at WS connection acceptance (read `Authorization` from `websocket.scope["headers"]`, validate with the same logic `OAuth2Middleware` uses, reject the connection with a close code on failure), coordinated with S2 Task 3.2 which deletes `_make_fake_request`. A new E2E test (`tests/e2e/test_websocket_oauth2.py`) connects without a token and asserts the message is denied, not dispatched. *Status: in progress on `feat/v2.5.1-s0-p0-fixes`.*
+
+---
+
+### C-3 (S0 B1 + BUG #3): Non-atomic `revoke_cascade` and missing `InMemoryDelegationStorage` lock
+
+**Severity:** CRITICAL (security invariant — revocation atomicity)
+**Location:** `src/asap/economics/delegation_storage.py:128-150` (`DelegationStorageBase.revoke_cascade`), `:153-220` (`InMemoryDelegationStorage`), `:277-292` (`SQLiteDelegationStorage.revoke`)
+**Status:** Identified; **Remediated in S0** (Task 1.0 — atomic cascade + InMemory lock)
+
+The cascade revocation lives on the **base class** and calls `self.revoke(tid)` per token id in an iterative BFS loop:
+
+```128:150:src/asap/economics/delegation_storage.py
+    async def revoke_cascade(
+        self,
+        token_id: str,
+        reason: str | None = None,
+    ) -> None:
+        """Revoke a token and all child delegations (iterative BFS).
+
+        Uses a visited set to handle circular delegation chains and a
+        depth limit (_MAX_CASCADE_DEPTH) to prevent DoS.
+        """
+        visited: set[str] = set()
+        stack: list[tuple[str, int]] = [(token_id, 0)]
+        while stack:
+            tid, depth = stack.pop()
+            if tid in visited or depth > _MAX_CASCADE_DEPTH:
+                continue
+            visited.add(tid)
+            delegate_urn = await self.get_delegate(tid)
+            if delegate_urn:
+                child_ids = await self.list_token_ids_issued_by(delegate_urn)
+                for child_id in child_ids:
+                    stack.append((child_id, depth + 1))
+            await self.revoke(tid, reason)
+```
+
+Two defects combine:
+
+1. **Non-atomic SQLite cascade (B1):** `SQLiteDelegationStorage.revoke` (`:277-292`) opens its **own** `aiosqlite.connect` and commits independently per id. A mid-cascade crash leaves a partial revocation state — the parent revoked but some children still alive — violating the "revoke parent ⟹ revoke all children, atomically" invariant.
+
+2. **Missing InMemory lock (BUG #3):** `InMemoryDelegationStorage.__init__` (`:156-158`) holds only `self._revoked` and `self._issued` dicts — **no `asyncio.Lock`** (contrast with `InMemorySLAStorage`/`InMemoryMeteringStorage`, which use `asyncio.Lock`). Concurrent `register_issued` interleaved between `list_token_ids_issued_by` and `revoke` in the cascade can lose newly-issued children.
+
+**Evidence (InMemory init, no lock):**
+
+```156:158:src/asap/economics/delegation_storage.py
+    def __init__(self) -> None:
+        self._revoked: dict[str, tuple[datetime, str | None]] = {}
+        self._issued: dict[str, tuple[str, str | None, datetime]] = {}
+```
+
+**S0 Remediation (Task 1.0):** Refactor `revoke_cascade` to delegate to a per-subclass `_revoke_cascade_atomic(token_id, reason)` hook. SQLite opens **one** connection, `BEGIN`, walks the tree, `COMMIT` (rollback on exception). InMemory adds an `asyncio.Lock` held across the whole cascade. Failing regression test simulates a 2nd-child failure and asserts no partial state. *Status: in progress on `feat/v2.5.1-s0-p0-fixes`.*
+
+---
+
+## 🟠 HIGH Findings
+
+### H-1 (S0 B6 / BUG #6): Client-side `correlation_id` not bound to request id
+
+**Severity:** HIGH (protocol integrity — request/response mixup under concurrency)
+**Location:** `src/asap/models/envelope.py:138-147` (`validate_response_correlation`), `src/asap/transport/client.py:1032` (HTTP response construction), `src/asap/transport/websocket.py:413` (WS recv loop)
+**Status:** Identified; **Remediated in S0** (Task 6.0 — bind `correlation_id == request.id` at the client pairing site)
+
+The envelope validator only checks that `correlation_id` is **non-empty** for response payload types — it does not bind the value to the originating request id:
+
+```138:147:src/asap/models/envelope.py
+    @model_validator(mode="after")
+    def validate_response_correlation(self) -> "Envelope":
+        response_type_keys = {"taskresponse", "mcptoolresult", "mcpresourcedata"}
+
+        if (
+            _normalize_payload_type(self.payload_type) in response_type_keys
+            and not self.correlation_id
+        ):
+            raise ValueError(f"{self.payload_type} must have correlation_id for request tracking")
+        return self
+```
+
+The HTTP client constructs the response envelope without asserting the correlation matches the request id:
+
+```1032:1032:src/asap/transport/client.py
+                response_envelope = Envelope(**envelope_data)
+```
+
+The WS recv loop (`websocket.py:413`) has the same gap: `envelope = Envelope.model_validate(result["envelope"])` is paired to `request_id` by futures at `:414-417` but the envelope's `correlation_id` is never asserted to equal `request_id`.
+
+**Impact:** A buggy or malicious server can return any non-empty `correlation_id` and the client accepts it as the response to a different request. Under concurrent in-flight requests this enables request/response mixup.
+
+**S0 Remediation (Task 6.0):** When awaiting a response for a known `request_id`, assert `response.correlation_id == request_id` and raise a typed `ProtocolCorrelationError` on mismatch. Keep `validate_response_correlation` as the structural non-empty check; add the binding check at the client pairing site. Document and skip the streaming/unmatched callback paths where correlation is intentionally loose. *Status: in progress on `feat/v2.5.1-s0-p0-fixes`.*
+
+---
+
+### H-2 (S0 B2): Divergent `usage_events` DDL — consumer index missing in one owner
+
+**Severity:** HIGH (correctness — non-deterministic query plans)
+**Location:** `src/asap/state/stores/sqlite.py:397-416` (state-layer DDL, missing index) vs `src/asap/economics/storage.py:486-511` (economics DDL, both indexes)
+**Status:** Identified; **Remediated in S0** (Task 2.0 — single canonical DDL owner)
+
+Two stores create the same physical `usage_events` table on a shared DB file (`asap_state.db`) with different index sets. Whichever store initializes first wins the index set; `CREATE INDEX IF NOT EXISTS` never adds the missing one later.
+
+State-layer DDL (missing the consumer index):
+
+```397:416:src/asap/state/stores/sqlite.py
+    async def _ensure_usage_table(self, conn: aiosqlite.Connection) -> None:
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS usage_events (
+                id TEXT PRIMARY KEY,
+                task_id TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                consumer_id TEXT NOT NULL,
+                metrics TEXT NOT NULL,
+                timestamp TEXT NOT NULL
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_usage_agent_timestamp
+            ON usage_events (agent_id, timestamp)
+            """
+        )
+        await conn.commit()
+```
+
+Economics DDL (creates both indexes):
+
+```505:510:src/asap/economics/storage.py
+        await conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_usage_consumer_timestamp
+            ON usage_events (consumer_id, timestamp)
+            """
+        )
+```
+
+**Impact:** When the state-layer store initializes first, `idx_usage_consumer_timestamp` is never created. Consumer-keyed usage queries fall back to full table scans — non-deterministic performance depending on init order, and a behavioral divergence between deployments that "should" be identical.
+
+**S0 Remediation (Task 2.0):** Extract a shared `_USAGE_EVENTS_DDL` constant + `_ensure_usage_events_schema(conn)` helper and call it from both stores. Full `AsyncSqliteRepository` consolidation is deferred to S1. Failing test asserts the consumer index exists under both init orders. *Status: in progress on `feat/v2.5.1-s0-p0-fixes`.*
+
+---
+
+## 🟡 MEDIUM Findings
+
+### M-1 (S0 B5): OpenAPI handler dead `resolve_headers` path + pre-v2.3.0 carry-over
+
+**Severity:** MEDIUM (maintainability / dead code)
+**Location:** `src/asap/adapters/openapi/handler.py:366-401` (`execute`), `:493-517` (module-level `execute` wiring `session=None`)
+**Status:** Identified; **Remediated in S0** (Task 5.0)
+
+> **Note on diff scope:** `src/asap/adapters/openapi/handler.py` is **byte-identical** between `v2.3.0` and `HEAD` (`git rev-parse` of both blobs returns `ac09b5d3c697d489bb6d074d4fcca87a4f1dd6ba`; no commits in `v2.3.0..HEAD` touch this file). The concerns below are therefore **pre-existing carry-over from v2.3.0 and earlier**, not regressions introduced by v2.4.0/v2.5.0. They are recorded here because Sprint S0 Task 5.0 cleans them up as part of the same patch series, and a retrospective review of the shipped range should note their presence.
+
+The handler exposes a `resolve_headers` callback plumbed through a `session` argument, but the default wiring hardcodes `session=None`, making the callback dead in the actual task-request path:
+
+```493:500:src/asap/adapters/openapi/handler.py
+async def execute(
+    ...,
+    session: object | None = None,
+) -> ...:
+    ...
+    return await handler.execute(capability_name, args, session=session)
+```
+
+```512:517:src/asap/adapters/openapi/handler.py
+        """Translate ``task.request`` envelopes through *upstream* (``session`` is always ``None``)."""
+        ...
+            session=None,
+```
+
+The inline-import and raising-constructor concerns originally listed under B5 are **not present** at HEAD: the `OpenAPIPathParameterError.__init__` (`:81-115`) is already pure (side-effect-free; the docstring at `:76-78` states "Construction is pure... use `for_missing`/`for_invalid` to enforce the invariant at the raise-site"), and the only imports in the file are top-level (`import logging`, `import re`, `import httpx`, and `asap.*` imports — no function-body inline imports). The remaining live concern is the dead `resolve_headers`/`session=None` branch.
+
+**S0 Remediation (Task 5.0):** Either wire `session` properly or delete `resolve_headers` and the dead branch. The "hoist inline import" and "fix raising constructor" sub-tasks are effectively already satisfied in the current tree; S0 confirms this and removes the dead path. *Status: in progress on `feat/v2.5.1-s0-p0-fixes`.*
+
+---
+
+### M-2 (additional): MCP Auth Bridge `allow_env_jwt_fallback` — process-wide token inheritance risk
+
+**Severity:** MEDIUM (security posture / defense-in-depth)
+**Location:** `src/asap/adapters/mcp/jwt_extractor.py:13-52`, `src/asap/adapters/mcp/config.py:47` (`allow_env_jwt_fallback: bool = False`)
+**Status:** New finding (not in the S0 bug list). No remediation required for v2.5.0; documented for awareness.
+
+The MCP Auth Bridge JWT extractor can fall back to reading the Agent JWT from the `ASAP_AGENT_JWT` environment variable when `allow_env_jwt_fallback=True`:
+
+```45:51:src/asap/adapters/mcp/jwt_extractor.py
+    if not allow_env_fallback:
+        return None
+
+    env_token = os.environ.get(_ENV_JWT_KEY)
+    if isinstance(env_token, str) and env_token.strip():
+        return env_token.strip()
+
+    return None
+```
+
+**Assessment:** The default is `False` and the docstring (`:18-27`) explicitly states this is "single-agent local testing only" and that the default "ensures production cannot inherit a process-wide token." This is a reasonable dev affordance. The residual risk is operator misconfiguration: if `allow_env_jwt_fallback=True` is set in a multi-tenant deployment, every `tools/call` from any caller would authenticate as the same agent identity (the one whose JWT is in the env). This is not a defect — it is a documented foot-gun. **Recommendation:** Consider a startup log warning when `allow_env_jwt_fallback=True` is set (mirroring the `hide_unauthorized_tools_noop` warning pattern in `protected_server.py:36-37`), and a hard error if it is enabled together with `enforce_grants=True` and more than one registered tool. No S0 action required.
+
+---
+
+### M-3 (additional): `ProtectedMCPServer` — `hide_unauthorized_tools` is a silent no-op
+
+**Severity:** MEDIUM (operator expectations / fail-open appearance)
+**Location:** `src/asap/adapters/mcp/protected_server.py:36-37`, `:28-29` (docstring)
+**Status:** New finding (not in the S0 bug list). Documented as deferred (MCP-MAP-004); no remediation required for v2.5.0.
+
+When `config.hide_unauthorized_tools=True`, the constructor only logs a warning and does nothing — `tools/list` still returns the full tool set:
+
+```36:37:src/asap/adapters/mcp/protected_server.py
+        if config.hide_unauthorized_tools:
+            logger.warning("mcp.auth.hide_unauthorized_tools_noop")
+```
+
+The class docstring (`:28-29`) and `MCPAuthConfig` docstring (`config.py:27-28`) both state MCP-MAP-004 is "deferred per design-lock §6 — no stdio JWT carriage on `tools/list`." This is a deliberate, documented scope deferral, not a bug. The risk is purely one of operator expectation: an operator setting `hide_unauthorized_tools=True` may believe unauthorized tools are hidden from discovery when in fact they are only gated at `tools/call`. **Recommendation:** The warning is the right mechanism; consider making the log message explicitly state "tools/list still returns all tools; only tools/call is gated" so operators do not infer a fail-closed discovery behavior. No S0 action required.
+
+---
+
+## 🔵 LOW / NITPICK
+
+### L-1: `wellknown.get_manifest_json` switched to `by_alias=True` — correct but changes ETag input
+
+**Severity:** LOW
+**Location:** `src/asap/discovery/wellknown.py:43` (diff: `manifest.model_dump()` → `manifest.model_dump(mode="json", by_alias=True)`)
+
+The change is **correct and an improvement**: `by_alias=True` ensures fields like `HardwareCapability.class_` (declared with `alias="class"`, `entities.py:101`) serialize as `"class"` rather than `"class_"`, matching the public manifest schema. `mode="json"` makes the output JSON-native (datetime → ISO string). The only thing to note is that this changes the byte output of `get_manifest_json`, which feeds `compute_manifest_etag` — any cached ETags computed against the old serialization will mismatch after this release. This is the expected behavior of a manifest format fix and does not require action; flagged only so release notes can mention that manifest ETags will recompute on upgrade.
+
+---
+
+### L-2: `ProtectedMCPServer.from_server` shallow-copies the tool dict
+
+**Severity:** LOW (nitpick)
+**Location:** `src/asap/adapters/mcp/protected_server.py:42-50`
+
+`from_server` does `protected._tools = dict(server._tools)`. This is a **shallow** copy: the outer dict is new, but each value tuple `(func, input_schema, description, title, capability)` is shared by reference with the original server. Because tuples are immutable and the contained `func`/`schema`/`capability` objects are treated as read-only after registration, this is safe in practice and avoids an unnecessary deep copy. No action required; noted only because a future change that mutates a tool's `input_schema` in place on one server would also affect the other. If that ever becomes a concern, switch to copying the per-tool tuples.
+
+---
+
+## Scope & Methodology Notes
+
+### Diff range determination
+
+The exact requested tags all exist: `v2.3.0`, `v2.4.0`, `v2.5.0`, plus `v2.5.0.1` (a follow-up `asap-compliance` tag). `v2.3.0` is a confirmed ancestor of `HEAD` (`git merge-base --is-ancestor v2.3.0 HEAD` → true). The review therefore uses the exact range `v2.3.0..HEAD` (275 commits) as specified. The v2.5.0 release commit is `1c5027c` (2026-06-24); `HEAD` (`4c367e0`, 2026-06-24) is 5 commits ahead of `v2.5.0` on the same lineage and includes the `v2.5.0.1` compliance bump. No tag substitution was necessary.
+
+### Areas surveyed (real code read, not inferred)
+
+- **Edge AI Discovery (v2.4.0):** `src/asap/models/entities.py` (`HardwareCapability`, `InferenceCapability`, `LocalModelInfo` — all additive, all fields optional); `src/asap/models/enums.py` (`HardwareClass`, `HardwareIoType`, `InferenceMode`); `src/asap/discovery/registry.py` (`hardware_class`/`inference_modes`/`hardware_io` fields on `RegistryEntry`, `find_by_hardware_class`/`find_by_inference_mode`/`find_by_io`, `derive_registry_hardware_fields`); `src/asap/discovery/wellknown.py` (alias-correct serialization — L-1).
+- **MCP Auth Bridge (v2.5.0):** `src/asap/adapters/mcp/` (`protected_server.py`, `config.py`, `capability_map.py`, `auth_middleware.py`, `jwt_extractor.py`, `errors.py`, `__init__.py`); `src/asap/mcp/{server,client,protocol}.py` (tool `capability` metadata, `subprocess_env`, `_meta` carriage); `src/asap/auth/{claims,jwks,agent_jwt,middleware}.py` (iss/aud centralization).
+- **Transport / auth (cross-cutting):** `src/asap/transport/{server,client,websocket,capability_routes,agent_routes,_auth_helpers}.py`; `src/asap/economics/{delegation_storage,storage}.py`; `src/asap/state/stores/sqlite.py`; `src/asap/adapters/openapi/handler.py`.
+
+### What this review is NOT
+
+This is a **retrospective** review of already-shipped releases, produced to close the process gap noted in S0 Task 7.2 ("No code review exists past `engineering/code-review/v2.3.0/`"). It does not gate any past release and does not propose new code changes beyond what Sprint S0 already tracks. The Critical/High findings (B1–B6) are recorded with their S0 remediation status; the two additional Medium findings (M-2, M-3) are awareness items that do not require S0 action.
+
+### Placement decision (public vs private)
+
+This document is placed in the public `engineering/code-review/v2.5.1/` directory. The findings describe **classes of defects and their locations** but do **not** contain exploit-ready proof-of-concept code, weaponized request payloads, or step-by-step reproduction instructions for end-users. The security-relevant findings (B3/B4/B1) are already publicly tracked in the Sprint S0 task file (`engineering/tasks/private/v2.5.1/sprint-S0-p0-correctness-security.md`) and the AGENTS.md architecture notes; recording their existence in a review doc does not elevate exposure beyond what the sprint file already states. If a future revision adds exploit-ready detail (e.g., a working unauthenticated WS `task.request` payload), it should be moved to `engineering/code-review/private/v2.5.1/`.
+
+---
+
+## Resolution Status — S0 Bugs (B1–B6)
+
+| Bug | Title | Severity | Location | S0 Status |
+|-----|-------|----------|----------|-----------|
+| **B1** (+BUG #3) | Non-atomic `revoke_cascade` + missing InMemory lock | 🔴 Critical | `economics/delegation_storage.py:128-150, 156-158, 277-292` | Remediated in S0 (Task 1.0) — in progress |
+| **B2** | Divergent `usage_events` DDL (missing consumer index) | 🟠 High | `state/stores/sqlite.py:397-416` vs `economics/storage.py:486-511` | Remediated in S0 (Task 2.0) — in progress |
+| **B3** (BUG #1) | Divergent Host-JWT verifiers — revoked-host bypass | 🔴 Critical | `transport/capability_routes.py:60-83` vs `agent_routes.py:239-282` | Remediated in S0 (Task 3.0) — in progress |
+| **B4** (BUG #4) | WebSocket bypasses `OAuth2Middleware` | 🔴 Critical | `transport/websocket.py:761-786, 1017, 1024`; `server.py:2141-2152`; `auth/middleware.py:135` | Remediated in S0 (Task 4.0) — in progress |
+| **B5** | OpenAPI handler dead `resolve_headers` path (inline-import / raising-ctor sub-items already satisfied) | 🟡 Medium | `adapters/openapi/handler.py:366-401, 493-517` (byte-identical to v2.3.0 — pre-existing carry-over) | Remediated in S0 (Task 5.0) — in progress |
+| **B6** (BUG #6) | Client-side `correlation_id` not bound to request id | 🟠 High | `models/envelope.py:138-147`; `transport/client.py:1032`; `transport/websocket.py:413` | Remediated in S0 (Task 6.0) — in progress |
+
+> All six bugs are confirmed present in the shipped `v2.3.0..HEAD` range by direct code inspection above, and all six are tracked for remediation in Sprint S0 with a failing-test-first policy. The "in progress" status reflects that the fixes are being implemented on branch `feat/v2.5.1-s0-p0-fixes` at the time of this review; commits are held by the user and have not been pushed.
+
+---
+
+## Verdict
+
+> **REQUEST CHANGES (retrospective)** — 3 Critical (B1/B3/B4), 2 High (B2/B6), 3 Medium (B5/M-2/M-3), 2 Low.
+
+The v2.4.0 and v2.5.0 releases shipped three security-relevant P0 defects (revoked-host bypass, WebSocket OAuth2 bypass, non-atomic revocation cascade) plus three correctness/maintainability defects. All are identified and under remediation in Sprint S0. The MCP Auth Bridge (v2.5.0) is architecturally sound — clean opt-in adapter, canonical verifier reuse, centralized iss/aud claim validation — and the Edge AI Discovery (v2.4.0) manifest extension is a safe, additive, backward-compatible change. The two additional Medium findings (M-2 env-JWT fallback posture, M-3 `hide_unauthorized_tools` no-op) are documented foot-guns/deferrals, not defects, and require no S0 action.

--- a/src/asap/adapters/openapi/handler.py
+++ b/src/asap/adapters/openapi/handler.py
@@ -23,6 +23,10 @@ from asap.models.enums import TaskStatus
 from asap.models.envelope import Envelope
 from asap.models.ids import generate_id
 from asap.models.payloads import TaskRequest, TaskResponse
+
+# No circular dependency: asap.transport.challenge imports only asap.discovery and
+# asap.models, never asap.adapters.openapi — safe to import at module top.
+from asap.transport.challenge import format_www_authenticate_asap
 from asap.transport.handlers import AsyncHandler
 
 logger = logging.getLogger(__name__)
@@ -68,7 +72,12 @@ class OpenAPIInvocationError(FatalError):
 
 
 class OpenAPIPathParameterError(FatalError):
-    """Path template could not be fully substituted from *args*."""
+    """Path template could not be fully substituted from *args*.
+
+    Construction is pure (side-effect-free); use :meth:`for_missing` or
+    :meth:`for_invalid` to enforce the "exactly one of missing/invalid" invariant
+    at the raise-site rather than from ``__init__``.
+    """
 
     def __init__(
         self,
@@ -79,21 +88,22 @@ class OpenAPIPathParameterError(FatalError):
     ) -> None:
         miss = list(missing) if missing else []
         inv = list(invalid) if invalid else []
-        if bool(miss) == bool(inv):
-            raise ValueError(
-                "OpenAPIPathParameterError requires exactly one of missing= or invalid=."
-            )
         if miss:
             message = (
                 f"Missing path parameter(s) for template {path_template!r}: {', '.join(miss)}."
             )
             details: dict[str, Any] = {"path_template": path_template, "missing": miss}
-        else:
+        elif inv:
             message = (
                 f"Invalid path parameter value(s) for template {path_template!r}: "
                 f"{', '.join(inv)} (must not be None, empty, or whitespace-only)."
             )
             details = {"path_template": path_template, "invalid": inv}
+        else:
+            # No validation here: pure construction. Ambiguous invocations get a
+            # neutral message; the invariant is enforced by the from_* factories.
+            message = f"Path parameter error for template {path_template!r}."
+            details = {"path_template": path_template}
         super().__init__(
             _PATH_PARAMS,
             message,
@@ -103,6 +113,20 @@ class OpenAPIPathParameterError(FatalError):
         self.path_template = path_template
         self.missing = miss
         self.invalid = inv
+
+    @classmethod
+    def for_missing(cls, path_template: str, missing: list[str]) -> OpenAPIPathParameterError:
+        """Build an error for unsubstituted path placeholders (requires non-empty *missing*)."""
+        if not missing:
+            raise ValueError("for_missing requires a non-empty missing= list.")
+        return cls(path_template=path_template, missing=missing)
+
+    @classmethod
+    def for_invalid(cls, path_template: str, invalid: list[str]) -> OpenAPIPathParameterError:
+        """Build an error for empty/None/whitespace path values (requires non-empty *invalid*)."""
+        if not invalid:
+            raise ValueError("for_invalid requires a non-empty invalid= list.")
+        return cls(path_template=path_template, invalid=invalid)
 
 
 def index_capabilities(caps: Iterable[OpenAPICapability]) -> dict[str, OpenAPICapability]:
@@ -283,7 +307,7 @@ def _fill_path_template(path_template: str, path_params: Mapping[str, Any]) -> s
     names_order = list(dict.fromkeys(raw_names))
     missing = [n for n in names_order if n not in path_params]
     if missing:
-        raise OpenAPIPathParameterError(path_template=path_template, missing=missing)
+        raise OpenAPIPathParameterError.for_missing(path_template, missing)
     invalid_names = [
         n
         for n in names_order
@@ -291,7 +315,7 @@ def _fill_path_template(path_template: str, path_params: Mapping[str, Any]) -> s
         or (isinstance(path_params[n], str) and cast(str, path_params[n]).strip() == "")
     ]
     if invalid_names:
-        raise OpenAPIPathParameterError(path_template=path_template, invalid=invalid_names)
+        raise OpenAPIPathParameterError.for_invalid(path_template, invalid_names)
     out = path_template
     for name in names_order:
         raw = path_params[name]
@@ -437,8 +461,6 @@ class OpenAPIUpstreamHandler:
                 "body_snippet": snippet,
             }
             if status == 401 and self._asap_challenge_discovery_url:
-                from asap.transport.challenge import format_www_authenticate_asap
-
                 details["_www_authenticate_asap"] = format_www_authenticate_asap(
                     self._asap_challenge_discovery_url,
                 )

--- a/src/asap/auth/middleware.py
+++ b/src/asap/auth/middleware.py
@@ -258,6 +258,113 @@ class OAuth2Middleware(BaseHTTPMiddleware):
                 require_exp=False,
             )
 
+    async def validate_bearer_token(
+        self, token: str, *, path: str = ""
+    ) -> tuple[OAuth2Claims | None, JSONResponse | None]:
+        """Run the full JWKS validation pipeline for a single Bearer token.
+
+        Shared by the HTTP middleware ``dispatch`` and the WebSocket acceptance
+        path so both transports enforce identical OAuth2 semantics (B4/BUG #4).
+        Returns ``(claims, None)`` on success or ``(None, error_response)`` on
+        failure. ``path`` is used only for log context.
+        """
+        try:
+            key_set = await self._get_key_set()
+            claims = await self._validate_token_claims(token, key_set)
+        except httpx.HTTPError as e:
+            logger.error(
+                "asap.oauth2.jwks_fetch_failed",
+                path=path,
+                jwks_uri=self._jwks_uri,
+                error=str(e),
+            )
+            return None, JSONResponse(
+                status_code=503,
+                content={"detail": "Authentication service unavailable"},
+            )
+        except JoseError as e:
+            logger.warning("asap.oauth2.invalid_token", path=path, error=str(e))
+            return None, JSONResponse(
+                status_code=HTTP_UNAUTHORIZED,
+                content={"detail": ERROR_INVALID_TOKEN},
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        exp = claims.get("exp")
+        exp_ts = 0
+        if exp is not None:
+            if not isinstance(exp, (int, float)):
+                logger.warning("asap.oauth2.invalid_exp_type", path=path)
+                return None, JSONResponse(
+                    status_code=HTTP_UNAUTHORIZED,
+                    content={"detail": ERROR_INVALID_TOKEN},
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            try:
+                exp_ts = int(exp)
+            except (TypeError, ValueError):
+                logger.warning("asap.oauth2.invalid_exp_type", path=path)
+                return None, JSONResponse(
+                    status_code=HTTP_UNAUTHORIZED,
+                    content={"detail": ERROR_INVALID_TOKEN},
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+        if exp is not None and exp_ts < time.time():
+            logger.warning("asap.oauth2.expired_token", path=path)
+            return None, JSONResponse(
+                status_code=HTTP_UNAUTHORIZED,
+                content={"detail": ERROR_INVALID_TOKEN},
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        sub = claims.get("sub")
+        if not sub or not isinstance(sub, str):
+            logger.warning("asap.oauth2.missing_sub", path=path)
+            return None, JSONResponse(
+                status_code=HTTP_UNAUTHORIZED,
+                content={"detail": ERROR_INVALID_TOKEN},
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        scope_list = parse_scope(claims.get("scope"))
+        if not self._validate_scope(scope_list):
+            logger.warning(
+                "asap.oauth2.insufficient_scope",
+                path=path,
+                required=self._required_scope,
+                has_scopes=scope_list,
+            )
+            return None, JSONResponse(
+                status_code=HTTP_FORBIDDEN,
+                content={"detail": ERROR_INSUFFICIENT_SCOPE},
+            )
+
+        success, err_detail, _, use_allowlist = self._validate_identity_binding(claims, sub)
+        if not success:
+            logger.warning(
+                "asap.oauth2.identity_mismatch",
+                path=path,
+                detail=err_detail,
+            )
+            detail_msg = (
+                f"{ERROR_IDENTITY_MISMATCH} (expected: {self._manifest_id})"
+                if self._manifest_id
+                else ERROR_IDENTITY_MISMATCH
+            )
+            return None, JSONResponse(
+                status_code=HTTP_FORBIDDEN,
+                content={"detail": detail_msg},
+            )
+        if use_allowlist:
+            logger.warning(
+                "asap.oauth2.identity_via_allowlist",
+                path=path,
+                manifest_id=self._manifest_id,
+                sub=sub,
+            )
+
+        return OAuth2Claims(sub=sub, scope=scope_list, exp=exp_ts), None
+
     async def dispatch(
         self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
@@ -274,100 +381,10 @@ class OAuth2Middleware(BaseHTTPMiddleware):
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        try:
-            key_set = await self._get_key_set()
-            claims = await self._validate_token_claims(token, key_set)
-        except httpx.HTTPError as e:
-            logger.error(
-                "asap.oauth2.jwks_fetch_failed",
-                path=request.url.path,
-                jwks_uri=self._jwks_uri,
-                error=str(e),
-            )
-            return JSONResponse(
-                status_code=503,
-                content={"detail": "Authentication service unavailable"},
-            )
-        except JoseError as e:
-            logger.warning("asap.oauth2.invalid_token", path=request.url.path, error=str(e))
-            return JSONResponse(
-                status_code=HTTP_UNAUTHORIZED,
-                content={"detail": ERROR_INVALID_TOKEN},
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-
-        exp = claims.get("exp")
-        exp_ts = 0
-        if exp is not None:
-            if not isinstance(exp, (int, float)):
-                logger.warning("asap.oauth2.invalid_exp_type", path=request.url.path)
-                return JSONResponse(
-                    status_code=HTTP_UNAUTHORIZED,
-                    content={"detail": ERROR_INVALID_TOKEN},
-                    headers={"WWW-Authenticate": "Bearer"},
-                )
-            try:
-                exp_ts = int(exp)
-            except (TypeError, ValueError):
-                logger.warning("asap.oauth2.invalid_exp_type", path=request.url.path)
-                return JSONResponse(
-                    status_code=HTTP_UNAUTHORIZED,
-                    content={"detail": ERROR_INVALID_TOKEN},
-                    headers={"WWW-Authenticate": "Bearer"},
-                )
-        if exp is not None and exp_ts < time.time():
-            logger.warning("asap.oauth2.expired_token", path=request.url.path)
-            return JSONResponse(
-                status_code=HTTP_UNAUTHORIZED,
-                content={"detail": ERROR_INVALID_TOKEN},
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-
-        sub = claims.get("sub")
-        if not sub or not isinstance(sub, str):
-            logger.warning("asap.oauth2.missing_sub", path=request.url.path)
-            return JSONResponse(
-                status_code=HTTP_UNAUTHORIZED,
-                content={"detail": ERROR_INVALID_TOKEN},
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-
-        scope_list = parse_scope(claims.get("scope"))
-        if not self._validate_scope(scope_list):
-            logger.warning(
-                "asap.oauth2.insufficient_scope",
-                path=request.url.path,
-                required=self._required_scope,
-                has_scopes=scope_list,
-            )
-            return JSONResponse(
-                status_code=HTTP_FORBIDDEN,
-                content={"detail": ERROR_INSUFFICIENT_SCOPE},
-            )
-
-        success, err_detail, _, use_allowlist = self._validate_identity_binding(claims, sub)
-        if not success:
-            logger.warning(
-                "asap.oauth2.identity_mismatch",
-                path=request.url.path,
-                detail=err_detail,
-            )
-            detail_msg = (
-                f"{ERROR_IDENTITY_MISMATCH} (expected: {self._manifest_id})"
-                if self._manifest_id
-                else ERROR_IDENTITY_MISMATCH
-            )
-            return JSONResponse(
-                status_code=HTTP_FORBIDDEN,
-                content={"detail": detail_msg},
-            )
-        if use_allowlist:
-            logger.warning(
-                "asap.oauth2.identity_via_allowlist",
-                path=request.url.path,
-                manifest_id=self._manifest_id,
-                sub=sub,
-            )
-
-        request.state.oauth2_claims = OAuth2Claims(sub=sub, scope=scope_list, exp=exp_ts)
+        claims, error = await self.validate_bearer_token(token, path=request.url.path)
+        if error is not None:
+            return error
+        # validate_bearer_token returns None claims only with an error response;
+        # the guard above ensures claims is set on the success path.
+        request.state.oauth2_claims = claims
         return await call_next(request)

--- a/src/asap/economics/delegation_storage.py
+++ b/src/asap/economics/delegation_storage.py
@@ -9,6 +9,7 @@ Table: revocations (id, revoked_at, reason). Persists across restarts.
 
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -132,8 +133,22 @@ class DelegationStorageBase(ABC):
     ) -> None:
         """Revoke a token and all child delegations (iterative BFS).
 
+        Delegates the tree-walk + revocation to :meth:`_revoke_cascade_atomic`
+        so each backend controls its own transaction/lock boundary. Public
+        signature is stable.
+        """
+        await self._revoke_cascade_atomic(token_id, reason)
+
+    async def _revoke_cascade_atomic(
+        self,
+        token_id: str,
+        reason: str | None = None,
+    ) -> None:
+        """Default BFS cascade using public per-id methods.
+
         Uses a visited set to handle circular delegation chains and a
-        depth limit (_MAX_CASCADE_DEPTH) to prevent DoS.
+        depth limit (_MAX_CASCADE_DEPTH) to prevent DoS. Subclasses override
+        this to wrap the walk in a single transaction/lock for atomicity.
         """
         visited: set[str] = set()
         stack: list[tuple[str, int]] = [(token_id, 0)]
@@ -151,9 +166,15 @@ class DelegationStorageBase(ABC):
 
 
 class InMemoryDelegationStorage(DelegationStorageBase):
-    """In-memory revocation store for tests. Not persistent across restarts."""
+    """In-memory revocation store for tests. Not persistent across restarts.
+
+    Async-safe via ``asyncio.Lock`` (parity with ``InMemorySLAStorage`` /
+    ``InMemoryMeteringStorage``). The lock is held across the whole cascade so
+    concurrent ``register_issued`` cannot interleave and lose/split children.
+    """
 
     def __init__(self) -> None:
+        self._lock = asyncio.Lock()
         self._revoked: dict[str, tuple[datetime, str | None]] = {}
         self._issued: dict[str, tuple[str, str | None, datetime]] = {}
 
@@ -162,9 +183,12 @@ class InMemoryDelegationStorage(DelegationStorageBase):
         token_id: str,
         reason: str | None = None,
     ) -> None:
-        self._revoked[token_id] = (datetime.now(timezone.utc), reason)
+        async with self._lock:
+            self._revoked[token_id] = (datetime.now(timezone.utc), reason)
 
     async def is_revoked(self, token_id: str) -> bool:
+        # Read-only snapshot; a concurrent writer cannot corrupt a dict lookup
+        # under the GIL, so no lock is required here.
         return token_id in self._revoked
 
     async def register_issued(
@@ -174,7 +198,8 @@ class InMemoryDelegationStorage(DelegationStorageBase):
         delegate_urn: str | None = None,
     ) -> None:
         now = datetime.now(timezone.utc)
-        self._issued[token_id] = (delegator_urn, delegate_urn, now)
+        async with self._lock:
+            self._issued[token_id] = (delegator_urn, delegate_urn, now)
 
     async def get_delegator(self, token_id: str) -> str | None:
         entry = self._issued.get(token_id)
@@ -218,6 +243,32 @@ class InMemoryDelegationStorage(DelegationStorageBase):
             is_revoked=rev is not None,
             revoked_at=rev[0] if rev else None,
         )
+
+    async def _revoke_cascade_atomic(
+        self,
+        token_id: str,
+        reason: str | None = None,
+    ) -> None:
+        """Hold the lock across the whole BFS walk so concurrent mutations
+        (``register_issued`` / ``revoke``) cannot interleave and split the
+        cascade. The tree-walk reuses the base BFS logic on a consistent
+        in-memory snapshot.
+        """
+        async with self._lock:
+            visited: set[str] = set()
+            stack: list[tuple[str, int]] = [(token_id, 0)]
+            while stack:
+                tid, depth = stack.pop()
+                if tid in visited or depth > _MAX_CASCADE_DEPTH:
+                    continue
+                visited.add(tid)
+                entry = self._issued.get(tid)
+                delegate_urn = entry[1] if entry and entry[1] is not None else None
+                if delegate_urn:
+                    for child_id, (d, _, _) in self._issued.items():
+                        if d == delegate_urn:
+                            stack.append((child_id, depth + 1))
+                self._revoked[tid] = (datetime.now(timezone.utc), reason)
 
 
 class SQLiteDelegationStorage(DelegationStorageBase):
@@ -290,6 +341,73 @@ class SQLiteDelegationStorage(DelegationStorageBase):
                 (token_id, now, reason),
             )
             await conn.commit()
+
+    async def _revoke_on_conn(
+        self,
+        conn: aiosqlite.Connection,
+        token_id: str,
+        reason: str | None,
+    ) -> None:
+        """Insert a revocation row on a shared connection (no commit).
+
+        Used by :meth:`_revoke_cascade_atomic` so every per-id revoke in a
+        cascade shares one transaction boundary; the caller controls COMMIT /
+        ROLLBACK.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        await conn.execute(
+            """
+            INSERT OR REPLACE INTO revocations (id, revoked_at, reason)
+            VALUES (?, ?, ?)
+            """,
+            (token_id, now, reason),
+        )
+
+    async def _revoke_cascade_atomic(
+        self,
+        token_id: str,
+        reason: str | None = None,
+    ) -> None:
+        """Single-connection, single-transaction cascade.
+
+        Opens ONE ``aiosqlite.connect``, walks the delegation tree with
+        conn-scoped reads, and inserts every revocation on that connection.
+        COMMIT happens only after the full walk succeeds; any exception
+        propagates and the ``async with`` block closes the connection without
+        committing, so SQLite discards the uncommitted rows (atomic rollback).
+        """
+        async with aiosqlite.connect(self._db_path) as conn:
+            await self._ensure_tables(conn)
+            await conn.execute("BEGIN")
+            try:
+                visited: set[str] = set()
+                stack: list[tuple[str, int]] = [(token_id, 0)]
+                while stack:
+                    tid, depth = stack.pop()
+                    if tid in visited or depth > _MAX_CASCADE_DEPTH:
+                        continue
+                    visited.add(tid)
+                    cursor = await conn.execute(
+                        "SELECT delegate_urn FROM issued_delegations WHERE id = ?",
+                        (tid,),
+                    )
+                    row = await cursor.fetchone()
+                    delegate_urn = str(row[0]) if row and row[0] else None
+                    if delegate_urn:
+                        cursor = await conn.execute(
+                            "SELECT id FROM issued_delegations WHERE delegator_urn = ?",
+                            (delegate_urn,),
+                        )
+                        child_rows = await cursor.fetchall()
+                        for child_row in child_rows:
+                            stack.append((str(child_row[0]), depth + 1))
+                    await self._revoke_on_conn(conn, tid, reason)
+                await conn.commit()
+            except BaseException:
+                # Roll back any pending writes so a mid-cascade crash leaves
+                # no partial revocation state. Re-raise to surface the error.
+                await conn.rollback()
+                raise
 
     async def is_revoked(self, token_id: str) -> bool:
         async with aiosqlite.connect(self._db_path) as conn:

--- a/src/asap/economics/storage.py
+++ b/src/asap/economics/storage.py
@@ -37,6 +37,11 @@ from asap.economics.metering import (
 from asap.models.base import ASAPBaseModel
 from asap.models.ids import generate_id
 
+# State is the lower layer (never imports economics), so importing the shared
+# usage_events DDL helper here cannot form a cycle. Keeping one canonical DDL
+# owner prevents divergent indexes when both stores share asap_state.db.
+from asap.state.stores.sqlite import _ensure_usage_events_schema
+
 UsageAggregate = Union[
     UsageAggregateByAgent,
     UsageAggregateByConsumer,
@@ -484,31 +489,7 @@ class SQLiteMeteringStorage(MeteringStorageBase):
             yield conn
 
     async def _ensure_table(self, conn: aiosqlite.Connection) -> None:
-        await conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS usage_events (
-                id TEXT PRIMARY KEY,
-                task_id TEXT NOT NULL,
-                agent_id TEXT NOT NULL,
-                consumer_id TEXT NOT NULL,
-                metrics TEXT NOT NULL,
-                timestamp TEXT NOT NULL
-            )
-            """
-        )
-        await conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_usage_agent_timestamp
-            ON usage_events (agent_id, timestamp)
-            """
-        )
-        await conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_usage_consumer_timestamp
-            ON usage_events (consumer_id, timestamp)
-            """
-        )
-        await conn.commit()
+        await _ensure_usage_events_schema(conn)
 
     async def _ensure_table_once(self, conn: aiosqlite.Connection) -> None:
         if self._initialized:

--- a/src/asap/state/stores/sqlite.py
+++ b/src/asap/state/stores/sqlite.py
@@ -67,6 +67,39 @@ async def _apply_wal_pragmas(conn: aiosqlite.Connection, db_key: str) -> None:
     await conn.execute("PRAGMA synchronous=NORMAL")
 
 
+# Canonical usage_events DDL: the single source of truth for the table + BOTH
+# indexes (agent and consumer). Lives in the state stores module because state is
+# the lower layer (no dependency on economics), so economics.storage can import it
+# without forming an import cycle. Both SQLiteMeteringStore (state) and
+# SQLiteMeteringStorage (economics) call _ensure_usage_events_schema so the
+# physical schema is identical regardless of which store initializes first.
+_USAGE_EVENTS_DDL = """
+CREATE TABLE IF NOT EXISTS usage_events (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    consumer_id TEXT NOT NULL,
+    metrics TEXT NOT NULL,
+    timestamp TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_usage_agent_timestamp
+ON usage_events (agent_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_usage_consumer_timestamp
+ON usage_events (consumer_id, timestamp);
+"""
+
+
+async def _ensure_usage_events_schema(conn: aiosqlite.Connection) -> None:
+    """Apply the canonical usage_events schema (table + both indexes), idempotently.
+
+    Uses IF NOT EXISTS on every statement so re-running on an already-initialized
+    DB is a no-op AND a pre-existing table missing an index (created by an older
+    code path) gets the missing index added.
+    """
+    await conn.executescript(_USAGE_EVENTS_DDL)
+    await conn.commit()
+
+
 # Shared executor for sync bridge when called from async context.
 # Reused across all DB operations to avoid per-call ThreadPoolExecutor creation.
 _SYNC_BRIDGE_EXECUTOR: concurrent.futures.ThreadPoolExecutor | None = None
@@ -395,25 +428,7 @@ class SQLiteMeteringStore:
             yield conn
 
     async def _ensure_usage_table(self, conn: aiosqlite.Connection) -> None:
-        await conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS usage_events (
-                id TEXT PRIMARY KEY,
-                task_id TEXT NOT NULL,
-                agent_id TEXT NOT NULL,
-                consumer_id TEXT NOT NULL,
-                metrics TEXT NOT NULL,
-                timestamp TEXT NOT NULL
-            )
-            """
-        )
-        await conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_usage_agent_timestamp
-            ON usage_events (agent_id, timestamp)
-            """
-        )
-        await conn.commit()
+        await _ensure_usage_events_schema(conn)
 
     async def _record_impl(self, event: UsageEvent) -> None:
         async with self._connect() as conn:

--- a/src/asap/transport/_auth_helpers.py
+++ b/src/asap/transport/_auth_helpers.py
@@ -2,7 +2,23 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from asap.auth.agent_jwt import (
+    JtiReplayCache,
+    JwtVerifyResult,
+    verify_host_jwt,
+)
+from asap.auth.identity import HostStore
+
+# ``identity_host_store`` and ``identity_jwt_audience`` are attached to
+# ``app.state`` by :func:`asap.transport.server.create_app`; read at call time
+# so the helper stays decoupled from the server factory.
+_HOST_STORE_ATTR = "identity_host_store"
+_JWT_AUDIENCE_ATTR = "identity_jwt_audience"
 
 
 def bearer_token_from_request(request: Request) -> str | None:
@@ -11,3 +27,76 @@ def bearer_token_from_request(request: Request) -> str | None:
     if not auth or not auth.startswith("Bearer "):
         return None
     return auth[7:].strip() or None
+
+
+async def verify_host_bearer(
+    request: Request,
+    *,
+    jti_replay_cache: JtiReplayCache | None,
+    require_active_host: bool = True,
+) -> tuple[JwtVerifyResult | None, JSONResponse | None]:
+    """Verify a Host JWT Bearer token and enforce host liveness.
+
+    Single canonical Host-JWT verifier for the transport package. Mirrors the
+    strict behaviour previously inlined in ``agent_routes``: 401 when no token
+    or signature/claim verification fails, 400 on a missing ``iss`` claim, and
+    403 when the resolved host is ``revoked`` (gated by ``require_active_host``
+    so non-identity routes can opt out if needed).
+
+    Returns ``(result, None)`` on success or ``(None, JSONResponse)`` on
+    failure. Callers should propagate the error response unchanged.
+
+    Example:
+        >>> result, err = await verify_host_bearer(
+        ...     request, jti_replay_cache=cache
+        ... )
+        >>> if err is not None:
+        ...     return err
+    """
+    token = bearer_token_from_request(request)
+    if not token:
+        return None, JSONResponse(
+            status_code=401,
+            content={"detail": "Authentication required"},
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    host_store: HostStore = getattr(request.app.state, _HOST_STORE_ATTR)
+    expected_audience: str | list[str] = getattr(request.app.state, _JWT_AUDIENCE_ATTR)
+    result = await verify_host_jwt(
+        token,
+        host_store,
+        expected_audience=expected_audience,
+        jti_replay_cache=jti_replay_cache,
+    )
+    if not result.ok:
+        # ``verify_host_jwt`` short-circuits revoked hosts to ``ok=False`` with
+        # ``error="host revoked"`` before we can inspect ``result.host``; surface
+        # that as 403 (not 401) so a revoked HOST is rejected with the same
+        # status the strict verifier returned for the agent-identity routes.
+        if require_active_host and result.error == "host revoked":
+            return None, JSONResponse(status_code=403, content={"detail": "host revoked"})
+        return None, JSONResponse(
+            status_code=401,
+            content={"detail": result.error or "Invalid host token"},
+        )
+
+    claims: dict[str, Any] | None = result.claims
+    if claims is None:
+        return None, JSONResponse(status_code=401, content={"detail": "Invalid host token"})
+
+    iss = claims.get("iss")
+    if not isinstance(iss, str) or not iss.strip():
+        return None, JSONResponse(
+            status_code=400,
+            content={"detail": "missing iss in host JWT"},
+        )
+
+    # Defensive re-check: a future ``verify_host_jwt`` change that returns a
+    # revoked host with ``ok=True`` must still be rejected here.
+    if require_active_host:
+        host = result.host
+        if host is not None and host.status == "revoked":
+            return None, JSONResponse(status_code=403, content={"detail": "host revoked"})
+
+    return result, None

--- a/src/asap/transport/agent_routes.py
+++ b/src/asap/transport/agent_routes.py
@@ -21,7 +21,6 @@ from asap.auth.agent_jwt import (
     HOST_PUBLIC_KEY_CLAIM,
     JtiReplayCache,
     JwtVerifyResult,
-    verify_host_jwt,
 )
 from asap.auth.approval import (
     A2HApprovalChannel,
@@ -52,7 +51,7 @@ from asap.auth.identity import (
 from asap.models.base import ASAPBaseModel
 from asap.models.ids import generate_id
 from asap.observability import get_logger
-from asap.transport._auth_helpers import bearer_token_from_request
+from asap.transport._auth_helpers import verify_host_bearer
 from asap.transport.capability_routes import _grant_to_dict
 
 logger = get_logger(__name__)
@@ -236,52 +235,6 @@ async def background_a2h_resolve(
         )
 
 
-async def _verify_host_bearer_identity(
-    request: Request,
-    *,
-    jti_replay_cache: JtiReplayCache | None,
-) -> tuple[JwtVerifyResult | None, JSONResponse | None]:
-    """Verify Host JWT; optional ``jti`` replay cache for mutating routes."""
-    token = bearer_token_from_request(request)
-    if not token:
-        return None, JSONResponse(
-            status_code=401,
-            content={"detail": "Authentication required"},
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    host_store: HostStore = request.app.state.identity_host_store
-    expected_audience: str | list[str] = request.app.state.identity_jwt_audience
-    result = await verify_host_jwt(
-        token,
-        host_store,
-        expected_audience=expected_audience,
-        jti_replay_cache=jti_replay_cache,
-    )
-    if not result.ok:
-        return None, JSONResponse(
-            status_code=401,
-            content={"detail": result.error or "Invalid host token"},
-        )
-
-    claims = result.claims
-    if claims is None:
-        return None, JSONResponse(status_code=401, content={"detail": "Invalid host token"})
-
-    iss = claims.get("iss")
-    if not isinstance(iss, str) or not iss.strip():
-        return None, JSONResponse(
-            status_code=400,
-            content={"detail": "missing iss in host JWT"},
-        )
-
-    host = result.host
-    if host is not None and host.status == "revoked":
-        return None, JSONResponse(status_code=403, content={"detail": "host revoked"})
-
-    return result, None
-
-
 def _effective_identity_host_id(result: JwtVerifyResult) -> str:
     """Host id from store or synthetic id for first-seen keys (matches register)."""
     claims = result.claims
@@ -327,7 +280,7 @@ async def _handle_agent_register(
 ) -> JSONResponse:
     """Create or return an agent session from a verified Host JWT."""
     jti_cache: JtiReplayCache = request.app.state.identity_jti_cache
-    result, err = await _verify_host_bearer_identity(request, jti_replay_cache=jti_cache)
+    result, err = await verify_host_bearer(request, jti_replay_cache=jti_cache)
     if err is not None:
         return err
     if result is None:
@@ -548,7 +501,7 @@ async def _handle_agent_register(
 
 async def _handle_agent_status(request: Request, agent_id: str) -> JSONResponse:
     """Return agent session status and lifecycle for the authenticated host."""
-    result, err = await _verify_host_bearer_identity(request, jti_replay_cache=None)
+    result, err = await verify_host_bearer(request, jti_replay_cache=None)
     if err is not None:
         return err
     if result is None:
@@ -663,7 +616,7 @@ async def _handle_agent_status(request: Request, agent_id: str) -> JSONResponse:
 async def _handle_agent_revoke(request: Request, body: AgentRevokeBody) -> JSONResponse:
     """Permanently revoke an agent session for the authenticated host."""
     jti_cache: JtiReplayCache = request.app.state.identity_jti_cache
-    result, err = await _verify_host_bearer_identity(request, jti_replay_cache=jti_cache)
+    result, err = await verify_host_bearer(request, jti_replay_cache=jti_cache)
     if err is not None:
         return err
     if result is None:
@@ -696,7 +649,7 @@ async def _handle_agent_revoke(request: Request, body: AgentRevokeBody) -> JSONR
 async def _handle_agent_rotate_key(request: Request, body: AgentRotateKeyBody) -> JSONResponse:
     """Replace the agent session's Ed25519 public JWK (old JWTs no longer verify)."""
     jti_cache: JtiReplayCache = request.app.state.identity_jti_cache
-    result, err = await _verify_host_bearer_identity(request, jti_replay_cache=jti_cache)
+    result, err = await verify_host_bearer(request, jti_replay_cache=jti_cache)
     if err is not None:
         return err
     if result is None:

--- a/src/asap/transport/capability_routes.py
+++ b/src/asap/transport/capability_routes.py
@@ -12,7 +12,6 @@ from asap.auth.agent_jwt import (
     JtiReplayCache,
     JwtVerifyResult,
     verify_agent_jwt,
-    verify_host_jwt,
 )
 from pydantic import ValidationError
 
@@ -21,7 +20,7 @@ from asap.auth.identity import AgentStore, HostStore
 from asap.auth.lifecycle import reactivate_agent
 from asap.models.base import ASAPBaseModel
 from asap.observability import get_logger
-from asap.transport._auth_helpers import bearer_token_from_request
+from asap.transport._auth_helpers import bearer_token_from_request, verify_host_bearer
 
 logger = get_logger(__name__)
 
@@ -55,32 +54,6 @@ class AgentReactivateBody(ASAPBaseModel):
 # ---------------------------------------------------------------------------
 # Auth helpers
 # ---------------------------------------------------------------------------
-
-
-async def _verify_host_bearer(
-    request: Request,
-    *,
-    jti_replay_cache: JtiReplayCache | None = None,
-) -> tuple[JwtVerifyResult | None, JSONResponse | None]:
-    """Verify a Host JWT Bearer token."""
-    token = bearer_token_from_request(request)
-    if not token:
-        return None, JSONResponse(
-            status_code=401,
-            content={"detail": "Authentication required"},
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    host_store: HostStore = request.app.state.identity_host_store
-    audience = request.app.state.identity_jwt_audience
-    result = await verify_host_jwt(
-        token,
-        host_store,
-        expected_audience=audience,
-        jti_replay_cache=jti_replay_cache,
-    )
-    if not result.ok:
-        return None, JSONResponse(status_code=401, content={"detail": result.error})
-    return result, None
 
 
 async def verify_agent_bearer(
@@ -276,7 +249,7 @@ async def _handle_capability_execute(request: Request) -> JSONResponse:
 async def _handle_agent_reactivate(request: Request) -> JSONResponse:
     """Reactivate an expired agent (Host JWT required)."""
     jti_cache: JtiReplayCache = request.app.state.identity_jti_cache
-    result, err = await _verify_host_bearer(request, jti_replay_cache=jti_cache)
+    result, err = await verify_host_bearer(request, jti_replay_cache=jti_cache)
     if err is not None:
         return err
     if result is None or result.claims is None:

--- a/src/asap/transport/client.py
+++ b/src/asap/transport/client.py
@@ -87,6 +87,7 @@ from asap.transport.mtls import MTLSConfig, create_ssl_context
 from asap.transport.circuit_breaker import CircuitBreaker, CircuitState, get_registry
 from asap.transport.codecs import lambda_codec
 from asap.transport.codecs.lambda_codec import LAMBDA_CONTENT_TYPE
+from asap.transport.errors import ProtocolCorrelationError, assert_correlation_binds
 from asap.transport.compression import (
     COMPRESSION_THRESHOLD,
     CompressionAlgorithm,
@@ -1031,6 +1032,11 @@ class ASAPClient:
 
                 response_envelope = Envelope(**envelope_data)
 
+                # BINDING check: a structurally valid response still must bind to the
+                # request we sent, otherwise a buggy/malicious server could return a
+                # response meant for a different request and mix pairs under concurrency.
+                assert_correlation_binds(str(envelope.id), response_envelope)
+
                 # Record success in circuit breaker
                 if self._circuit_breaker is not None:
                     previous_state = self._circuit_breaker.get_state()
@@ -1142,6 +1148,7 @@ class ASAPClient:
                 ASAPRemoteError,
                 RemoteRecoverableRPCError,
                 ASAPTimeoutError,
+                ProtocolCorrelationError,
             ):
                 # Re-raise our custom errors without recording failure again
                 # (failures are already recorded before these exceptions are raised)
@@ -1893,6 +1900,11 @@ class ASAPClient:
             )
 
         batch_body: list[dict[str, Any]] = []
+        # Map JSON-RPC id -> originating request envelope so each batch sub-response
+        # can be bound to its request by correlation_id (B6/BUG #6). A malicious/buggy
+        # peer could otherwise permute response bodies while keeping HTTP 200 and the
+        # client would pair the wrong task.response to each batch slot.
+        requests_by_id: dict[str, Envelope] = {}
         for env in envelopes:
             rpc_req = {
                 "jsonrpc": "2.0",
@@ -1901,6 +1913,7 @@ class ASAPClient:
                 "id": env.id,
             }
             batch_body.append(rpc_req)
+            requests_by_id[str(env.id)] = env
 
         url = f"{self.base_url}/asap"
         headers: dict[str, str] = {
@@ -1930,5 +1943,19 @@ class ASAPClient:
                 raise remote_rpc_error_from_json(wire_code, err_msg, err_data)
             result_data = item.get("result", {})
             env_data = result_data.get("envelope", result_data)
-            out.append(Envelope.model_validate(env_data))
+            response_envelope = Envelope.model_validate(env_data)
+            # BINDING check (B6/BUG #6): each batch sub-response must bind to its
+            # originating request by correlation_id. Resolve the request via the
+            # JSON-RPC id; if the peer permuted ids or returned a response for a
+            # request we did not send, reject it.
+            rpc_id = item.get("id")
+            request_envelope = requests_by_id.get(str(rpc_id)) if rpc_id is not None else None
+            if request_envelope is None:
+                raise ProtocolCorrelationError(
+                    request_id=str(rpc_id) if rpc_id is not None else "",
+                    correlation_id=response_envelope.correlation_id,
+                    details={"reason": "batch sub-response id does not match any sent request"},
+                )
+            assert_correlation_binds(str(request_envelope.id), response_envelope)
+            out.append(response_envelope)
         return out

--- a/src/asap/transport/errors.py
+++ b/src/asap/transport/errors.py
@@ -1,0 +1,103 @@
+"""Transport-layer protocol errors for the ASAP client pairing paths.
+
+These errors are raised on the CLIENT side when a remote peer returns a response
+that violates a request/response binding invariant (e.g. a ``correlation_id``
+that does not match the request id). They are distinct from the structural
+``Envelope`` validation in ``asap.models.envelope``: the envelope may be
+well-formed yet still be the wrong response for the in-flight request, which
+under concurrency would mix request/response pairs.
+
+The taxonomy code and JSON-RPC slot reuse ``asap:protocol/malformed_envelope``
+(``RPC_MALFORMED_ENVELOPE``) to stay consistent with the existing error style
+(``RemoteFatalRPCError`` / ``RemoteRecoverableRPCError``) until the roadmap
+collapse of those two RPC error types happens in a later wave.
+
+This module is also the single source of truth for the response-binding check
+(``assert_correlation_binds``) shared by the HTTP client (``send``/``batch``)
+and the WebSocket recv loop, so the binding contract cannot drift between
+pairing sites (B6/BUG #6).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from asap.errors import FatalError, RPC_MALFORMED_ENVELOPE
+from asap.models.envelope import _normalize_payload_type
+
+if TYPE_CHECKING:
+    from asap.models.envelope import Envelope
+
+__all__ = ["RESPONSE_PAYLOAD_KEYS", "ProtocolCorrelationError", "assert_correlation_binds"]
+
+
+# Response payload types whose correlation_id must bind to the request id
+# (B6/BUG #6). Server-push notifications, acks and streaming chunks are
+# intentionally loose because they are not paired to a single request id.
+RESPONSE_PAYLOAD_KEYS = frozenset({"taskresponse", "mcptoolresult", "mcpresourcedata"})
+
+
+class ProtocolCorrelationError(FatalError):
+    """Raised when a response envelope's ``correlation_id`` does not bind to its request.
+
+    A remote peer may return a structurally valid response (non-empty
+    ``correlation_id``) that nonetheless does not match the id of the in-flight
+    request. Accepting it would pair a response with the wrong request under
+    concurrency, so the client MUST reject it.
+
+    Attributes:
+        request_id: The id of the request envelope we were awaiting a response for.
+        correlation_id: The ``correlation_id`` actually carried by the response.
+    """
+
+    def __init__(
+        self,
+        request_id: str,
+        correlation_id: str | None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        message = f"correlation_id mismatch: expected {request_id!r}, got {correlation_id!r}"
+        super().__init__(
+            "asap:protocol/malformed_envelope",
+            message,
+            {
+                "request_id": request_id,
+                "correlation_id": correlation_id,
+                **(details or {}),
+            },
+            rpc_code=RPC_MALFORMED_ENVELOPE,
+        )
+        self.request_id = request_id
+        self.correlation_id = correlation_id
+
+
+def assert_correlation_binds(request_envelope_id: str, response: "Envelope") -> None:
+    """Assert that a response envelope binds to the request it answers (B6/BUG #6).
+
+    Envelope-level validation only guarantees the response carries a non-empty
+    ``correlation_id``. This BINDING check ensures that id equals the request
+    envelope id, so a buggy/malicious server cannot return a response meant for
+    another request and have the client accept it under concurrency or in a
+    batch.
+
+    Non-response payload types (server-push notifications, acks, streaming
+    chunks) intentionally skip the binding check because they are not paired to
+    a specific request id.
+
+    Args:
+        request_envelope_id: The ``id`` of the request envelope we are pairing
+            the response against.
+        response: The response envelope received from the peer.
+
+    Raises:
+        ProtocolCorrelationError: If ``response`` is a response payload type
+            whose ``correlation_id`` does not equal ``request_envelope_id``.
+    """
+    if _normalize_payload_type(response.payload_type) not in RESPONSE_PAYLOAD_KEYS:
+        return
+    if response.correlation_id == request_envelope_id:
+        return
+    raise ProtocolCorrelationError(
+        request_id=request_envelope_id,
+        correlation_id=response.correlation_id,
+    )

--- a/src/asap/transport/server.py
+++ b/src/asap/transport/server.py
@@ -1998,7 +1998,13 @@ def create_app(
         }
         if oauth2_config.jwks_fetcher is not None:
             middleware_kwargs["jwks_fetcher"] = oauth2_config.jwks_fetcher
+        oauth2_middleware = OAuth2Middleware(app, **middleware_kwargs)
         app.add_middleware(OAuth2Middleware, **middleware_kwargs)
+        # Expose the middleware instance so the WS path can enforce OAuth2 at
+        # connection acceptance; the HTTP middleware stack never runs over WS
+        # (B4/BUG #4). Stored on app.state to keep server.py decoupled from the
+        # WS module's signature.
+        app.state.oauth2_middleware = oauth2_middleware
         logger.info(
             "asap.server.oauth2_enabled",
             manifest_id=manifest.id,
@@ -2143,12 +2149,16 @@ def create_app(
         """ASAP JSON-RPC over WebSocket; same handlers as POST /asap."""
         ws_rate_limit: float | None = getattr(app.state, "websocket_message_rate_limit", 10.0)
         sla_subscribers: set[WebSocket] | None = getattr(app.state, "sla_breach_subscribers", None)
+        # OAuth2 is enforced at WS acceptance when configured (B4/BUG #4); the
+        # HTTP middleware stack does not run over WebSocket.
+        oauth2_middleware: OAuth2Middleware | None = getattr(app.state, "oauth2_middleware", None)
         await handle_websocket_connection(
             websocket,
             handler,
             app.state.websocket_connections,
             ws_message_rate_limit=ws_rate_limit,
             sla_breach_subscribers=sla_subscribers,
+            oauth2_middleware=oauth2_middleware,
         )
 
     @app.get("/audit")

--- a/src/asap/transport/websocket.py
+++ b/src/asap/transport/websocket.py
@@ -33,6 +33,7 @@ from asap.models.envelope import Envelope
 from asap.models.payloads import MessageAck
 from asap.observability import get_logger
 from asap.transport.circuit_breaker import CircuitBreaker
+from asap.transport.errors import ProtocolCorrelationError, assert_correlation_binds
 from asap.transport.jsonrpc import ASAP_METHOD
 from asap.transport.rate_limit import (
     DEFAULT_WS_MESSAGES_PER_SECOND,
@@ -43,6 +44,7 @@ from asap.transport.rate_limit import (
 ASAP_ACK_METHOD = "asap.ack"
 
 if TYPE_CHECKING:
+    from asap.auth.middleware import OAuth2Middleware
     from asap.economics.sla import SLABreach
     from asap.transport.server import ASAPRequestHandler
     from websockets.legacy.client import WebSocketClientProtocol
@@ -132,6 +134,7 @@ __all__ = [
     "WebSocketConnectionPool",
     "WebSocketRemoteError",
     "WebSocketTransport",
+    "WS_CLOSE_AUTH_REQUIRED",
     "WS_CLOSE_GOING_AWAY",
     "WS_CLOSE_POLICY_VIOLATION",
     "WS_CLOSE_REASON_SHUTDOWN",
@@ -217,6 +220,10 @@ class WebSocketTransport:
         self._ack_check_interval = ack_check_interval
         self._request_counter = itertools.count(1)
         self._pending: dict[str, asyncio.Future[Envelope]] = {}
+        # Maps JSON-RPC request_id -> request envelope id so the recv loop can
+        # enforce response.correlation_id binding (B6/BUG #6). Kept separate from
+        # ``_pending`` to avoid disturbing the future cleanup paths in close().
+        self._pending_request_ids: dict[str, str] = {}
         self._pending_acks: dict[str, PendingAck] = {}
         self._recv_task: asyncio.Task[None] | None = None
         self._ack_check_task: asyncio.Task[None] | None = None
@@ -388,6 +395,10 @@ class WebSocketTransport:
                     exc = WebSocketRemoteError(code, msg, err_data)
                     if request_id is not None and request_id in self._pending:
                         future = self._pending.pop(request_id, None)
+                        # Keep _pending_request_ids in lockstep with _pending so the
+                        # recv loop is self-contained and no stale id entries leak
+                        # if other callers ever read this map (B6 review follow-up).
+                        self._pending_request_ids.pop(request_id, None)
                         if future is not None and not future.done():
                             future.set_exception(exc)
                     else:
@@ -401,6 +412,7 @@ class WebSocketTransport:
                 if not result or "envelope" not in result:
                     if request_id is not None and request_id in self._pending:
                         future = self._pending.pop(request_id, None)
+                        self._pending_request_ids.pop(request_id, None)
                         if future is not None and not future.done():
                             future.set_exception(
                                 WebSocketRemoteError(
@@ -413,7 +425,16 @@ class WebSocketTransport:
                 envelope = Envelope.model_validate(result["envelope"])
                 if request_id is not None and request_id in self._pending:
                     future = self._pending.pop(request_id, None)
+                    request_envelope_id = self._pending_request_ids.pop(request_id, None)
                     if future is not None and not future.done():
+                        # BINDING check: the response must correlate to the request
+                        # we sent, else a buggy/malicious server could pair a response
+                        # with the wrong request under concurrency (B6/BUG #6).
+                        try:
+                            assert_correlation_binds(str(request_envelope_id), envelope)
+                        except ProtocolCorrelationError as corr_err:
+                            future.set_exception(corr_err)
+                            continue
                         future.set_result(envelope)
                 elif self._on_message is not None:
                     try:
@@ -435,6 +456,7 @@ class WebSocketTransport:
                 if not future.done():
                     future.set_exception(WebSocketRemoteError(-32603, str(e)))
             self._pending.clear()
+            self._pending_request_ids.clear()
 
     async def close(self) -> None:
         self._closed = True
@@ -459,6 +481,7 @@ class WebSocketTransport:
             if not future.done():
                 future.set_exception(asyncio.TimeoutError("Connection closed"))
         self._pending.clear()
+        self._pending_request_ids.clear()
         if self._ws is not None:
             with suppress(OSError):
                 await self._ws.close()
@@ -577,6 +600,9 @@ class WebSocketTransport:
         request_id = self._next_request_id()
         future: asyncio.Future[Envelope] = asyncio.get_running_loop().create_future()
         self._pending[request_id] = future
+        # Track the request envelope id so the recv loop can bind the response
+        # correlation_id to it (B6/BUG #6).
+        self._pending_request_ids[request_id] = str(envelope.id)
         frame = encode_envelope_frame(
             self._envelope_dict_for_send(envelope),
             request_id=request_id,
@@ -590,6 +616,7 @@ class WebSocketTransport:
             return await asyncio.wait_for(future, timeout=self._receive_timeout)
         finally:
             self._pending.pop(request_id, None)
+            self._pending_request_ids.pop(request_id, None)
 
     async def send_and_receive_stream(self, envelope: Envelope) -> AsyncIterator[Envelope]:
         """Send one JSON-RPC frame and yield every streaming ``result.envelope`` with matching id.
@@ -786,6 +813,54 @@ async def _make_fake_request(body: str, websocket: WebSocket) -> Request:
     return Request(scope, receive, send)
 
 
+def _bearer_token_from_websocket(websocket: WebSocket) -> str | None:
+    """Return the raw Bearer token from the WS ``Authorization`` header, if any.
+
+    WS subprotocols cannot carry per-message auth headers, so the Bearer MUST be
+    presented in the handshake ``Authorization`` header (kept in
+    ``websocket.scope["headers"]`` by Starlette).
+    """
+    auth = websocket.headers.get("Authorization")
+    if not auth or not auth.startswith("Bearer "):
+        return None
+    return auth[7:].strip() or None
+
+
+async def _enforce_ws_oauth2(
+    websocket: WebSocket,
+    oauth2_middleware: "OAuth2Middleware",
+) -> bool:
+    """Validate the WS Bearer JWT at acceptance; close 4401 on failure (B4/BUG #4).
+
+    Returns ``True`` when the connection is admitted, ``False`` after closing it.
+    Mirrors :class:`OAuth2Middleware` HTTP semantics so a WS-only deployment can
+    no longer bypass IdP JWT validation. Auth is decided here, at acceptance,
+    so it does NOT depend on the ``_make_fake_request`` middleware pass-through
+    that S2 Task 3.2 will remove.
+
+    Auth scope asymmetry (deliberate for S0): unlike the HTTP path, which
+    re-validates the JWT and refreshes ``request.state.oauth2_claims`` on every
+    POST, the WS path validates the Bearer ONCE at connection acceptance. A
+    token that expires or loses scope mid-session stays admitted on WS until the
+    client disconnects. This is acceptable for S0 (closes the bypass gap); S3
+    hardening can re-validate on the first message or on token expiry.
+    """
+    token = _bearer_token_from_websocket(websocket)
+    path = websocket.scope.get("path", "/asap/ws")
+    if not token:
+        logger.warning("asap.oauth2.missing_token", path=path)
+        await websocket.close(code=WS_CLOSE_AUTH_REQUIRED, reason="Authentication required")
+        return False
+    _claims, error = await oauth2_middleware.validate_bearer_token(token, path=path)
+    if error is not None:
+        # The middleware returns 401/403 JSON for HTTP; over WS we surface the
+        # failure as a close with the auth code rather than a JSON body, since
+        # the client has not yet sent any JSON-RPC frame to correlate.
+        await websocket.close(code=WS_CLOSE_AUTH_REQUIRED, reason="Invalid token")
+        return False
+    return True
+
+
 def _is_heartbeat_pong(data: dict[str, Any]) -> bool:
     return data.get("type") == HEARTBEAT_FRAME_TYPE_PONG and "method" not in data
 
@@ -864,6 +939,10 @@ WS_CLOSE_REASON_SHUTDOWN = "Server shutting down"
 # Rate limit: close code when client exceeds message rate (RFC 6455 policy violation)
 WS_CLOSE_POLICY_VIOLATION = 1008
 
+# Auth rejection at WS acceptance (B4/BUG #4): RFC 6455 application range 4000-4999.
+# Custom code keeps WS auth failures distinct from rate-limit (1008) and shutdown (1001).
+WS_CLOSE_AUTH_REQUIRED = 4401
+
 # JSON-RPC methods for SLA breach subscription (v1.3)
 SLA_SUBSCRIBE_METHOD = "sla.subscribe"
 SLA_UNSUBSCRIBE_METHOD = "sla.unsubscribe"
@@ -908,8 +987,16 @@ async def handle_websocket_connection(
     active_connections: set[WebSocket] | None = None,
     ws_message_rate_limit: float | None = DEFAULT_WS_MESSAGES_PER_SECOND,
     sla_breach_subscribers: set[WebSocket] | None = None,
+    oauth2_middleware: "OAuth2Middleware | None" = None,
 ) -> None:
     await websocket.accept()
+    # OAuth2-only deployments must not admit an unauthenticated WS: the HTTP
+    # middleware stack never runs over WebSocket, so enforce IdP JWT validation
+    # explicitly at acceptance (B4/BUG #4). When ``manifest.auth`` is the active
+    # auth path, ``oauth2_middleware`` is None and the existing fake-request
+    # flow keeps handling auth via ``handle_message``.
+    if oauth2_middleware is not None and not await _enforce_ws_oauth2(websocket, oauth2_middleware):
+        return
     if active_connections is not None:
         active_connections.add(websocket)
     logger.info("asap.websocket.connected", client=websocket.client)

--- a/tests/adapters/openapi/test_handler.py
+++ b/tests/adapters/openapi/test_handler.py
@@ -830,11 +830,29 @@ async def test_create_openapi_task_handler_returns_task_response_envelope(tmp_pa
         assert envelope_out.correlation_id == envelope_in.id
 
 
-def test_openapi_path_parameter_error_requires_exactly_one_of_missing_or_invalid() -> None:
-    with pytest.raises(ValueError, match="exactly one of missing="):
-        OpenAPIPathParameterError(path_template="/x/{a}", missing=[], invalid=[])
-    with pytest.raises(ValueError, match="exactly one of missing="):
-        OpenAPIPathParameterError(path_template="/x/{a}", missing=["a"], invalid=["a"])
+def test_openapi_path_parameter_error_constructor_is_pure() -> None:
+    # Construction must NOT raise, even for ambiguous (both/neither) invocations.
+    both = OpenAPIPathParameterError(path_template="/x/{a}", missing=["a"], invalid=["a"])
+    neither = OpenAPIPathParameterError(path_template="/x/{a}", missing=[], invalid=[])
+    assert both.path_template == "/x/{a}"
+    assert neither.path_template == "/x/{a}"
+    assert isinstance(both, OpenAPIPathParameterError)
+    assert isinstance(neither, OpenAPIPathParameterError)
+
+
+def test_openapi_path_parameter_error_factories_enforce_invariant() -> None:
+    # The "exactly one / non-empty" invariant now lives at the call-site factories.
+    with pytest.raises(ValueError, match="for_missing requires a non-empty"):
+        OpenAPIPathParameterError.for_missing("/x/{a}", [])
+    with pytest.raises(ValueError, match="for_invalid requires a non-empty"):
+        OpenAPIPathParameterError.for_invalid("/x/{a}", [])
+    # Valid factory calls still produce the expected messages/details.
+    miss_err = OpenAPIPathParameterError.for_missing("/x/{a}", ["a"])
+    assert "Missing path parameter" in str(miss_err)
+    assert miss_err.missing == ["a"]
+    inv_err = OpenAPIPathParameterError.for_invalid("/x/{a}", ["a"])
+    assert "Invalid path parameter" in str(inv_err)
+    assert inv_err.invalid == ["a"]
 
 
 @pytest.mark.asyncio

--- a/tests/chaos/test_message_reliability.py
+++ b/tests/chaos/test_message_reliability.py
@@ -352,7 +352,14 @@ class TestOutOfOrderDelivery:
 
         Simulates a scenario where responses get mixed up or delayed,
         and the client receives a response with wrong correlation ID.
+
+        Per B6/BUG #6, the client now BINDS the response correlation_id to the
+        request envelope id and rejects a mismatch (preventing request/response
+        mixup under concurrency). Previously the client accepted any non-empty
+        correlation_id and left validation to the application — that was the bug.
         """
+        from asap.transport.errors import ProtocolCorrelationError
+
         wrong_response = Envelope(
             asap_version="0.1",
             sender="urn:asap:agent:server",
@@ -379,12 +386,16 @@ class TestOutOfOrderDelivery:
             transport=httpx.MockTransport(mock_transport),
             max_retries=1,
         ) as client:
-            # Client should still return the response (correlation validation
-            # is typically done at application level, not transport)
-            response = await client.send(sample_request_envelope)
-            assert response.payload_type == "task.response"
-            # Correlation ID mismatch - application should validate
-            assert response.correlation_id != sample_request_envelope.id
+            # B6: the client must REJECT a response whose correlation_id does not
+            # bind to the request id, rather than accepting it and leaving the
+            # mismatch for the application to detect.
+            with pytest.raises(ProtocolCorrelationError) as exc_info:
+                await client.send(sample_request_envelope)
+
+            message = str(exc_info.value)
+            assert "correlation_id" in message
+            assert repr(sample_request_envelope.id) in message
+            assert repr("completely_different_id") in message
 
     async def test_stale_response_ignored(self) -> None:
         """Test handling of stale responses from previous requests.

--- a/tests/chaos/test_websocket_stability.py
+++ b/tests/chaos/test_websocket_stability.py
@@ -83,6 +83,16 @@ class _DroppingWebSocket:
 @pytest.mark.asyncio
 async def test_websocket_high_latency_resilience() -> None:
     """Client handles high latency (within timeout) gracefully."""
+    envelope = Envelope(
+        asap_version="0.1",
+        payload_type="task.request",
+        sender="urn:asap:agent:me",
+        recipient="urn:asap:agent:remote",
+        payload={"conversation_id": "c1", "skill_id": "s1", "input": {}},
+    )
+    # Per ASAP protocol semantics, the response correlation_id MUST echo the
+    # REQUEST envelope's id (see handlers.py + testing/mocks.py). The client
+    # binding (B6/BUG #6) enforces this, so the mock must match.
     rpc_response = {
         "jsonrpc": "2.0",
         "result": {
@@ -93,7 +103,7 @@ async def test_websocket_high_latency_resilience() -> None:
                 "sender": "urn:asap:agent:remote",
                 "recipient": "urn:asap:agent:local",
                 "payload": {"task_id": "t1", "status": "completed"},
-                "correlation_id": "req_1",
+                "correlation_id": envelope.id,
             }
         },
         "id": "req_1",
@@ -123,13 +133,6 @@ async def test_websocket_high_latency_resilience() -> None:
 
     try:
         start_time = time.monotonic()
-        envelope = Envelope(
-            asap_version="0.1",
-            payload_type="task.request",
-            sender="urn:asap:agent:me",
-            recipient="urn:asap:agent:remote",
-            payload={"conversation_id": "c1", "skill_id": "s1", "input": {}},
-        )
         result = await transport.send_and_receive(envelope)
         duration = time.monotonic() - start_time
 

--- a/tests/e2e/test_websocket_two_agents.py
+++ b/tests/e2e/test_websocket_two_agents.py
@@ -1,0 +1,215 @@
+"""End-to-end WebSocket round-trip regression gate (v2.5.1 Thermo-Nuclear Patch, S0 Task 7.1).
+
+Spins up a real uvicorn server exposing ``/asap/ws`` and drives a true
+client↔server WebSocket round-trip: a client opens the WS handshake carrying a
+Bearer token (``manifest.auth`` + ``token_validator``), sends a JSON-RPC
+``task.request`` envelope for the ``echo`` skill, and asserts the server
+returns a ``task.response`` frame whose ``correlation_id`` matches the request
+``id`` and whose payload echoes the input back.
+
+This is the regression gate for S2 Task 3 (decompose ``websocket.py``): without
+an E2E WS test, the decomposition can silently break the WS request/response
+flow. ``tests/transport/test_websocket.py`` covers framing/unit concerns;
+``tests/e2e/test_two_agents.py`` is HTTP-only. This test pins the full
+client↔server WS path with auth + correlation exercised end-to-end.
+
+A single-client round-trip is sufficient and intentionally chosen over a
+two-agent flow: the gate's purpose is "WS client↔server round-trip works
+end-to-end with auth + correlation", which a single client→echo-server request
+already proves. The two-agent variant would add a coordinator hop without
+exercising any additional WS code path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from typing import Any
+
+import pytest
+from websockets.asyncio.client import connect as ws_connect
+
+from asap.models.entities import AuthScheme, Capability, Endpoint, Manifest, Skill
+from asap.models.envelope import Envelope
+from asap.models.payloads import TaskRequest
+from asap.testing import assert_response_correlates
+from asap.transport.handlers import create_default_registry
+from asap.transport.jsonrpc import ASAP_METHOD, JsonRpcRequest
+from asap.transport.server import create_app
+from asap.transport.websocket import decode_frame_to_json
+
+from tests.transport.conftest import TEST_RATE_LIMIT_DEFAULT, NoRateLimitTestBase
+
+# Bearer token accepted by the test ``token_validator`` and the agent identity
+# it resolves to. The envelope ``sender`` MUST match this identity or the
+# server's sender/auth binding rejects the request.
+E2E_WS_TOKEN = "e2e-ws-bearer-token"
+E2E_WS_CLIENT_ID = "urn:asap:agent:e2e-ws-client"
+E2E_WS_SERVER_ID = "urn:asap:agent:e2e-ws-server"
+E2E_WS_ECHO_INPUT = {"msg": "e2e-ws-correlation"}
+
+
+def _free_port() -> int:
+    """Return an unused TCP port on 127.0.0.1 for the ephemeral uvicorn server."""
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _auth_manifest() -> Manifest:
+    """Manifest with a ``bearer`` auth scheme so the WS path enforces token validation."""
+    return Manifest(
+        id=E2E_WS_SERVER_ID,
+        name="E2E WS Server",
+        version="1.0.0",
+        description="Echo server for the E2E WebSocket round-trip gate",
+        capabilities=Capability(
+            asap_version="0.1",
+            skills=[Skill(id="echo", description="Echo input as output")],
+            state_persistence=False,
+        ),
+        endpoints=Endpoint(asap="http://localhost:8000/asap"),
+        auth=AuthScheme(schemes=["bearer"]),
+    )
+
+
+def _token_validator(token: str) -> str | None:
+    """Validate a Bearer token and return the authenticated agent identity.
+
+    Returns ``None`` for unknown tokens so the server's auth middleware rejects
+    them with a JSON-RPC auth error, exercising the fail path end-to-end.
+    """
+    if token == E2E_WS_TOKEN:
+        return E2E_WS_CLIENT_ID
+    return None
+
+
+def _task_request_frame(envelope: Envelope, request_id: str | int) -> str:
+    """Serialize a ``task.request`` envelope into a JSON-RPC text frame."""
+    rpc = JsonRpcRequest(
+        method=ASAP_METHOD,
+        params={"envelope": envelope.model_dump(mode="json")},
+        id=request_id,
+    )
+    return json.dumps(rpc.model_dump())
+
+
+class TestE2EWebSocketRoundTrip(NoRateLimitTestBase):
+    """True client↔server E2E WebSocket round-trip with auth + correlation."""
+
+    @pytest.mark.asyncio
+    async def test_task_request_round_trips_over_websocket_with_auth(
+        self,
+        disable_rate_limiting: Any,
+    ) -> None:
+        """A Bearer-authenticated WS client sends ``task.request`` and receives a correlated ``task.response``.
+
+        Steps:
+        1. Build an auth-gated echo app (``manifest.auth`` bearer + ``token_validator``).
+        2. Start a real uvicorn server on a free port in a daemon thread.
+        3. Open the WS handshake with ``Authorization: Bearer <token>`` so the
+           fake-request auth path validates the token via ``token_validator``.
+        4. Send a JSON-RPC ``task.request`` frame for the ``echo`` skill.
+        5. Receive the ``task.response`` frame and assert:
+           - ``payload_type == "task.response"``
+           - ``assert_response_correlates(request, response)`` (correlation_id == request id)
+           - echoed payload: ``result["echoed"]`` contains the request input
+           - the connection closes cleanly after.
+        """
+        import uvicorn
+        from asap.transport import middleware as middleware_module
+
+        # Isolate rate limiting: replace the module-level limiter AND the
+        # app.state limiter so neither HTTP nor WS token-bucket paths can 429.
+        middleware_module.limiter = disable_rate_limiting
+
+        app_instance = create_app(
+            _auth_manifest(),
+            registry=create_default_registry(),
+            token_validator=_token_validator,
+            rate_limit=TEST_RATE_LIMIT_DEFAULT,
+        )
+        app_instance.state.limiter = disable_rate_limiting
+
+        port = _free_port()
+        server_started = threading.Event()
+        thread_err: list[Exception] = []
+
+        def run() -> None:
+            try:
+                config = uvicorn.Config(
+                    app_instance,
+                    host="127.0.0.1",
+                    port=port,
+                    log_level="warning",
+                )
+                server_started.set()
+                asyncio.run(uvicorn.Server(config).serve())
+            except Exception as exc:  # pragma: no cover - surfaced via thread_err
+                thread_err.append(exc)
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        assert server_started.wait(timeout=5.0)
+        # Let the socket settle before the client connects.
+        await asyncio.sleep(0.2)
+
+        ws_url = f"ws://127.0.0.1:{port}/asap/ws"
+        request_envelope = Envelope(
+            asap_version="0.1",
+            sender=E2E_WS_CLIENT_ID,
+            recipient=E2E_WS_SERVER_ID,
+            payload_type="task.request",
+            payload=TaskRequest(
+                conversation_id="e2e-ws-conv-1",
+                skill_id="echo",
+                input=E2E_WS_ECHO_INPUT,
+            ).model_dump(),
+        )
+        # request_id is generated locally so the server-side envelope keeps its
+        # own auto-generated id; correlation is asserted via the response's
+        # ``correlation_id`` matching the request envelope ``id``.
+        request_frame = _task_request_frame(request_envelope, request_id="e2e-ws-req-1")
+
+        try:
+            async with ws_connect(
+                ws_url,
+                additional_headers={"Authorization": f"Bearer {E2E_WS_TOKEN}"},
+                open_timeout=10.0,
+                close_timeout=5.0,
+            ) as websocket:
+                await websocket.send(request_frame)
+                response_text = await asyncio.wait_for(websocket.recv(), timeout=10.0)
+                # Clean close initiated by the client after the round-trip.
+                await websocket.close()
+
+            if thread_err:
+                raise thread_err[0]
+
+            assert isinstance(response_text, str)
+            data = decode_frame_to_json(response_text)
+            # JSON-RPC success envelope, not an error frame.
+            assert data.get("jsonrpc") == "2.0"
+            assert "error" not in data, f"unexpected JSON-RPC error: {data.get('error')}"
+            assert "result" in data, f"missing result in WS frame: {data}"
+
+            response_env_dict = data["result"].get("envelope")
+            assert isinstance(response_env_dict, dict), (
+                f"expected envelope dict in result, got {response_env_dict!r}"
+            )
+            response_envelope = Envelope.model_validate(response_env_dict)
+
+            assert response_envelope.payload_type == "task.response"
+            assert_response_correlates(request_envelope, response_envelope)
+
+            echoed = response_envelope.payload_dict.get("result", {}).get("echoed")
+            assert echoed == E2E_WS_ECHO_INPUT, (
+                f"echoed payload mismatch: expected {E2E_WS_ECHO_INPUT!r}, got {echoed!r}"
+            )
+        except Exception as e:
+            if thread_err:
+                raise thread_err[0] from e
+            raise

--- a/tests/economics/test_delegation_storage.py
+++ b/tests/economics/test_delegation_storage.py
@@ -1,6 +1,8 @@
 """Tests for delegation revocation storage."""
 
+import asyncio
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -10,6 +12,9 @@ from asap.economics.delegation_storage import (
     _assert_sql_in_placeholders,
     _build_sql_in_placeholders,
 )
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
 
 
 # ---------------------------------------------------------------------------
@@ -512,3 +517,187 @@ class TestSQLiteDelegationStorageCoverage:
     def test_assert_sql_in_placeholders_rejects_malformed(self) -> None:
         with pytest.raises(ValueError, match="placeholders must be"):
             _assert_sql_in_placeholders("id=1; DROP TABLE revocations; --")
+
+
+# ---------------------------------------------------------------------------
+# Task 1.0 (B1) — Atomic cascade revocation regression tests
+# ---------------------------------------------------------------------------
+
+
+class TestRevokeCascadeAtomic:
+    """Atomic cascade revocation: SQLite rollback + InMemory lock parity.
+
+    Covers the two regression scenarios from the v2.5.1 Thermo-Nuclear Patch:
+    1. SQLite mid-cascade crash must roll back atomically (no partial state).
+    2. InMemory concurrent ``register_issued`` during a cascade must not lose a
+       newly-issued child (cascade holds an ``asyncio.Lock``).
+    """
+
+    @pytest.mark.asyncio
+    async def test_revoke_cascade_atomic_rollback(
+        self,
+        sqlite_storage: SQLiteDelegationStorage,
+        monkeypatch: "MonkeyPatch",
+    ) -> None:
+        """A failing mid-cascade revoke must leave NO token revoked (atomic rollback).
+
+        Tree seeded (two branches off the root):
+            parent      -> child1      (delegate urn:mid1) -> grandchild1 (leaf1)
+            child_extra -> (issued by root, delegate urn:mid2)
+            child2      -> (issued by mid2) -> grandchild2 (leaf2)
+        The cascade from `parent` reaches child1, grandchild1, child_extra,
+        child2, grandchild2.
+        """
+        await sqlite_storage.register_issued(
+            "parent", "urn:asap:agent:root", delegate_urn="urn:asap:agent:mid1"
+        )
+        await sqlite_storage.register_issued(
+            "child1", "urn:asap:agent:mid1", delegate_urn="urn:asap:agent:leaf1"
+        )
+        await sqlite_storage.register_issued(
+            "child_extra", "urn:asap:agent:root", delegate_urn="urn:asap:agent:mid2"
+        )
+        await sqlite_storage.register_issued(
+            "child2", "urn:asap:agent:mid2", delegate_urn="urn:asap:agent:leaf2"
+        )
+        await sqlite_storage.register_issued(
+            "grandchild1", "urn:asap:agent:leaf1", delegate_urn="urn:asap:agent:end1"
+        )
+        await sqlite_storage.register_issued(
+            "grandchild2", "urn:asap:agent:leaf2", delegate_urn="urn:asap:agent:end2"
+        )
+        all_ids = [
+            "parent",
+            "child1",
+            "child_extra",
+            "child2",
+            "grandchild1",
+            "grandchild2",
+        ]
+
+        # Fail exactly once, on the 2nd per-id revoke the cascade performs.
+        # Patch the per-id hook the atomic path uses when present, and also the
+        # public ``revoke`` (used by the legacy non-atomic path) so the test is
+        # valid both before and after the refactor.
+        call_count = {"n": 0}
+
+        def _should_fail() -> bool:
+            call_count["n"] += 1
+            return call_count["n"] == 2
+
+        original_revoke = sqlite_storage.revoke
+
+        async def _failing_revoke(token_id: str, reason: str | None = None) -> None:
+            if _should_fail():
+                raise RuntimeError("simulated mid-cascade crash")
+            await original_revoke(token_id, reason)
+
+        monkeypatch.setattr(sqlite_storage, "revoke", _failing_revoke)
+
+        if hasattr(sqlite_storage, "_revoke_on_conn"):
+            from datetime import datetime, timezone
+
+            async def _failing_revoke_on_conn(
+                conn: object, token_id: str, reason: str | None
+            ) -> None:
+                if _should_fail():
+                    raise RuntimeError("simulated mid-cascade crash")
+                now_iso = datetime.now(timezone.utc).isoformat()
+                await conn.execute(
+                    "INSERT OR REPLACE INTO revocations (id, revoked_at, reason) VALUES (?, ?, ?)",
+                    (token_id, now_iso, reason),
+                )
+
+            monkeypatch.setattr(sqlite_storage, "_revoke_on_conn", _failing_revoke_on_conn)
+
+        with pytest.raises(RuntimeError, match="simulated mid-cascade crash"):
+            await sqlite_storage.revoke_cascade("parent", reason="rollback test")
+
+        # Atomic rollback: nothing should be persisted.
+        revoked = await sqlite_storage.are_revoked(all_ids)
+        assert revoked == dict.fromkeys(all_ids, False), (
+            f"expected no revocations after rollback, got {revoked}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_revoke_cascade_concurrent_inmemory_no_lost_child(
+        self,
+        memory_storage: InMemoryDelegationStorage,
+        monkeypatch: "MonkeyPatch",
+    ) -> None:
+        """A child issued mid-cascade must not be lost (cascade holds a lock).
+
+        Invariant: the cascade and a concurrent ``register_issued`` must be
+        serialized by an ``asyncio.Lock`` — the issue must not interleave
+        *inside* the cascade's critical section. We detect non-serialization
+        by recording the relative order of ``register_issued(child_new)``
+        completing vs. the cascade revoking the root's delegate branch. Without
+        a lock the issue completes mid-cascade (recorded before the cascade
+        finishes revoking); with the lock the issue is delayed until the
+        cascade releases, so it completes only after the cascade's final revoke.
+
+        The "not lost" check (``get_delegator(child_new)`` is observable) holds
+        in both worlds; the ordering check is what the lock guarantees.
+        """
+        await memory_storage.register_issued(
+            "parent", "urn:asap:agent:root", delegate_urn="urn:asap:agent:mid"
+        )
+        await memory_storage.register_issued(
+            "child", "urn:asap:agent:mid", delegate_urn="urn:asap:agent:leaf"
+        )
+
+        events: list[str] = []
+        yielded_once = {"done": False}
+        original_list = memory_storage.list_token_ids_issued_by
+        original_revoke = memory_storage.revoke
+
+        async def _yielding_list(delegator_urn: str) -> list[str]:
+            # Yield exactly once, while walking the root's delegate ("mid"),
+            # so the concurrent register_issued races the cascade's snapshot.
+            if delegator_urn == "urn:asap:agent:mid" and not yielded_once["done"]:
+                await asyncio.sleep(0)
+                yielded_once["done"] = True
+            return await original_list(delegator_urn)
+
+        async def _recording_revoke(token_id: str, reason: str | None = None) -> None:
+            events.append(f"revoke:{token_id}:start")
+            await original_revoke(token_id, reason)
+            events.append(f"revoke:{token_id}:end")
+
+        monkeypatch.setattr(memory_storage, "list_token_ids_issued_by", _yielding_list)
+        monkeypatch.setattr(memory_storage, "revoke", _recording_revoke)
+
+        async def _issue_new_child() -> None:
+            await memory_storage.register_issued(
+                "child_new",
+                "urn:asap:agent:mid",
+                delegate_urn="urn:asap:agent:leaf_new",
+            )
+            events.append("issue:child_new")
+
+        cascade_task = asyncio.create_task(
+            memory_storage.revoke_cascade("parent", reason="concurrent test")
+        )
+        issue_task = asyncio.create_task(_issue_new_child())
+        await asyncio.gather(cascade_task, issue_task)
+
+        # The new child was issued and is observable in the store (not lost).
+        delegator = await memory_storage.get_delegator("child_new")
+        assert delegator == "urn:asap:agent:mid", (
+            f"concurrent register_issued was lost during cascade (get_delegator={delegator!r})"
+        )
+        # Serialization: the issue must not complete while the cascade is
+        # mid-revoke. With the lock, every "revoke:*:end" for the cascade
+        # precedes "issue:child_new". Without the lock, "issue:child_new"
+        # appears between the yield and the first revoke (interleaved).
+        issue_idx = events.index("issue:child_new")
+        last_revoke_end = max(
+            (i for i, e in enumerate(events) if e.startswith("revoke:") and e.endswith(":end")),
+            default=-1,
+        )
+        assert issue_idx > last_revoke_end, (
+            f"register_issued interleaved inside the cascade critical section (events={events})"
+        )
+        # And the originally-seeded tree was revoked consistently.
+        assert await memory_storage.is_revoked("parent") is True
+        assert await memory_storage.is_revoked("child") is True

--- a/tests/state/test_sqlite_store.py
+++ b/tests/state/test_sqlite_store.py
@@ -17,6 +17,8 @@ from asap.state.metering import (
     UsageEvent,
     UsageMetrics,
 )
+from asap.economics.storage import SQLiteMeteringStorage
+from asap.economics.metering import UsageMetrics as EconomicsUsageMetrics
 from asap.state.snapshot import AsyncSnapshotStore, SnapshotStore
 from asap.state.stores.sqlite import (
     SQLiteAsyncSnapshotStore,
@@ -434,3 +436,77 @@ class TestSQLiteMeteringStore:
         assert agg.total_tokens == 0
         assert agg.total_tasks == 0
         assert agg.total_api_calls == 0
+
+
+async def _usage_event_indexes(db_path: Path) -> set[str]:
+    """Return the set of index names on the usage_events table for ``db_path``.
+
+    Queries sqlite_master directly so the assertion reflects the physical schema,
+    not any in-memory cache held by either store.
+    """
+    async with aiosqlite.connect(db_path) as conn:
+        cursor = await conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='usage_events'"
+        )
+        rows = await cursor.fetchall()
+    return {str(r[0]) for r in rows}
+
+
+class TestUsageEventsIndexConsolidation:
+    """Both stores must install both usage_events indexes regardless of init order.
+
+    Regression guard for divergent query plans: the state-layer store historically
+    omitted idx_usage_consumer_timestamp, and CREATE TABLE IF NOT EXISTS made the
+    metering store a no-op when it initialized second — so the consumer index was
+    never created if the state store won the race.
+    """
+
+    @pytest.mark.asyncio
+    async def test_state_store_only_creates_both_indexes(self, db_path: Path) -> None:
+        """State store alone must install both indexes (currently omits the consumer one)."""
+        state_store = SQLiteMeteringStore(db_path=db_path)
+        await state_store.initialize()
+
+        indexes = await _usage_event_indexes(db_path)
+        assert "idx_usage_agent_timestamp" in indexes, (
+            f"agent index missing after state-only init; got {sorted(indexes)}"
+        )
+        assert "idx_usage_consumer_timestamp" in indexes, (
+            f"consumer index missing after state-only init; got {sorted(indexes)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_metering_storage_first_then_state_store_has_consumer_index(
+        self,
+        db_path: Path,
+        sample_usage_event: UsageEvent,
+    ) -> None:
+        """Economics store inits first (both indexes); state store reuses the same DB."""
+        metering = SQLiteMeteringStorage(db_path=db_path)
+        await metering.record(EconomicsUsageMetrics.from_usage_event(sample_usage_event))
+
+        state_store = SQLiteMeteringStore(db_path=db_path)
+        await state_store.initialize()
+
+        indexes = await _usage_event_indexes(db_path)
+        assert "idx_usage_consumer_timestamp" in indexes, (
+            f"consumer index missing after metering-first init; got {sorted(indexes)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_state_store_first_then_metering_storage_has_consumer_index(
+        self,
+        db_path: Path,
+        sample_usage_event: UsageEvent,
+    ) -> None:
+        """State store inits first (previously omitted consumer index); economics store must add it."""
+        state_store = SQLiteMeteringStore(db_path=db_path)
+        await state_store.initialize()
+
+        metering = SQLiteMeteringStorage(db_path=db_path)
+        await metering.record(EconomicsUsageMetrics.from_usage_event(sample_usage_event))
+
+        indexes = await _usage_event_indexes(db_path)
+        assert "idx_usage_consumer_timestamp" in indexes, (
+            f"consumer index missing after state-first init; got {sorted(indexes)}"
+        )

--- a/tests/transport/test_batch.py
+++ b/tests/transport/test_batch.py
@@ -238,3 +238,115 @@ class TestBatchClient(NoRateLimitTestBase):
         ) as client:
             with pytest.raises(ValueError, match="empty"):
                 await client.batch([])
+
+    async def test_client_batch_rejects_mismatched_correlation_id(self) -> None:
+        """B6/BUG #6: batch() rejects a sub-response whose correlation_id != request id.
+
+        A malicious/buggy peer could permute batch response bodies (or ids) while
+        keeping HTTP 200; the client must bind each sub-response to its originating
+        request by correlation_id and raise ProtocolCorrelationError on mismatch,
+        mirroring send() and the WebSocket recv loop.
+        """
+        import httpx
+
+        from asap.models.enums import TaskStatus
+        from asap.models.payloads import TaskResponse
+        from asap.transport.client import ASAPClient
+        from asap.transport.errors import ProtocolCorrelationError
+
+        env1 = _make_envelope()
+        env2 = _make_envelope()
+
+        def malicious_transport(request: httpx.Request) -> httpx.Response:
+            # Parse the batch array the client sent so we can echo each request's
+            # JSON-RPC id while returning a response whose correlation_id does NOT
+            # match the request envelope id (the B6 attack).
+            batch_body = json.loads(request.content)
+            items: list[dict[str, Any]] = []
+            for entry in batch_body:
+                req_id = entry["id"]
+                response_envelope = Envelope(
+                    asap_version="0.1",
+                    sender="urn:asap:agent:batch-test",
+                    recipient="urn:asap:agent:client",
+                    payload_type="task.response",
+                    payload=TaskResponse(
+                        task_id="task_evil",
+                        status=TaskStatus.COMPLETED,
+                        result={"echoed": {"message": "permuted"}},
+                    ).model_dump(),
+                    # Non-empty but wrong: does not match the request envelope id.
+                    correlation_id="definitely-not-the-request-id",
+                )
+                items.append(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "result": {"envelope": response_envelope.model_dump(mode="json")},
+                    }
+                )
+            return httpx.Response(200, json=items)
+
+        async with ASAPClient(
+            "http://test",
+            require_https=False,
+            transport=httpx.MockTransport(malicious_transport),
+        ) as client:
+            with pytest.raises(ProtocolCorrelationError) as exc_info:
+                await client.batch([env1, env2])
+
+            message = str(exc_info.value)
+            assert "correlation_id" in message
+            assert repr("definitely-not-the-request-id") in message
+
+    async def test_client_batch_rejects_unknown_response_id(self) -> None:
+        """B6/BUG #6: batch() rejects a sub-response whose JSON-RPC id matches no sent request.
+
+        A peer that returns a result for an id we did not send (permutation / forgery)
+        must be rejected rather than silently paired by array index.
+        """
+        import httpx
+
+        from asap.models.enums import TaskStatus
+        from asap.models.payloads import TaskResponse
+        from asap.transport.client import ASAPClient
+        from asap.transport.errors import ProtocolCorrelationError
+
+        env1 = _make_envelope()
+
+        def malicious_transport(request: httpx.Request) -> httpx.Response:
+            response_envelope = Envelope(
+                asap_version="0.1",
+                sender="urn:asap:agent:batch-test",
+                recipient="urn:asap:agent:client",
+                payload_type="task.response",
+                payload=TaskResponse(
+                    task_id="task_evil",
+                    status=TaskStatus.COMPLETED,
+                    result={},
+                ).model_dump(),
+                correlation_id=env1.id,
+            )
+            # An id we never sent.
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "forged-id-not-in-batch",
+                        "result": {"envelope": response_envelope.model_dump(mode="json")},
+                    }
+                ],
+            )
+
+        async with ASAPClient(
+            "http://test",
+            require_https=False,
+            transport=httpx.MockTransport(malicious_transport),
+        ) as client:
+            with pytest.raises(ProtocolCorrelationError) as exc_info:
+                await client.batch([env1])
+
+            # The forged JSON-RPC id appears as the expected request_id, proving
+            # the unknown-id branch fired (no sent request had that id).
+            assert repr("forged-id-not-in-batch") in str(exc_info.value)

--- a/tests/transport/test_capability_routes.py
+++ b/tests/transport/test_capability_routes.py
@@ -547,6 +547,41 @@ class TestAgentReactivate:
         assert r.status_code == 403
         assert "revoked" in r.json()["detail"].lower()
 
+    async def test_reactivate_revoked_host_returns_403(
+        self,
+        sample_manifest: Manifest,
+        isolated_rate_limiter: ASAPRateLimiter | None,
+    ) -> None:
+        """A revoked HOST must not authenticate on capability routes.
+
+        Distinct from ``test_reactivate_revoked_agent_returns_403`` (which
+        revokes the AGENT and hits the agent-status check inside
+        ``reactivate_agent``): here the HOST is revoked, so the Host-JWT
+        verifier itself must reject the request with 403.
+        """
+        app, agent_store, host_store, _ = _setup(sample_manifest, isolated_rate_limiter)
+        client = TestClient(app)
+        host_sk = Ed25519PrivateKey.generate()
+        agent_sk = Ed25519PrivateKey.generate()
+        aid = await _register_and_activate(
+            client, app, agent_store, host_sk, agent_sk, status="active"
+        )
+
+        host = await host_store.get_by_public_key(
+            jwk_thumbprint_sha256(ed25519_public_jwk(host_sk))
+        )
+        assert host is not None
+        await host_store.revoke(host.host_id)
+
+        token = _host_jwt(host_sk)
+        r = client.post(
+            "/asap/agent/reactivate",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"agent_id": aid},
+        )
+        assert r.status_code == 403
+        assert "revoked" in r.json()["detail"].lower()
+
     async def test_reactivate_absolute_lifetime_exceeded_returns_403(
         self,
         sample_manifest: Manifest,

--- a/tests/transport/test_client.py
+++ b/tests/transport/test_client.py
@@ -2117,3 +2117,48 @@ class TestManifestSignatureVerification:
         ) as client:
             result = await client.get_manifest()
         assert result.id == "urn:asap:agent:plain"
+
+
+class TestClientCorrelationBinding:
+    """B6 (BUG #6): client must reject responses whose correlation_id does not bind to the request.
+
+    The structural ``validate_response_correlation`` check only ensures the response carries a
+    non-empty ``correlation_id``. The BINDING check (response.correlation_id == request.id)
+    must be enforced at the client pairing site so a buggy/malicious server cannot return a
+    response meant for a different request under concurrency.
+    """
+
+    async def test_send_rejects_mismatched_correlation_id(
+        self, sample_request_envelope: Envelope
+    ) -> None:
+        """``send`` raises ``ProtocolCorrelationError`` when response correlation_id != request id."""
+        from asap.transport.errors import ProtocolCorrelationError
+
+        # Non-empty but different from sample_request_envelope.id so it passes the
+        # structural non-empty check but must fail the binding check.
+        mismatched_response = Envelope(
+            asap_version="0.1",
+            sender="urn:asap:agent:server",
+            recipient="urn:asap:agent:client",
+            payload_type="task.response",
+            payload=TaskResponse(
+                task_id="task_456",
+                status=TaskStatus.COMPLETED,
+                result={"echoed": {"message": "Hello!"}},
+            ).model_dump(),
+            correlation_id="different-id",
+        )
+
+        def mock_transport(request: httpx.Request) -> httpx.Response:
+            return create_mock_response(mismatched_response)
+
+        async with ASAPClient(
+            "http://localhost:8000", transport=httpx.MockTransport(mock_transport)
+        ) as client:
+            with pytest.raises(ProtocolCorrelationError) as exc_info:
+                await client.send(sample_request_envelope)
+
+            message = str(exc_info.value)
+            assert "correlation_id" in message
+            assert repr(sample_request_envelope.id) in message
+            assert repr("different-id") in message

--- a/tests/transport/test_client_edge_cases.py
+++ b/tests/transport/test_client_edge_cases.py
@@ -44,6 +44,9 @@ def sample_request_envelope() -> Envelope:
 
 def _make_success_response(envelope: Envelope) -> httpx.Response:
     """Create a mock httpx.Response with valid JSON-RPC success."""
+    # Per ASAP protocol semantics, a response's correlation_id MUST echo the
+    # REQUEST envelope's id (see handlers.py + testing/mocks.py). The client
+    # binding (B6/BUG #6) enforces this.
     response_envelope = Envelope(
         asap_version="0.1",
         sender="urn:asap:agent:server",
@@ -53,7 +56,7 @@ def _make_success_response(envelope: Envelope) -> httpx.Response:
             task_id="task_1",
             status=TaskStatus.COMPLETED,
         ).model_dump(),
-        correlation_id="req_1",
+        correlation_id=envelope.id,
     )
     body = {
         "jsonrpc": "2.0",

--- a/tests/transport/test_http_client.py
+++ b/tests/transport/test_http_client.py
@@ -15,12 +15,15 @@ from asap.transport.client import ASAPClient
 
 
 def _echo_response_json(for_envelope: Envelope) -> dict[str, object]:
+    # Per ASAP protocol semantics (see handlers.py + testing/mocks.py), a
+    # response's correlation_id MUST echo the REQUEST envelope's id, not its
+    # correlation_id field. Binding the client (B6/BUG #6) enforces this.
     env = Envelope(
         asap_version=for_envelope.asap_version,
         sender=for_envelope.recipient,
         recipient=for_envelope.sender,
         payload_type="task.response",
-        correlation_id=for_envelope.correlation_id,
+        correlation_id=for_envelope.id,
         payload=TaskResponse(
             task_id="task-version",
             status=TaskStatus.COMPLETED,

--- a/tests/transport/test_websocket.py
+++ b/tests/transport/test_websocket.py
@@ -490,6 +490,90 @@ class TestWebSocketTransportCorrelation(NoRateLimitTestBase):
             )
 
     @pytest.mark.asyncio
+    async def test_send_and_receive_rejects_mismatched_correlation_id(self) -> None:
+        """B6 (BUG #6): WS recv loop rejects a response whose correlation_id != request id.
+
+        The server returns a structurally valid JSON-RPC response (non-empty
+        ``correlation_id``) carrying the right JSON-RPC ``id`` but an envelope
+        ``correlation_id`` that does not match the request envelope id. The recv
+        loop must raise ``ProtocolCorrelationError`` rather than pairing it with
+        the in-flight request. Deterministic: ``_ws`` is mocked, no real server.
+        """
+        from asap.models.enums import TaskStatus
+        from asap.models.payloads import TaskResponse
+        from asap.transport.errors import ProtocolCorrelationError
+
+        request = Envelope(
+            asap_version="0.1",
+            sender="urn:asap:agent:client",
+            recipient="urn:asap:agent:server",
+            payload_type="task.request",
+            payload=TaskRequest(
+                conversation_id="c1",
+                skill_id="echo",
+                input={"msg": "hi"},
+            ).model_dump(),
+        )
+
+        # Response envelope: non-empty correlation_id that does NOT match request.id.
+        mismatched_response = Envelope(
+            asap_version="0.1",
+            sender="urn:asap:agent:server",
+            recipient="urn:asap:agent:client",
+            payload_type="task.response",
+            payload=TaskResponse(
+                task_id="task_456",
+                status=TaskStatus.COMPLETED,
+                result={"echoed": {"message": "hi"}},
+            ).model_dump(),
+            correlation_id="different-id",
+        )
+
+        async def send_stub(frame: str) -> None:
+            # Capture the JSON-RPC request_id the transport assigned so the
+            # fake recv() can return a response carrying that same id.
+            payload = json.loads(frame)
+            send_stub.request_id = payload["id"]
+
+        async def recv_stub() -> str:
+            await asyncio.sleep(0)  # let send_and_receive register the pending future
+            response_frame = {
+                "jsonrpc": "2.0",
+                "id": send_stub.request_id,
+                "result": {"envelope": mismatched_response.model_dump(by_alias=True, mode="json")},
+            }
+            return json.dumps(response_frame)
+
+        class FakeWs:
+            sent_id: str = ""
+
+            async def send(self, frame: str) -> None:
+                await send_stub(frame)
+
+            async def recv(self) -> str:
+                return await recv_stub()
+
+            async def close(self) -> None:
+                return None
+
+        transport = WebSocketTransport(receive_timeout=2.0)
+        transport._ws = cast(Any, FakeWs())
+        transport._closed = False
+        transport._recv_task = asyncio.create_task(transport._recv_loop())
+        transport._ack_check_task = asyncio.create_task(transport._ack_check_loop())
+
+        try:
+            with pytest.raises(ProtocolCorrelationError) as exc_info:
+                await transport.send_and_receive(request)
+
+            message = str(exc_info.value)
+            assert "correlation_id" in message
+            assert repr(request.id) in message
+            assert repr("different-id") in message
+        finally:
+            await transport.close()
+
+    @pytest.mark.asyncio
     async def test_close_swallows_oserror_from_ws_close(self) -> None:
         """close() does not raise when _ws.close() raises OSError."""
         transport = WebSocketTransport(receive_timeout=5.0)

--- a/tests/transport/test_websocket_oauth2.py
+++ b/tests/transport/test_websocket_oauth2.py
@@ -1,0 +1,172 @@
+"""WebSocket auth enforcement under OAuth2-only deployments (B4/BUG #4).
+
+In an OAuth2-only deployment (``oauth2_config`` set, ``manifest.auth`` left
+``None``) the HTTP path ``/asap`` is protected by ``OAuth2Middleware`` while
+the WebSocket path ``/asap/ws`` historically bypassed the middleware stack
+entirely: ``handle_websocket_connection`` synthesizes a fake ``Request`` and
+dispatches messages straight to the handler, so a client could send
+``task.request`` envelopes with no Bearer token at all. These tests pin the
+fail-closed behaviour: a WS connection without a valid Bearer JWT is rejected
+at acceptance time, while a valid JWT is still admitted.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from joserfc import jwk, jwt as jose_jwt
+
+from asap.auth import OAuth2Config
+from asap.auth.middleware import DEFAULT_CUSTOM_CLAIM
+from asap.models.entities import Capability, Endpoint, Manifest, Skill
+from asap.models.envelope import Envelope
+from asap.models.payloads import TaskRequest
+from asap.transport.handlers import create_default_registry
+from asap.transport.jsonrpc import ASAP_METHOD, JsonRpcRequest
+from asap.transport.server import create_app
+from asap.transport.websocket import WS_CLOSE_AUTH_REQUIRED
+
+from .conftest import TEST_RATE_LIMIT_DEFAULT
+
+
+def _oauth2_only_manifest() -> Manifest:
+    """Manifest with no ``auth`` block — OAuth2 is the sole auth path."""
+    return Manifest(
+        id="urn:asap:agent:test-server",
+        name="Test Server",
+        version="1.0.0",
+        description="OAuth2-only test server",
+        capabilities=Capability(
+            asap_version="0.1",
+            skills=[Skill(id="echo", description="Echo")],
+            state_persistence=False,
+        ),
+        endpoints=Endpoint(asap="http://localhost:8000/asap"),
+    )
+
+
+def _task_request_body(req_id: str | int = "ws-oauth2-1") -> str:
+    """Serialize a minimal ``task.request`` JSON-RPC frame."""
+    envelope = Envelope(
+        asap_version="0.1",
+        sender="urn:asap:agent:client",
+        recipient="urn:asap:agent:test-server",
+        payload_type="task.request",
+        payload=TaskRequest(
+            conversation_id="conv-ws-oauth2",
+            skill_id="echo",
+            input={"message": "hi"},
+        ).model_dump(),
+    )
+    rpc = JsonRpcRequest(
+        method=ASAP_METHOD,
+        params={"envelope": envelope.model_dump(mode="json")},
+        id=req_id,
+    )
+    return json.dumps(rpc.model_dump())
+
+
+def _make_oauth2_app(key_set: jwk.KeySet) -> "Any":
+    """Build an OAuth2-only app that resolves JWKS from ``key_set``."""
+
+    async def mock_jwks(_uri: str) -> jwk.KeySet:
+        return key_set
+
+    return create_app(
+        _oauth2_only_manifest(),
+        registry=create_default_registry(),
+        oauth2_config=OAuth2Config(
+            jwks_uri="https://auth.example.com/jwks.json",
+            path_prefix="/asap",
+            jwks_fetcher=mock_jwks,
+        ),
+        rate_limit=TEST_RATE_LIMIT_DEFAULT,
+    )
+
+
+def _mint_valid_jwt(signing_key: jwk.RSAKey) -> str:
+    """Mint a valid RS256 JWT carrying the manifest-bound custom claim."""
+    now = int(time.time())
+    return jose_jwt.encode(
+        {"alg": "RS256", "typ": "JWT"},
+        {
+            "sub": "urn:asap:agent:client",
+            "scope": "asap:execute",
+            "exp": now + 3600,
+            DEFAULT_CUSTOM_CLAIM: "urn:asap:agent:test-server",
+        },
+        signing_key,
+    )
+
+
+class TestWebSocketOAuth2Enforcement:
+    """WS connections under OAuth2-only deployments must be authenticated."""
+
+    def test_ws_without_bearer_is_rejected(self) -> None:
+        """No Bearer token → connection is closed, message not dispatched.
+
+        This is the core regression for B4/BUG #4: previously the envelope
+        reached the handler and returned a ``task.response`` even though the
+        HTTP path would have returned 401.
+        """
+        key = jwk.RSAKey.generate_key(2048, private=True)
+        key_set = jwk.KeySet.import_key_set({"keys": [key.as_dict(private=False)]})
+        app = _make_oauth2_app(key_set)
+
+        from fastapi.websockets import WebSocketDisconnect
+
+        with TestClient(app) as client, client.websocket_connect("/asap/ws") as websocket:
+            websocket.send_text(_task_request_body())
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                websocket.receive_text()
+            # B4 closes with WS_CLOSE_AUTH_REQUIRED (4401). Assert it specifically so a
+            # regression to a rate-limit close (1008) or a silent dispatch is caught
+            # (review follow-up: the loose {4401, 1008, None} set hid such regressions).
+            assert exc_info.value.code == WS_CLOSE_AUTH_REQUIRED
+
+    def test_ws_with_valid_bearer_is_admitted(self) -> None:
+        """A valid Bearer JWT lets the connection through and dispatches the envelope."""
+        key = jwk.RSAKey.generate_key(2048, private=True)
+        key_set = jwk.KeySet.import_key_set({"keys": [key.as_dict(private=False)]})
+        app = _make_oauth2_app(key_set)
+        token = _mint_valid_jwt(key)
+
+        with (
+            TestClient(app) as client,
+            client.websocket_connect(
+                "/asap/ws", headers={"Authorization": f"Bearer {token}"}
+            ) as websocket,
+        ):
+            websocket.send_text(_task_request_body())
+            response_text = websocket.receive_text()
+
+        data = json.loads(response_text)
+        assert data.get("jsonrpc") == "2.0"
+        assert "result" in data
+        assert data["result"]["envelope"].get("payload_type") == "task.response"
+
+    def test_ws_with_invalid_bearer_is_rejected(self) -> None:
+        """A malformed/garbage Bearer token is rejected just like a missing one."""
+        key = jwk.RSAKey.generate_key(2048, private=True)
+        key_set = jwk.KeySet.import_key_set({"keys": [key.as_dict(private=False)]})
+        app = _make_oauth2_app(key_set)
+
+        from fastapi.websockets import WebSocketDisconnect
+
+        with (
+            TestClient(app) as client,
+            client.websocket_connect(
+                "/asap/ws", headers={"Authorization": "Bearer not-a-jwt"}
+            ) as websocket,
+        ):
+            websocket.send_text(_task_request_body())
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                websocket.receive_text()
+            # B4 closes with WS_CLOSE_AUTH_REQUIRED (4401) for any auth failure
+            # (missing OR invalid token). Assert the specific code so a regression
+            # to a silent dispatch or a different close code is caught.
+            assert exc_info.value.code == WS_CLOSE_AUTH_REQUIRED


### PR DESCRIPTION
## Summary

Sprint S0 of the v2.5.1 Thermo-Nuclear Patch: validated P0 correctness/security blockers + test prerequisites that gate S2's decomposition. All fixes are TDD (failing regression test first, then fix, red→green) and surgical — no wire-protocol, manifest schema, or public API breaking changes.

**6 P0 bugs fixed + 2 test prerequisites landed**, across 8 atomic commits.

### Fixes (B1–B6)
- **B1 (economics)** — `revoke_cascade` is now atomic: base class delegates to a per-subclass `_revoke_cascade_atomic` hook; SQLite uses one connection + `BEGIN`/`COMMIT`/`rollback`; `InMemoryDelegationStorage` gains an `asyncio.Lock` (BUG #3) so concurrent `register_issued` can't interleave.
- **B2 (state)** — `usage_events` DDL consolidated to one canonical owner (`state/stores/sqlite.py`, lower layer, no cycle); both indexes (`idx_usage_agent_timestamp`, `idx_usage_consumer_timestamp`) created via `IF NOT EXISTS` regardless of store init order.
- **B3 / BUG #1 (transport, security)** — unified the divergent Host-JWT verifiers into one canonical `verify_host_bearer` in `_auth_helpers.py`; revoked hosts now return 403 on both `/register` and `/reactivate`. **Finding:** the strict verifier's revoked-host 403 branch was dead code (`verify_host_jwt` short-circuits revoked hosts before the caller sees `result.host`), so the weak route returned 401 and the strict 403 never fired — fixed by mapping `error == "host revoked"` → 403.
- **B4 / BUG #4 (transport, security, NEW P0)** — WebSocket bypassed `OAuth2Middleware` (a `BaseHTTPMiddleware` that only runs on the HTTP stack). OAuth2 auth is now enforced explicitly at WS connection acceptance via a shared `validate_bearer_token` pipeline (DRY HTTP/WS); missing/invalid Bearer → close 4401. S2-compatible (auth decided at acceptance, not via `_make_fake_request`).
- **B5 (adapters)** — hoisted the inline `format_www_authenticate_asap` import to module top; made `OpenAPIPathParameterError.__init__` pure via `for_missing`/`for_invalid` factories with call-site validation; `resolve_headers` kept as live documented public API (OA-009) — deleting it would break a documented public surface + 5 tests.
- **B6 / BUG #6 (client, NEW)** — client now binds `response.correlation_id == request.id` at both HTTP `send()` and the WS recv loop, raising a typed `ProtocolCorrelationError` on mismatch. Per protocol semantics (`handlers.py`, `testing/mocks.py`) a response `correlation_id` MUST echo the request envelope `id`.

### Test prerequisites (gate S2)
- **7.1** — `tests/e2e/test_websocket_two_agents.py`: true client↔server WS round-trip regression gate (Bearer-authenticated handshake → `task.request` → correlated `task.response`); protects S2's `websocket.py` decomposition.
- **7.2** — `engineering/code-review/v2.5.1/review-v2.4-v2.5-diff.md`: formal review of `v2.3.0..HEAD` (275 commits) covering the two releases that shipped without a recorded review (v2.4.0 Edge AI Discovery, v2.5.0 MCP Auth Bridge).

### Notable side-effect (B6)
B6 exposed that **4 legacy test mocks diverged from production server correlation semantics** — they echoed `request.correlation_id` instead of `request.id`. Corrected to match `handlers.py:554` / `testing/mocks.py:118`. One chaos test (`test_response_for_different_request`) was explicitly asserting the old buggy behavior (client accepts mismatched correlation); updated to assert the client now REJECTS it (`ProtocolCorrelationError`).

## CI verification (all green on `feat/v2.5.1-s0-p0-fixes`)
- `uv run ruff check .` ✓
- `uv run ruff format --check .` ✓ (477 files)
- `uv run mypy src/ scripts/ tests/` ✓ (440 files)
- `uv run pytest --tb=short --cov=asap --cov-report=xml --cov-fail-under=85` ✓ **3632 passed, 12 skipped, 0 failed** (3614 baseline + 18 new); coverage **93.02%**
- `uv run pip-audit` ✓ no known vulnerabilities

## Test plan (for review)
- [ ] Review each commit independently (8 atomic commits, one per task)
- [ ] Verify B3 security fix: revoked HOST (not agent) → 403 on `/register` + `/reactivate`
- [ ] Verify B4 security fix: WS connection rejected without valid Bearer under `oauth2_config` (close 4401)
- [ ] Verify B6: client rejects mismatched `correlation_id` (HTTP + WS); existing E2E (`test_two_agents_echo_flow`, `test_streaming_pipeline_client_consumes_sse`) still green
- [ ] Confirm no public API break (imports, envelope validation behavior unchanged)
- [ ] Spot-check the 4 corrected test mocks now echo `request.id` (matching `handlers.py`)
- [ ] After approval: merge `--no-ff` into `release/2.5.1` (NOT done in this PR — held for review)

## Notes for reviewers
- `delegation_storage.py` grew to 573 lines (>500 guideline) — justified (Base/InMemory/SQLite trio pattern shared with `sla_storage.py`/`storage.py`); will be absorbed by S1's `AsyncSqliteRepository` consolidation.
- B4 uses a second `OAuth2Middleware` instance on `app.state.oauth2_middleware` (stack instance has no public handle) → 2 JWKS caches; acceptable for S0 (duplicate cache dedup is S3).
- Sprint tracking file (`engineering/tasks/private/...`) is gitignored (local-only planning), so not in this diff.

**Merge target: `release/2.5.1`** (per plan). Merge is **held pending code review** — do not merge until approved.