### PR TITLE
Sprint S1: Storage Consolidation (AsyncSqliteRepository) — v2.5.1

### DIFF
--- a/src/asap/economics/audit.py
+++ b/src/asap/economics/audit.py
@@ -18,7 +18,7 @@ from pydantic import ConfigDict, Field
 
 from asap.models.base import ASAPBaseModel
 from asap.models.ids import generate_id
-from asap.state.stores._sqlite_base import AsyncSqliteRepository
+from asap.state.stores import AsyncSqliteRepository
 
 
 class AuditChainBroken(Exception):
@@ -194,12 +194,17 @@ class SQLiteAuditStore(AsyncSqliteRepository):
     async def _get_connection(self) -> aiosqlite.Connection:
         """Return an open connection the caller must close (unless persistent).
 
-        Thin compatibility shim over the base ``_acquire_connection`` so
-        existing tamper-detection tests can grab a raw connection to mutate
-        rows outside the store API. Schema init is skipped here on purpose:
-        callers always append first, so the table already exists.
+        Test-only escape hatch for the tamper-detection tests, which grab a raw
+        connection to mutate ``audit_log`` rows outside the store API. Ensures
+        the schema exists (so a caller that has not ``append``-ed first still
+        sees the table); WAL pragmas are not re-applied here because
+        ``journal_mode=WAL`` is persistent per file and ``:memory:`` has no WAL.
+        Production code should use ``self._connect()`` / ``self.execute`` /
+        ``self.fetch_*`` instead.
         """
-        return await self._acquire_connection()
+        conn = await self._acquire_connection()
+        await self._ensure_schema(conn)
+        return conn
 
     async def append(self, entry: AuditEntry) -> AuditEntry:
         """Append an entry, linking it to the last stored hash.

--- a/src/asap/economics/audit.py
+++ b/src/asap/economics/audit.py
@@ -13,10 +13,12 @@ import json
 from datetime import datetime
 from typing import Any, Protocol, runtime_checkable
 
+import aiosqlite
 from pydantic import ConfigDict, Field
 
 from asap.models.base import ASAPBaseModel
 from asap.models.ids import generate_id
+from asap.state.stores._sqlite_base import AsyncSqliteRepository
 
 
 class AuditChainBroken(Exception):
@@ -156,102 +158,83 @@ class InMemoryAuditStore:
         return len(self._entries)
 
 
-class SQLiteAuditStore:
+_AUDIT_LOG_DDL = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+    id TEXT NOT NULL UNIQUE,
+    timestamp TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    agent_urn TEXT NOT NULL,
+    details TEXT NOT NULL DEFAULT '{}',
+    prev_hash TEXT NOT NULL DEFAULT '',
+    hash TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_audit_urn ON audit_log(agent_urn);
+CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_log(timestamp);
+"""
+
+
+class SQLiteAuditStore(AsyncSqliteRepository):
     """SQLite-backed audit store with hash chain verification.
 
-    Uses ``aiosqlite`` for async access. The table is lazily created on first
-    use so the store can be instantiated synchronously.
-
-    For ``:memory:`` databases a single persistent connection is kept alive
-    (because each ``aiosqlite.connect(":memory:")`` creates a *new* empty
-    database).  File-backed databases use per-call connections.  An
-    ``asyncio.Lock`` serialises all writes so the hash-chain stays linear.
+    Subclasses :class:`AsyncSqliteRepository` so aiosqlite plumbing, the
+    ``:memory:`` persistent connection, per-path WAL setup, and idempotent
+    schema init are owned by the base. An ``asyncio.Lock`` serialises the
+    logical read-prev-hash-then-write step in :meth:`append` so the hash
+    chain stays linear across concurrent writers (independent of which
+    backend holds the connection).
     """
 
     def __init__(self, db_path: str = ":memory:") -> None:
-        self._db_path = db_path
-        self._lock = asyncio.Lock()
-        self._initialized = False
-        self._persistent_conn: Any | None = None
+        super().__init__(db_path, schema_ddl=_AUDIT_LOG_DDL)
+        # Serialises the read-prev-hash + INSERT of an append so concurrent
+        # appends form one linear hash chain (the base owns connection mgmt).
+        self._lock: asyncio.Lock = asyncio.Lock()
 
-    async def _get_connection(self) -> Any:
-        """Return an open ``aiosqlite`` connection.
+    async def _get_connection(self) -> aiosqlite.Connection:
+        """Return an open connection the caller must close (unless persistent).
 
-        For ``:memory:`` databases the same connection is reused for the
-        lifetime of the store; for file-backed databases a fresh connection
-        is returned (caller must close it).
+        Thin compatibility shim over the base ``_acquire_connection`` so
+        existing tamper-detection tests can grab a raw connection to mutate
+        rows outside the store API. Schema init is skipped here on purpose:
+        callers always append first, so the table already exists.
         """
-        import aiosqlite
-
-        if self._db_path == ":memory:":
-            if self._persistent_conn is None:
-                self._persistent_conn = await aiosqlite.connect(":memory:")
-            return self._persistent_conn
-        return await aiosqlite.connect(self._db_path)
-
-    async def _release_connection(self, conn: Any) -> None:
-        """Close *conn* unless it is the persistent in-memory connection."""
-        if conn is not self._persistent_conn:
-            await conn.close()
-
-    async def _ensure_table(self, conn: Any) -> None:
-        """Create the audit_log table and indexes if they don't exist yet."""
-        if self._initialized:
-            return
-        await conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS audit_log (
-                rowid INTEGER PRIMARY KEY AUTOINCREMENT,
-                id TEXT NOT NULL UNIQUE,
-                timestamp TEXT NOT NULL,
-                operation TEXT NOT NULL,
-                agent_urn TEXT NOT NULL,
-                details TEXT NOT NULL DEFAULT '{}',
-                prev_hash TEXT NOT NULL DEFAULT '',
-                hash TEXT NOT NULL DEFAULT ''
-            )
-            """
-        )
-        await conn.execute("CREATE INDEX IF NOT EXISTS idx_audit_urn ON audit_log(agent_urn)")
-        await conn.execute("CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_log(timestamp)")
-        await conn.commit()
-        self._initialized = True
+        return await self._acquire_connection()
 
     async def append(self, entry: AuditEntry) -> AuditEntry:
-        """Append an entry, linking it to the last stored hash."""
-        async with self._lock:
-            conn = await self._get_connection()
-            try:
-                await self._ensure_table(conn)
-                cursor = await conn.execute(
-                    "SELECT hash FROM audit_log ORDER BY rowid DESC LIMIT 1"
-                )
-                row = await cursor.fetchone()
-                prev_hash = row[0] if row else ""
+        """Append an entry, linking it to the last stored hash.
 
-                computed_hash = compute_entry_hash(
-                    prev_hash, entry.timestamp, entry.operation, entry.details
-                )
-                sealed = entry.model_copy(update={"prev_hash": prev_hash, "hash": computed_hash})
+        The ``self._lock`` serialises the read-prev-hash + INSERT so
+        concurrent appends form a single linear chain; ``self._connect``
+        owns the connection lifecycle (persistent for ``:memory:``,
+        per-call WAL connection for files).
+        """
+        async with self._lock, self._connect() as conn:
+            cursor = await conn.execute("SELECT hash FROM audit_log ORDER BY rowid DESC LIMIT 1")
+            row = await cursor.fetchone()
+            prev_hash = row[0] if row else ""
 
-                await conn.execute(
-                    """
-                    INSERT INTO audit_log (id, timestamp, operation, agent_urn, details, prev_hash, hash)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        sealed.id,
-                        sealed.timestamp.isoformat(),
-                        sealed.operation,
-                        sealed.agent_urn,
-                        json.dumps(sealed.details, sort_keys=True, default=str),
-                        sealed.prev_hash,
-                        sealed.hash,
-                    ),
-                )
-                await conn.commit()
-            finally:
-                await self._release_connection(conn)
+            computed_hash = compute_entry_hash(
+                prev_hash, entry.timestamp, entry.operation, entry.details
+            )
+            sealed = entry.model_copy(update={"prev_hash": prev_hash, "hash": computed_hash})
+
+            await conn.execute(
+                """
+                INSERT INTO audit_log (id, timestamp, operation, agent_urn, details, prev_hash, hash)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    sealed.id,
+                    sealed.timestamp.isoformat(),
+                    sealed.operation,
+                    sealed.agent_urn,
+                    json.dumps(sealed.details, sort_keys=True, default=str),
+                    sealed.prev_hash,
+                    sealed.hash,
+                ),
+            )
+            await conn.commit()
         return sealed
 
     async def query(
@@ -283,9 +266,7 @@ class SQLiteAuditStore:
         params.extend([limit, offset])
 
         entries: list[AuditEntry] = []
-        conn = await self._get_connection()
-        try:
-            await self._ensure_table(conn)
+        async with self._connect() as conn:
             cursor = await conn.execute(sql, params)
             rows = await cursor.fetchall()
             for row in rows:
@@ -300,16 +281,12 @@ class SQLiteAuditStore:
                         hash=row[6],
                     )
                 )
-        finally:
-            await self._release_connection(conn)
         return entries
 
     async def verify_chain(self) -> bool:
         """Verify every hash link in insertion order."""
         prev_hash = ""
-        conn = await self._get_connection()
-        try:
-            await self._ensure_table(conn)
+        async with self._connect() as conn:
             cursor = await conn.execute(
                 "SELECT timestamp, operation, details, prev_hash, hash "
                 "FROM audit_log ORDER BY rowid"
@@ -326,17 +303,9 @@ class SQLiteAuditStore:
                 if stored_hash != expected or stored_prev != prev_hash:
                     return False
                 prev_hash = stored_hash
-        finally:
-            await self._release_connection(conn)
         return True
 
     async def count(self) -> int:
         """Return total number of stored entries."""
-        conn = await self._get_connection()
-        try:
-            await self._ensure_table(conn)
-            cursor = await conn.execute("SELECT COUNT(*) FROM audit_log")
-            row = await cursor.fetchone()
-            return row[0] if row else 0
-        finally:
-            await self._release_connection(conn)
+        row = await self.fetch_one("SELECT COUNT(*) FROM audit_log")
+        return row[0] if row else 0

--- a/src/asap/economics/delegation_storage.py
+++ b/src/asap/economics/delegation_storage.py
@@ -20,12 +20,8 @@ from typing import Protocol, runtime_checkable
 
 import aiosqlite
 
-from asap.state.stores._sqlite_base import (
-    DEFAULT_DB_PATH,
-    AsyncSqliteRepository,
-    _build_sql_in_placeholders,
-    parse_iso,
-)
+from asap.state.stores import DEFAULT_DB_PATH, AsyncSqliteRepository, parse_iso
+from asap.state.stores._sqlite_base import _build_sql_in_placeholders
 
 # Maximum cascade depth to prevent stack overflow / DoS from circular chains.
 _MAX_CASCADE_DEPTH = 50

--- a/src/asap/economics/delegation_storage.py
+++ b/src/asap/economics/delegation_storage.py
@@ -4,7 +4,9 @@ Persistent storage for revoked delegation token IDs. Used to enforce
 immediate revocation: validation checks DelegationStorage.is_revoked(token_id)
 before accepting a delegation token.
 
-Table: revocations (id, revoked_at, reason). Persists across restarts.
+Tables: ``revocations`` (id, revoked_at, reason) and ``issued_delegations``
+(id, delegator_urn, delegate_urn, created_at). Both persist across restarts
+and share the canonical SQLite plumbing from :class:`AsyncSqliteRepository`.
 """
 
 from __future__ import annotations
@@ -17,6 +19,34 @@ from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 import aiosqlite
+
+from asap.state.stores._sqlite_base import (
+    DEFAULT_DB_PATH,
+    AsyncSqliteRepository,
+    _build_sql_in_placeholders,
+    parse_iso,
+)
+
+# Maximum cascade depth to prevent stack overflow / DoS from circular chains.
+_MAX_CASCADE_DEPTH = 50
+
+_SCHEMA_DDL = """
+CREATE TABLE IF NOT EXISTS revocations (
+    id TEXT PRIMARY KEY,
+    revoked_at TEXT NOT NULL,
+    reason TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_revocations_revoked_at
+    ON revocations (revoked_at);
+CREATE TABLE IF NOT EXISTS issued_delegations (
+    id TEXT PRIMARY KEY,
+    delegator_urn TEXT NOT NULL,
+    delegate_urn TEXT,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_issued_delegator
+    ON issued_delegations (delegator_urn);
+"""
 
 
 @dataclass(frozen=True)
@@ -34,24 +64,6 @@ class TokenDetail:
     created_at: datetime
     is_revoked: bool
     revoked_at: datetime | None
-
-
-# Same default DB path as metering for a single shared SQLite file.
-_DEFAULT_DB_PATH = "asap_state.db"
-# Maximum cascade depth to prevent stack overflow / DoS from circular chains.
-_MAX_CASCADE_DEPTH = 50
-
-
-def _assert_sql_in_placeholders(placeholders: str) -> str:
-    """Fail closed when dynamic IN-clause placeholders are not ``?,?,…`` only."""
-    if set(placeholders) - {"?", ","}:
-        raise ValueError("placeholders must be `?,?,…` only")
-    return placeholders
-
-
-def _build_sql_in_placeholders(count: int) -> str:
-    """Build ``?,?,…`` placeholders for SQLite ``IN`` clauses."""
-    return _assert_sql_in_placeholders(",".join("?" for _ in range(count)))
 
 
 @runtime_checkable
@@ -271,59 +283,46 @@ class InMemoryDelegationStorage(DelegationStorageBase):
                 self._revoked[tid] = (datetime.now(timezone.utc), reason)
 
 
-class SQLiteDelegationStorage(DelegationStorageBase):
+class SQLiteDelegationStorage(AsyncSqliteRepository, DelegationStorageBase):
     """SQLite-backed revocation storage. Survives restarts.
 
-    Uses table revocations (id TEXT PRIMARY KEY, revoked_at TEXT, reason TEXT).
-    Shares the same DB file as metering/state when using the default path.
+    Subclasses :class:`AsyncSqliteRepository` for connection lifecycle, WAL
+    pragmas, idempotent schema init, and the ``transaction()`` context manager
+    used by the atomic cascade. Shares the same DB file as metering/state when
+    using the default path.
     """
 
-    def __init__(self, db_path: str | Path = _DEFAULT_DB_PATH) -> None:
-        self._db_path = Path(db_path)
-        self._initialized = False
+    def __init__(self, db_path: str | Path = DEFAULT_DB_PATH) -> None:
+        super().__init__(db_path, schema_ddl=_SCHEMA_DDL)
+        # Guard for the one-time delegate_urn back-migration; the base's
+        # ``_initialized`` only covers the CREATE TABLE/INDEX DDL.
+        self._migration_done = False
 
-    async def _ensure_tables(self, conn: aiosqlite.Connection) -> None:
-        if self._initialized:
+    async def _ensure_schema(self, conn: aiosqlite.Connection) -> None:
+        """Run the shared DDL, then back-migrate ``delegate_urn`` once.
+
+        ``executescript`` cannot mix ``PRAGMA table_info`` with a conditional
+        ``ALTER``, so the CREATE/INDEX DDL goes through the base and the
+        legacy-column migration runs once under the same per-instance lock.
+        """
+        await super()._ensure_schema(conn)
+        if self._migration_done:
             return
-        await conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS revocations (
-                id TEXT PRIMARY KEY,
-                revoked_at TEXT NOT NULL,
-                reason TEXT
-            )
-            """
-        )
-        await conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_revocations_revoked_at
-            ON revocations (revoked_at)
-            """
-        )
-        await conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS issued_delegations (
-                id TEXT PRIMARY KEY,
-                delegator_urn TEXT NOT NULL,
-                delegate_urn TEXT,
-                created_at TEXT NOT NULL
-            )
-            """
-        )
-        await conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_issued_delegator
-            ON issued_delegations (delegator_urn)
-            """
-        )
-        # Migrate existing DBs: add delegate_urn if missing (for cascade).
+        async with self._init_lock:
+            if self._migration_done:
+                return
+            await self._migrate_issued_delegations(conn)
+            self._migration_done = True
+
+    @staticmethod
+    async def _migrate_issued_delegations(conn: aiosqlite.Connection) -> None:
+        """Add ``delegate_urn`` to legacy DBs that predate the column."""
         cursor = await conn.execute("PRAGMA table_info(issued_delegations)")
         rows = await cursor.fetchall()
         columns = [row[1] for row in rows] if rows else []
         if "delegate_urn" not in columns:
             await conn.execute("ALTER TABLE issued_delegations ADD COLUMN delegate_urn TEXT")
-        await conn.commit()
-        self._initialized = True
+            await conn.commit()
 
     async def revoke(
         self,
@@ -331,16 +330,10 @@ class SQLiteDelegationStorage(DelegationStorageBase):
         reason: str | None = None,
     ) -> None:
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            await conn.execute(
-                """
-                INSERT OR REPLACE INTO revocations (id, revoked_at, reason)
-                VALUES (?, ?, ?)
-                """,
-                (token_id, now, reason),
-            )
-            await conn.commit()
+        await self.execute(
+            "INSERT OR REPLACE INTO revocations (id, revoked_at, reason) VALUES (?, ?, ?)",
+            (token_id, now, reason),
+        )
 
     async def _revoke_on_conn(
         self,
@@ -351,15 +344,11 @@ class SQLiteDelegationStorage(DelegationStorageBase):
         """Insert a revocation row on a shared connection (no commit).
 
         Used by :meth:`_revoke_cascade_atomic` so every per-id revoke in a
-        cascade shares one transaction boundary; the caller controls COMMIT /
-        ROLLBACK.
+        cascade shares one transaction boundary owned by ``self.transaction()``.
         """
         now = datetime.now(timezone.utc).isoformat()
         await conn.execute(
-            """
-            INSERT OR REPLACE INTO revocations (id, revoked_at, reason)
-            VALUES (?, ?, ?)
-            """,
+            "INSERT OR REPLACE INTO revocations (id, revoked_at, reason) VALUES (?, ?, ?)",
             (token_id, now, reason),
         )
 
@@ -368,58 +357,39 @@ class SQLiteDelegationStorage(DelegationStorageBase):
         token_id: str,
         reason: str | None = None,
     ) -> None:
-        """Single-connection, single-transaction cascade.
+        """Single-transaction cascade using the shared ``transaction()`` base.
 
-        Opens ONE ``aiosqlite.connect``, walks the delegation tree with
-        conn-scoped reads, and inserts every revocation on that connection.
-        COMMIT happens only after the full walk succeeds; any exception
-        propagates and the ``async with`` block closes the connection without
-        committing, so SQLite discards the uncommitted rows (atomic rollback).
+        Walks the delegation tree with conn-scoped reads and inserts every
+        revocation on that one connection. The base commits on success and
+        rolls back on any exception, so a mid-cascade crash leaves no partial
+        revocation state (the S0 B1 atomicity invariant).
         """
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            await conn.execute("BEGIN")
-            try:
-                visited: set[str] = set()
-                stack: list[tuple[str, int]] = [(token_id, 0)]
-                while stack:
-                    tid, depth = stack.pop()
-                    if tid in visited or depth > _MAX_CASCADE_DEPTH:
-                        continue
-                    visited.add(tid)
+        async with self.transaction() as conn:
+            visited: set[str] = set()
+            stack: list[tuple[str, int]] = [(token_id, 0)]
+            while stack:
+                tid, depth = stack.pop()
+                if tid in visited or depth > _MAX_CASCADE_DEPTH:
+                    continue
+                visited.add(tid)
+                cursor = await conn.execute(
+                    "SELECT delegate_urn FROM issued_delegations WHERE id = ?",
+                    (tid,),
+                )
+                row = await cursor.fetchone()
+                delegate_urn = str(row[0]) if row and row[0] else None
+                if delegate_urn:
                     cursor = await conn.execute(
-                        "SELECT delegate_urn FROM issued_delegations WHERE id = ?",
-                        (tid,),
+                        "SELECT id FROM issued_delegations WHERE delegator_urn = ?",
+                        (delegate_urn,),
                     )
-                    row = await cursor.fetchone()
-                    delegate_urn = str(row[0]) if row and row[0] else None
-                    if delegate_urn:
-                        cursor = await conn.execute(
-                            "SELECT id FROM issued_delegations WHERE delegator_urn = ?",
-                            (delegate_urn,),
-                        )
-                        child_rows = await cursor.fetchall()
-                        for child_row in child_rows:
-                            stack.append((str(child_row[0]), depth + 1))
-                    await self._revoke_on_conn(conn, tid, reason)
-                await conn.commit()
-            except BaseException:
-                # Roll back any pending writes so a mid-cascade crash leaves
-                # no partial revocation state. Re-raise to surface the error.
-                await conn.rollback()
-                raise
+                    for child_row in await cursor.fetchall():
+                        stack.append((str(child_row[0]), depth + 1))
+                await self._revoke_on_conn(conn, tid, reason)
 
     async def is_revoked(self, token_id: str) -> bool:
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            cursor = await conn.execute(
-                """
-                SELECT 1 FROM revocations WHERE id = ?
-                """,
-                (token_id,),
-            )
-            row = await cursor.fetchone()
-            return row is not None
+        row = await self.fetch_one("SELECT 1 FROM revocations WHERE id = ?", (token_id,))
+        return row is not None
 
     async def register_issued(
         self,
@@ -428,146 +398,85 @@ class SQLiteDelegationStorage(DelegationStorageBase):
         delegate_urn: str | None = None,
     ) -> None:
         now = datetime.now(timezone.utc).isoformat()
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            await conn.execute(
-                """
-                INSERT OR REPLACE INTO issued_delegations (id, delegator_urn, delegate_urn, created_at)
-                VALUES (?, ?, ?, ?)
-                """,
-                (token_id, delegator_urn, delegate_urn, now),
-            )
-            await conn.commit()
+        await self.execute(
+            "INSERT OR REPLACE INTO issued_delegations "
+            "(id, delegator_urn, delegate_urn, created_at) VALUES (?, ?, ?, ?)",
+            (token_id, delegator_urn, delegate_urn, now),
+        )
 
     async def get_delegator(self, token_id: str) -> str | None:
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            cursor = await conn.execute(
-                """
-                SELECT delegator_urn FROM issued_delegations WHERE id = ?
-                """,
-                (token_id,),
-            )
-            row = await cursor.fetchone()
-            return str(row[0]) if row and row[0] else None
+        row = await self.fetch_one(
+            "SELECT delegator_urn FROM issued_delegations WHERE id = ?", (token_id,)
+        )
+        return str(row[0]) if row and row[0] else None
 
     async def get_delegate(self, token_id: str) -> str | None:
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            cursor = await conn.execute(
-                """
-                SELECT delegate_urn FROM issued_delegations WHERE id = ?
-                """,
-                (token_id,),
-            )
-            row = await cursor.fetchone()
-            return str(row[0]) if row and row[0] else None
+        row = await self.fetch_one(
+            "SELECT delegate_urn FROM issued_delegations WHERE id = ?", (token_id,)
+        )
+        return str(row[0]) if row and row[0] else None
 
     async def list_token_ids_issued_by(self, delegator_urn: str) -> list[str]:
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            cursor = await conn.execute(
-                """
-                SELECT id FROM issued_delegations WHERE delegator_urn = ?
-                """,
-                (delegator_urn,),
-            )
-            rows = await cursor.fetchall()
-            return [str(r[0]) for r in rows] if rows else []
-
-    def _parse_iso_datetime(self, value: str | None) -> datetime | None:
-        if value is None or not value:
-            return None
-        try:
-            return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-        except (ValueError, TypeError):
-            return None
+        rows = await self.fetch_all(
+            "SELECT id FROM issued_delegations WHERE delegator_urn = ?", (delegator_urn,)
+        )
+        return [str(r[0]) for r in rows]
 
     async def list_issued_summaries(self, delegator_urn: str) -> list[IssuedSummary]:
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            cursor = await conn.execute(
-                """
-                SELECT id, delegate_urn, created_at FROM issued_delegations
-                WHERE delegator_urn = ?
-                ORDER BY created_at DESC
-                """,
-                (delegator_urn,),
-            )
-            rows = await cursor.fetchall()
+        rows = await self.fetch_all(
+            "SELECT id, delegate_urn, created_at FROM issued_delegations "
+            "WHERE delegator_urn = ? ORDER BY created_at DESC",
+            (delegator_urn,),
+        )
         return [
             IssuedSummary(
                 id=str(r[0]),
                 delegate_urn=str(r[1]) if r[1] else None,
-                created_at=self._parse_iso_datetime(str(r[2])) or datetime.now(timezone.utc),
+                created_at=parse_iso(str(r[2])) or datetime.now(timezone.utc),
             )
             for r in rows
         ]
 
     async def get_issued_at(self, token_id: str) -> datetime | None:
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            cursor = await conn.execute(
-                """
-                SELECT created_at FROM issued_delegations WHERE id = ?
-                """,
-                (token_id,),
-            )
-            row = await cursor.fetchone()
-        return self._parse_iso_datetime(str(row[0]) if row and row[0] else None)
+        row = await self.fetch_one(
+            "SELECT created_at FROM issued_delegations WHERE id = ?", (token_id,)
+        )
+        return parse_iso(str(row[0]) if row and row[0] else None)
 
     async def get_revoked_at(self, token_id: str) -> datetime | None:
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            cursor = await conn.execute(
-                """
-                SELECT revoked_at FROM revocations WHERE id = ?
-                """,
-                (token_id,),
-            )
-            row = await cursor.fetchone()
-        return self._parse_iso_datetime(str(row[0]) if row and row[0] else None)
+        row = await self.fetch_one("SELECT revoked_at FROM revocations WHERE id = ?", (token_id,))
+        return parse_iso(str(row[0]) if row and row[0] else None)
 
     async def are_revoked(self, token_ids: list[str]) -> dict[str, bool]:
         """Batch revocation check in a single query."""
         if not token_ids:
             return {}
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            # ``placeholders`` is built from ``len(token_ids)`` and can only contain ``?`` and
-            # ``,``; every value comes through the tuple passed to ``execute``. SQLite does
-            # not support binding a list to a single parameter, so dynamic SQL is required.
-            placeholders = _build_sql_in_placeholders(len(token_ids))
-            cursor = await conn.execute(
-                f"SELECT id FROM revocations WHERE id IN ({placeholders})",  # nosec B608 - placeholders asserted to be `?,?,…`; values parameterized
-                token_ids,
-            )
-            revoked_rows = await cursor.fetchall()
-        revoked_ids = {str(r[0]) for r in revoked_rows}
+        # ``placeholders`` is built from ``len(token_ids)`` and can only contain ``?`` and
+        # ``,``; every value comes through the tuple passed to ``execute``. SQLite does
+        # not support binding a list to a single parameter, so dynamic SQL is required.
+        placeholders = _build_sql_in_placeholders(len(token_ids))
+        rows = await self.fetch_all(
+            f"SELECT id FROM revocations WHERE id IN ({placeholders})",  # nosec B608 - placeholders asserted to be `?,?,…`; values parameterized
+            tuple(token_ids),
+        )
+        revoked_ids = {str(r[0]) for r in rows}
         return {tid: tid in revoked_ids for tid in token_ids}
 
     async def get_token_detail(self, token_id: str) -> TokenDetail | None:
         """Fetch all token details in a single connection (LEFT JOIN)."""
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            cursor = await conn.execute(
-                """
-                SELECT i.id, i.delegator_urn, i.delegate_urn, i.created_at,
-                       r.revoked_at
-                FROM issued_delegations i
-                LEFT JOIN revocations r ON i.id = r.id
-                WHERE i.id = ?
-                """,
-                (token_id,),
-            )
-            row = await cursor.fetchone()
+        row = await self.fetch_one(
+            "SELECT i.id, i.delegator_urn, i.delegate_urn, i.created_at, r.revoked_at "
+            "FROM issued_delegations i "
+            "LEFT JOIN revocations r ON i.id = r.id WHERE i.id = ?",
+            (token_id,),
+        )
         if not row:
             return None
         return TokenDetail(
             id=str(row[0]),
             delegator_urn=str(row[1]),
             delegate_urn=str(row[2]) if row[2] else None,
-            created_at=self._parse_iso_datetime(str(row[3])) or datetime.now(timezone.utc),
+            created_at=parse_iso(str(row[3])) or datetime.now(timezone.utc),
             is_revoked=row[4] is not None,
-            revoked_at=self._parse_iso_datetime(str(row[4])) if row[4] else None,
+            revoked_at=parse_iso(str(row[4])) if row[4] else None,
         )

--- a/src/asap/economics/sla_storage.py
+++ b/src/asap/economics/sla_storage.py
@@ -20,12 +20,7 @@ import aiosqlite  # noqa: F401 - retained so tests can patch `sla_storage.aiosql
 
 from asap.economics.metering import StorageStats
 from asap.economics.sla import SLABreach, SLAMetrics
-from asap.state.stores._sqlite_base import (
-    DEFAULT_DB_PATH,
-    AsyncSqliteRepository,
-    build_where,
-    parse_iso,
-)
+from asap.state.stores import DEFAULT_DB_PATH, AsyncSqliteRepository, build_where, parse_iso
 
 # Backward-compat alias: tests/economics/test_sla_storage.py:18 imports
 # `_parse_iso` from this module. The canonical impl now lives in the shared base.

--- a/src/asap/economics/sla_storage.py
+++ b/src/asap/economics/sla_storage.py
@@ -2,6 +2,10 @@
 
 Protocol and implementations (InMemory, SQLite) for SLA metrics and breach
 records. Shares the same SQLite file (asap_state.db) with metering and delegation.
+
+SQLiteSLAStorage (v2.5.1 S1) subclasses :class:`AsyncSqliteRepository`, which owns
+the aiosqlite plumbing, WAL pragmas, schema init, ISO parsing, and WHERE assembly
+once for all persistent stores. The SLA-specific SQL + row mappers live here.
 """
 
 from __future__ import annotations
@@ -10,14 +14,65 @@ import asyncio
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
-import aiosqlite
+import aiosqlite  # noqa: F401 - retained so tests can patch `sla_storage.aiosqlite.connect`
 
 from asap.economics.metering import StorageStats
 from asap.economics.sla import SLABreach, SLAMetrics
+from asap.state.stores._sqlite_base import (
+    DEFAULT_DB_PATH,
+    AsyncSqliteRepository,
+    build_where,
+    parse_iso,
+)
 
-_DEFAULT_DB_PATH = "asap_state.db"
+# Backward-compat alias: tests/economics/test_sla_storage.py:18 imports
+# `_parse_iso` from this module. The canonical impl now lives in the shared base.
+_parse_iso = parse_iso
+
+# WHERE allow-lists for the SLA query methods (fragments are compile-time
+# constants; values are bound via params in build_where — never interpolated).
+_METRICS_WHERE: dict[str, str] = {
+    "agent_id": "agent_id = ?",
+    "start": "period_end >= ?",
+    "end": "period_start <= ?",
+}
+_BREACH_WHERE: dict[str, str] = {
+    "agent_id": "agent_id = ?",
+    "start": "detected_at >= ?",
+    "end": "detected_at <= ?",
+}
+
+# Canonical SLA schema (both tables + both indexes); the base runs it
+# idempotently under the per-instance lock.
+_SLA_SCHEMA_DDL = """
+CREATE TABLE IF NOT EXISTS sla_metrics (
+    agent_id TEXT NOT NULL,
+    period_start TEXT NOT NULL,
+    period_end TEXT NOT NULL,
+    uptime_percent REAL NOT NULL,
+    latency_p95_ms INTEGER NOT NULL,
+    error_rate_percent REAL NOT NULL,
+    tasks_completed INTEGER NOT NULL,
+    tasks_failed INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sla_metrics_agent_period
+    ON sla_metrics (agent_id, period_start);
+
+CREATE TABLE IF NOT EXISTS sla_breaches (
+    id TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    breach_type TEXT NOT NULL,
+    threshold TEXT NOT NULL,
+    actual TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    detected_at TEXT NOT NULL,
+    resolved_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_sla_breaches_agent_detected
+    ON sla_breaches (agent_id, detected_at);
+"""
 
 
 @runtime_checkable
@@ -174,91 +229,73 @@ class InMemorySLAStorage(SLAStorageBase):
         )
 
 
-def _parse_iso(s: str | None) -> datetime | None:
-    if not s:
-        return None
-    try:
-        return datetime.fromisoformat(str(s).replace("Z", "+00:00"))
-    except (ValueError, TypeError):
-        return None
+def _metrics_filters(
+    agent_id: str | None, start: datetime | None, end: datetime | None
+) -> dict[str, Any]:
+    """Build the filter dict shared by query_metrics/count_metrics."""
+    return {
+        "agent_id": agent_id,
+        "start": start.isoformat() if start else None,
+        "end": end.isoformat() if end else None,
+    }
 
 
-class SQLiteSLAStorage(SLAStorageBase):
-    """SQLite-backed SLA storage. Tables: sla_metrics, sla_breaches. Shares asap_state.db."""
+def _row_to_metrics(r: tuple[Any, ...]) -> SLAMetrics:
+    # Columns are NOT NULL; the `or now()` fallback only guards corrupted rows
+    # so the non-Optional SLAMetrics fields stay non-None.
+    return SLAMetrics(
+        agent_id=str(r[0]),
+        period_start=parse_iso(str(r[1])) or datetime.now(timezone.utc),
+        period_end=parse_iso(str(r[2])) or datetime.now(timezone.utc),
+        uptime_percent=float(r[3]),
+        latency_p95_ms=int(r[4]),
+        error_rate_percent=float(r[5]),
+        tasks_completed=int(r[6]),
+        tasks_failed=int(r[7]),
+    )
 
-    def __init__(self, db_path: str | Path = _DEFAULT_DB_PATH) -> None:
-        self._db_path = Path(db_path)
-        self._initialized = False
 
-    async def _ensure_tables(self, conn: aiosqlite.Connection) -> None:
-        if self._initialized:
-            return
-        await conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS sla_metrics (
-                agent_id TEXT NOT NULL,
-                period_start TEXT NOT NULL,
-                period_end TEXT NOT NULL,
-                uptime_percent REAL NOT NULL,
-                latency_p95_ms INTEGER NOT NULL,
-                error_rate_percent REAL NOT NULL,
-                tasks_completed INTEGER NOT NULL,
-                tasks_failed INTEGER NOT NULL
-            )
-            """
-        )
-        await conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_sla_metrics_agent_period
-            ON sla_metrics (agent_id, period_start)
-            """
-        )
-        await conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS sla_breaches (
-                id TEXT PRIMARY KEY,
-                agent_id TEXT NOT NULL,
-                breach_type TEXT NOT NULL,
-                threshold TEXT NOT NULL,
-                actual TEXT NOT NULL,
-                severity TEXT NOT NULL,
-                detected_at TEXT NOT NULL,
-                resolved_at TEXT
-            )
-            """
-        )
-        await conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_sla_breaches_agent_detected
-            ON sla_breaches (agent_id, detected_at)
-            """
-        )
-        await conn.commit()
-        self._initialized = True
+def _row_to_breach(r: tuple[Any, ...]) -> SLABreach:
+    # detected_at is NOT NULL (keep fallback); resolved_at is nullable (None passthrough).
+    return SLABreach(
+        id=str(r[0]),
+        agent_id=str(r[1]),
+        breach_type=str(r[2]),
+        threshold=str(r[3]),
+        actual=str(r[4]),
+        severity=str(r[5]),
+        detected_at=parse_iso(str(r[6])) or datetime.now(timezone.utc),
+        resolved_at=parse_iso(str(r[7])) if r[7] else None,
+    )
+
+
+class SQLiteSLAStorage(AsyncSqliteRepository, SLAStorageBase):
+    """SQLite-backed SLA storage. Tables: sla_metrics, sla_breaches. Shares asap_state.db.
+
+    The base owns connection lifecycle, WAL pragmas, idempotent schema init, and
+    the execute/fetch_all/fetch_one helpers; WHERE assembly is routed through
+    build_where so dynamic fragments are allow-list-guarded.
+    """
+
+    def __init__(self, db_path: str | Path = DEFAULT_DB_PATH) -> None:
+        super().__init__(db_path, schema_ddl=_SLA_SCHEMA_DDL)
 
     async def record_metrics(self, metrics: SLAMetrics) -> None:
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            await conn.execute(
-                """
-                INSERT INTO sla_metrics (
-                    agent_id, period_start, period_end,
-                    uptime_percent, latency_p95_ms, error_rate_percent,
-                    tasks_completed, tasks_failed
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    metrics.agent_id,
-                    metrics.period_start.isoformat(),
-                    metrics.period_end.isoformat(),
-                    metrics.uptime_percent,
-                    metrics.latency_p95_ms,
-                    metrics.error_rate_percent,
-                    metrics.tasks_completed,
-                    metrics.tasks_failed,
-                ),
-            )
-            await conn.commit()
+        await self.execute(
+            "INSERT INTO sla_metrics (agent_id, period_start, period_end, "
+            "uptime_percent, latency_p95_ms, error_rate_percent, "
+            "tasks_completed, tasks_failed) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                metrics.agent_id,
+                metrics.period_start.isoformat(),
+                metrics.period_end.isoformat(),
+                metrics.uptime_percent,
+                metrics.latency_p95_ms,
+                metrics.error_rate_percent,
+                metrics.tasks_completed,
+                metrics.tasks_failed,
+            ),
+        )
 
     async def query_metrics(
         self,
@@ -270,41 +307,22 @@ class SQLiteSLAStorage(SLAStorageBase):
     ) -> list[SLAMetrics]:
         if offset < 0:
             raise ValueError("offset must be non-negative")
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            query = "SELECT agent_id, period_start, period_end, uptime_percent, latency_p95_ms, error_rate_percent, tasks_completed, tasks_failed FROM sla_metrics WHERE 1=1"
-            params: list[object] = []
-            if agent_id is not None:
-                query += " AND agent_id = ?"
-                params.append(agent_id)
-            if start is not None:
-                query += " AND period_end >= ?"
-                params.append(start.isoformat())
-            if end is not None:
-                query += " AND period_start <= ?"
-                params.append(end.isoformat())
-            query += " ORDER BY period_start"
-            if limit is not None:
-                query += " LIMIT ? OFFSET ?"
-                params.extend([limit, offset])
-            elif offset > 0:
-                query += " LIMIT -1 OFFSET ?"
-                params.append(offset)
-            cursor = await conn.execute(query, params)
-            rows = await cursor.fetchall()
-        return [
-            SLAMetrics(
-                agent_id=str(r[0]),
-                period_start=_parse_iso(str(r[1])) or datetime.now(timezone.utc),
-                period_end=_parse_iso(str(r[2])) or datetime.now(timezone.utc),
-                uptime_percent=float(r[3]),
-                latency_p95_ms=int(r[4]),
-                error_rate_percent=float(r[5]),
-                tasks_completed=int(r[6]),
-                tasks_failed=int(r[7]),
-            )
-            for r in rows
-        ]
+        where, params = build_where(_metrics_filters(agent_id, start, end), _METRICS_WHERE)
+        # `where` is assembled by build_where from the _METRICS_WHERE allow-list;
+        # values are bound via params — never interpolated into SQL.
+        query = (
+            f"SELECT agent_id, period_start, period_end, uptime_percent, "
+            f"latency_p95_ms, error_rate_percent, tasks_completed, tasks_failed "
+            f"FROM sla_metrics WHERE {where} ORDER BY period_start"  # nosec B608
+        )
+        if limit is not None:
+            query += " LIMIT ? OFFSET ?"
+            params.extend([limit, offset])
+        elif offset > 0:
+            query += " LIMIT -1 OFFSET ?"
+            params.append(offset)
+        rows = await self.fetch_all(query, tuple(params))
+        return [_row_to_metrics(r) for r in rows]
 
     async def count_metrics(
         self,
@@ -312,43 +330,29 @@ class SQLiteSLAStorage(SLAStorageBase):
         start: datetime | None = None,
         end: datetime | None = None,
     ) -> int:
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            query = "SELECT COUNT(*) FROM sla_metrics WHERE 1=1"
-            params: list[object] = []
-            if agent_id is not None:
-                query += " AND agent_id = ?"
-                params.append(agent_id)
-            if start is not None:
-                query += " AND period_end >= ?"
-                params.append(start.isoformat())
-            if end is not None:
-                query += " AND period_start <= ?"
-                params.append(end.isoformat())
-            cursor = await conn.execute(query, params)
-            row = await cursor.fetchone()
-            return int(row[0]) if row else 0
+        where, params = build_where(_metrics_filters(agent_id, start, end), _METRICS_WHERE)
+        row = await self.fetch_one(
+            f"SELECT COUNT(*) FROM sla_metrics WHERE {where}",  # nosec B608
+            tuple(params),
+        )
+        return int(row[0]) if row else 0
 
     async def record_breach(self, breach: SLABreach) -> None:
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            await conn.execute(
-                """
-                INSERT OR REPLACE INTO sla_breaches (id, agent_id, breach_type, threshold, actual, severity, detected_at, resolved_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    breach.id,
-                    breach.agent_id,
-                    breach.breach_type,
-                    breach.threshold,
-                    breach.actual,
-                    breach.severity,
-                    breach.detected_at.isoformat(),
-                    breach.resolved_at.isoformat() if breach.resolved_at else None,
-                ),
-            )
-            await conn.commit()
+        await self.execute(
+            "INSERT OR REPLACE INTO sla_breaches (id, agent_id, breach_type, "
+            "threshold, actual, severity, detected_at, resolved_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                breach.id,
+                breach.agent_id,
+                breach.breach_type,
+                breach.threshold,
+                breach.actual,
+                breach.severity,
+                breach.detected_at.isoformat(),
+                breach.resolved_at.isoformat() if breach.resolved_at else None,
+            ),
+        )
 
     async def query_breaches(
         self,
@@ -356,51 +360,34 @@ class SQLiteSLAStorage(SLAStorageBase):
         start: datetime | None = None,
         end: datetime | None = None,
     ) -> list[SLABreach]:
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            query = "SELECT id, agent_id, breach_type, threshold, actual, severity, detected_at, resolved_at FROM sla_breaches WHERE 1=1"
-            params: list[object] = []
-            if agent_id is not None:
-                query += " AND agent_id = ?"
-                params.append(agent_id)
-            if start is not None:
-                query += " AND detected_at >= ?"
-                params.append(start.isoformat())
-            if end is not None:
-                query += " AND detected_at <= ?"
-                params.append(end.isoformat())
-            query += " ORDER BY detected_at"
-            cursor = await conn.execute(query, params)
-            rows = await cursor.fetchall()
-        return [
-            SLABreach(
-                id=str(r[0]),
-                agent_id=str(r[1]),
-                breach_type=str(r[2]),
-                threshold=str(r[3]),
-                actual=str(r[4]),
-                severity=str(r[5]),
-                detected_at=_parse_iso(str(r[6])) or datetime.now(timezone.utc),
-                resolved_at=_parse_iso(str(r[7])) if r[7] else None,
-            )
-            for r in rows
-        ]
+        filters = {
+            "agent_id": agent_id,
+            "start": start.isoformat() if start else None,
+            "end": end.isoformat() if end else None,
+        }
+        where, params = build_where(filters, _BREACH_WHERE)
+        query = (
+            f"SELECT id, agent_id, breach_type, threshold, actual, severity, "
+            f"detected_at, resolved_at FROM sla_breaches WHERE {where} "
+            f"ORDER BY detected_at"  # nosec B608
+        )
+        rows = await self.fetch_all(query, tuple(params))
+        return [_row_to_breach(r) for r in rows]
 
     async def stats(self) -> StorageStats:
-        async with aiosqlite.connect(self._db_path) as conn:
-            await self._ensure_tables(conn)
-            cursor = await conn.execute("SELECT COUNT(*) FROM sla_metrics")
-            m_count = (await cursor.fetchone() or (0,))[0]
-            cursor = await conn.execute("SELECT COUNT(*) FROM sla_breaches")
-            b_count = (await cursor.fetchone() or (0,))[0]
-            cursor = await conn.execute("SELECT MIN(period_start) FROM sla_metrics")
-            m_oldest = (await cursor.fetchone() or (None,))[0]
-            cursor = await conn.execute("SELECT MIN(detected_at) FROM sla_breaches")
-            b_oldest = (await cursor.fetchone() or (None,))[0]
+        m_count_row = await self.fetch_one("SELECT COUNT(*) FROM sla_metrics")
+        b_count_row = await self.fetch_one("SELECT COUNT(*) FROM sla_breaches")
+        m_oldest_row = await self.fetch_one("SELECT MIN(period_start) FROM sla_metrics")
+        b_oldest_row = await self.fetch_one("SELECT MIN(detected_at) FROM sla_breaches")
+        m_count = int(m_count_row[0]) if m_count_row else 0
+        b_count = int(b_count_row[0]) if b_count_row else 0
         oldest_ts: datetime | None = None
-        for raw in (m_oldest, b_oldest):
+        for raw in (
+            m_oldest_row[0] if m_oldest_row else None,
+            b_oldest_row[0] if b_oldest_row else None,
+        ):
             if raw is not None:
-                dt = _parse_iso(str(raw))
+                dt = parse_iso(str(raw))
                 if dt and (oldest_ts is None or dt < oldest_ts):
                     oldest_ts = dt
         return StorageStats(
@@ -408,3 +395,12 @@ class SQLiteSLAStorage(SLAStorageBase):
             oldest_timestamp=oldest_ts,
             retention_ttl_seconds=None,
         )
+
+
+__all__ = [
+    "SLAStorage",
+    "SLAStorageBase",
+    "InMemorySLAStorage",
+    "SQLiteSLAStorage",
+    "_parse_iso",
+]

--- a/src/asap/economics/storage.py
+++ b/src/asap/economics/storage.py
@@ -41,12 +41,7 @@ from asap.models.ids import generate_id
 # usage_events DDL + repository base here cannot form a cycle. One canonical DDL
 # owner prevents divergent indexes when both stores share asap_state.db; the
 # shared base owns WAL pragmas, ``:memory:`` handling, and idempotent schema init.
-from asap.state.stores._sqlite_base import (
-    DEFAULT_DB_PATH,
-    AsyncSqliteRepository,
-    build_where,
-    parse_iso,
-)
+from asap.state.stores import DEFAULT_DB_PATH, AsyncSqliteRepository, build_where, parse_iso
 from asap.state.stores.sqlite import _USAGE_EVENTS_DDL
 
 UsageAggregate = Union[
@@ -474,14 +469,19 @@ class SQLiteMeteringStorage(AsyncSqliteRepository, MeteringStorageBase):
 
     async def _query_impl(self, filters: MeteringQuery) -> list[UsageMetrics]:
         """Select events matching ``filters`` via the base allow-list WHERE builder."""
-        where, params = _filters_to_where(filters)
-        # Fail-closed: reject any fragment not in _ALLOWED_QUERY_FRAGMENTS (tests
-        # empty the set to verify the guard).
-        fragments = (
-            [fragment.strip() for fragment in where.split(" AND ")] if where != "1=1" else []
-        )
-        if not all(f in self._ALLOWED_QUERY_FRAGMENTS for f in fragments):
+        # Fail-closed: derive the emitted fragments from the non-None filter keys
+        # (rather than splitting the assembled WHERE string, which would be brittle
+        # if a fragment ever embedded " AND "). Tests empty _ALLOWED_QUERY_FRAGMENTS
+        # to verify the guard rejects any fragment outside the allow-list.
+        active_keys = [
+            key
+            for key in ("agent_id", "consumer_id", "task_id", "start", "end")
+            if getattr(filters, key) is not None
+        ]
+        emitted = [_USAGE_EVENTS_WHERE[key] for key in active_keys]
+        if not all(f in self._ALLOWED_QUERY_FRAGMENTS for f in emitted):
             raise ValueError("unexpected WHERE fragment")
+        where, params = _filters_to_where(filters)
         sql = f"""
             {_USAGE_EVENTS_SELECT}
             WHERE {where}

--- a/src/asap/economics/storage.py
+++ b/src/asap/economics/storage.py
@@ -15,15 +15,15 @@ from __future__ import annotations
 import asyncio
 import json
 from abc import ABC, abstractmethod
-from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, Union, cast, runtime_checkable
 
 if TYPE_CHECKING:
-    from asap.state.metering import MeteringStore, UsageAggregate as StateUsageAggregate, UsageEvent
+    # ``MeteringStore`` is referenced only as a string return annotation on the
+    # ``metering_storage_adapter`` compat shim (resolved by mypy via TYPE_CHECKING).
+    from asap.state.metering import MeteringStore
 
-import aiosqlite
 from pydantic import Field
 
 from asap.economics.metering import (
@@ -38,9 +38,16 @@ from asap.models.base import ASAPBaseModel
 from asap.models.ids import generate_id
 
 # State is the lower layer (never imports economics), so importing the shared
-# usage_events DDL helper here cannot form a cycle. Keeping one canonical DDL
-# owner prevents divergent indexes when both stores share asap_state.db.
-from asap.state.stores.sqlite import _ensure_usage_events_schema
+# usage_events DDL + repository base here cannot form a cycle. One canonical DDL
+# owner prevents divergent indexes when both stores share asap_state.db; the
+# shared base owns WAL pragmas, ``:memory:`` handling, and idempotent schema init.
+from asap.state.stores._sqlite_base import (
+    DEFAULT_DB_PATH,
+    AsyncSqliteRepository,
+    build_where,
+    parse_iso,
+)
+from asap.state.stores.sqlite import _USAGE_EVENTS_DDL
 
 UsageAggregate = Union[
     UsageAggregateByAgent,
@@ -330,8 +337,6 @@ class InMemoryMeteringStorage(MeteringStorageBase):
         """Remove events older than retention_ttl_seconds. Returns count removed."""
         if self._retention_ttl_seconds is None:
             return 0
-        from datetime import timedelta, timezone
-
         cutoff = datetime.now(timezone.utc) - timedelta(seconds=self._retention_ttl_seconds)
         cutoff = cutoff.replace(microsecond=0)
         async with self._lock:
@@ -340,88 +345,39 @@ class InMemoryMeteringStorage(MeteringStorageBase):
             return before - len(self._events)
 
 
-# Adapter: MeteringStorage -> MeteringStore (state layer) for handler recording.
+# Compat shim: the MeteringStorage -> MeteringStore bridge now lives in the
+# state foundation layer (``asap.state.metering.MeteringStorageBridge``); this
+# wrapper preserves the public name for existing importers.
 def metering_storage_adapter(storage: MeteringStorage) -> "MeteringStore":
-    """Create MeteringStore adapter wrapping MeteringStorage for use by handlers."""
+    """Create a ``MeteringStore`` view over ``storage`` (delegates to the state bridge)."""
+    from asap.state.metering import MeteringStorageBridge
 
-    class _Adapter:
-        def __init__(self, s: MeteringStorage) -> None:
-            self._storage = s
-
-        async def record(self, event: "UsageEvent") -> None:
-            metrics = UsageMetrics.from_usage_event(event)
-            await self._storage.record(metrics)
-
-        async def query(
-            self,
-            agent_id: str,
-            start: datetime,
-            end: datetime,
-            limit: int | None = None,
-            offset: int = 0,
-        ) -> list["UsageEvent"]:
-            filters = MeteringQuery(
-                agent_id=agent_id,
-                start=start,
-                end=end,
-                limit=limit,
-                offset=offset,
-            )
-            events = await self._storage.query(filters)
-            return [m.to_usage_event() for m in events]
-
-        async def aggregate(self, agent_id: str, period: str) -> "StateUsageAggregate":
-            from asap.economics.metering import UsageAggregateByAgent
-            from asap.state.metering import UsageAggregate as StateUsageAggregate
-
-            filters = _period_to_metering_query(agent_id, period)
-            aggs = await self._storage.aggregate("agent", filters=filters)
-            for a in aggs:
-                if isinstance(a, UsageAggregateByAgent) and a.agent_id == agent_id:
-                    return StateUsageAggregate(
-                        agent_id=a.agent_id,
-                        period=period,
-                        total_tokens=a.total_tokens,
-                        total_duration=a.total_duration_ms,
-                        total_tasks=a.total_tasks,
-                        total_api_calls=a.total_api_calls,
-                    )
-            return StateUsageAggregate(agent_id=agent_id, period=period)
-
-    return _Adapter(storage)
+    return MeteringStorageBridge(storage)
 
 
+# Compat shim: delegates to ``asap.state.metering._period_to_metering_query``.
 def _period_to_metering_query(agent_id: str, period: str) -> MeteringQuery | None:
-    """Convert period string (hour, day, week, today) to MeteringQuery with start/end.
+    """Convert a period string to a ``MeteringQuery`` (delegates to the state helper)."""
+    from asap.state.metering import _period_to_metering_query as _state_helper
 
-    Returns None for unknown periods (no time filter).
-    """
-    from datetime import timedelta, timezone
-
-    now = datetime.now(timezone.utc)
-    if period in ("hour", "h"):
-        start = now - timedelta(hours=1)
-        return MeteringQuery(agent_id=agent_id, start=start, end=now)
-    if period in ("day", "d", "today"):
-        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-        return MeteringQuery(agent_id=agent_id, start=start, end=now)
-    if period in ("week", "w"):
-        start = now - timedelta(weeks=1)
-        return MeteringQuery(agent_id=agent_id, start=start, end=now)
-    # Unknown period: filter by agent_id only (no time range)
-    return MeteringQuery(agent_id=agent_id)
+    return _state_helper(agent_id, period)
 
 
-# SQLite storage constants (aligned with state layer for shared DB).
-_DEFAULT_DB_PATH = "asap_state.db"
-# Safe to use in f-strings: compile-time constant, never user-controlled (no SQL injection).
+# MeteringQuery field -> usage_events WHERE fragment. Values are bound via
+# ``build_where`` params, never interpolated. ``_ALLOWED_QUERY_FRAGMENTS`` is
+# the fail-closed guard tests monkeypatch to verify no fragment leaks.
+_USAGE_EVENTS_WHERE: dict[str, str] = {
+    "agent_id": "agent_id = ?",
+    "consumer_id": "consumer_id = ?",
+    "task_id": "task_id = ?",
+    "start": "timestamp >= ?",
+    "end": "timestamp <= ?",
+}
 
-
-async def _apply_wal_pragmas(conn: aiosqlite.Connection) -> None:
-    """WAL + NORMAL sync for concurrency; busy_timeout to avoid 'database is locked' under load."""
-    await conn.execute("PRAGMA journal_mode=WAL")
-    await conn.execute("PRAGMA synchronous=NORMAL")
-    await conn.execute("PRAGMA busy_timeout=15000")
+# SELECT projection for usage_events (shared by query/aggregate/summary full scans).
+_USAGE_EVENTS_SELECT = (
+    "SELECT id, task_id, agent_id, consumer_id, metrics, timestamp FROM usage_events"
+)
 
 
 def _metrics_to_row(metrics: UsageMetrics, event_id: str) -> tuple[str, str, str, str, str, str]:
@@ -449,7 +405,7 @@ def _row_to_metrics(row: tuple[Any, ...]) -> UsageMetrics:
     """Build UsageMetrics from DB row."""
     _id, task_id, agent_id, consumer_id, metrics_json, ts_str = row
     data = json.loads(metrics_json)
-    ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    ts = datetime.fromisoformat(str(ts_str).replace("Z", "+00:00"))
     return UsageMetrics(
         task_id=task_id,
         agent_id=agent_id,
@@ -462,107 +418,85 @@ def _row_to_metrics(row: tuple[Any, ...]) -> UsageMetrics:
     )
 
 
-class SQLiteMeteringStorage(MeteringStorageBase):
+def _filters_to_where(filters: MeteringQuery) -> tuple[str, list[Any]]:
+    """Map a ``MeteringQuery`` to a WHERE clause via the base allow-list builder.
+
+    Datetimes are isoformatted for SQLite TEXT comparison. ``limit``/``offset``
+    are appended separately by callers (they are not WHERE predicates).
+    """
+    return build_where(
+        {
+            "agent_id": filters.agent_id,
+            "consumer_id": filters.consumer_id,
+            "task_id": filters.task_id,
+            "start": filters.start.isoformat() if filters.start else None,
+            "end": filters.end.isoformat() if filters.end else None,
+        },
+        _USAGE_EVENTS_WHERE,
+    )
+
+
+class SQLiteMeteringStorage(AsyncSqliteRepository, MeteringStorageBase):
     """SQLite-backed MeteringStorage; usage events persist across restarts.
 
-    Uses the same usage_events table as state SQLiteMeteringStore for
-    compatibility. Indexed by agent_id, consumer_id, and timestamp.
-    Optional retention_ttl_seconds for configurable TTL; call purge_expired()
-    periodically to remove old data.
+    Subclasses :class:`AsyncSqliteRepository` so aiosqlite plumbing, WAL pragmas,
+    the ``:memory:`` persistent connection, and idempotent schema init are owned
+    by the shared base. Uses the same ``usage_events`` table as the state
+    ``SQLiteMeteringStore`` (canonical DDL via ``_USAGE_EVENTS_DDL``) for physical
+    compatibility. Optional ``retention_ttl_seconds`` for configurable TTL; call
+    ``purge_expired()`` periodically to remove old data.
     """
 
     def __init__(
         self,
-        db_path: str | Path = _DEFAULT_DB_PATH,
+        db_path: str | Path = DEFAULT_DB_PATH,
         retention_ttl_seconds: int | None = None,
     ) -> None:
-        self._db_path = Path(db_path)
+        super().__init__(db_path, schema_ddl=_USAGE_EVENTS_DDL)
         self._retention_ttl_seconds = retention_ttl_seconds
-        self._initialized = False
-        self._init_lock = asyncio.Lock()
 
-    @asynccontextmanager
-    async def _connect(self) -> Any:
-        """Connection with WAL pragmas applied."""
-        async with aiosqlite.connect(self._db_path) as conn:
-            await _apply_wal_pragmas(conn)
-            yield conn
-
-    async def _ensure_table(self, conn: aiosqlite.Connection) -> None:
-        await _ensure_usage_events_schema(conn)
-
-    async def _ensure_table_once(self, conn: aiosqlite.Connection) -> None:
-        if self._initialized:
-            return
-        async with self._init_lock:
-            if not self._initialized:
-                await self._ensure_table(conn)
-                self._initialized = True
+    # Fail-closed guard: tests monkeypatch this to ``frozenset()`` to verify
+    # ``_query_impl`` rejects any WHERE fragment not in the allow-list.
+    _ALLOWED_QUERY_FRAGMENTS: frozenset[str] = frozenset(_USAGE_EVENTS_WHERE.values())
 
     async def _record_impl(self, metrics: UsageMetrics) -> None:
-        async with self._connect() as conn:
-            await self._ensure_table_once(conn)
-            event_id = f"evt_{generate_id()}"
-            row = _metrics_to_row(metrics, event_id)
-            await conn.execute(
-                """
-                INSERT INTO usage_events
-                (id, task_id, agent_id, consumer_id, metrics, timestamp)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                row,
-            )
-            await conn.commit()
-
-    # Closed set of WHERE clause fragments. Each appends ``?`` placeholders; values are
-    # bound via the ``params`` list, never interpolated. Keeping this as a module-level
-    # frozenset lets the dynamic-SQL builder below assert no unexpected fragment can leak
-    # into the final query even if a future edit forgets to parameterize.
-    _ALLOWED_QUERY_FRAGMENTS: frozenset[str] = frozenset(
-        {
-            "agent_id = ?",
-            "consumer_id = ?",
-            "task_id = ?",
-            "timestamp >= ?",
-            "timestamp <= ?",
-        }
-    )
+        """Insert one usage event row."""
+        event_id = f"evt_{generate_id()}"
+        row = _metrics_to_row(metrics, event_id)
+        await self.execute(
+            """
+            INSERT INTO usage_events
+            (id, task_id, agent_id, consumer_id, metrics, timestamp)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            row,
+        )
 
     async def _query_impl(self, filters: MeteringQuery) -> list[UsageMetrics]:
-        async with self._connect() as conn:
-            await self._ensure_table_once(conn)
-            conditions: list[str] = []
-            params: list[Any] = []
-            if filters.agent_id is not None:
-                conditions.append("agent_id = ?")
-                params.append(filters.agent_id)
-            if filters.consumer_id is not None:
-                conditions.append("consumer_id = ?")
-                params.append(filters.consumer_id)
-            if filters.task_id is not None:
-                conditions.append("task_id = ?")
-                params.append(filters.task_id)
-            if filters.start is not None:
-                conditions.append("timestamp >= ?")
-                params.append(filters.start.isoformat())
-            if filters.end is not None:
-                conditions.append("timestamp <= ?")
-                params.append(filters.end.isoformat())
-            if not all(c in self._ALLOWED_QUERY_FRAGMENTS for c in conditions):
-                raise ValueError("unexpected WHERE fragment")
-            where = " AND ".join(conditions) if conditions else "1=1"
-            sql = f"""
-                SELECT id, task_id, agent_id, consumer_id, metrics, timestamp
-                FROM usage_events
-                WHERE {where}
-                ORDER BY timestamp
-                LIMIT ? OFFSET ?
-            """  # nosec B608 - ``where`` is assembled from _ALLOWED_QUERY_FRAGMENTS only; values parameterized
-            limit_val = filters.limit if filters.limit is not None else -1
-            params.extend([limit_val, filters.offset])
-            cursor = await conn.execute(sql, params)
-            rows = await cursor.fetchall()
-            return [_row_to_metrics(tuple(r)) for r in rows]
+        """Select events matching ``filters`` via the base allow-list WHERE builder."""
+        where, params = _filters_to_where(filters)
+        # Fail-closed: reject any fragment not in _ALLOWED_QUERY_FRAGMENTS (tests
+        # empty the set to verify the guard).
+        fragments = (
+            [fragment.strip() for fragment in where.split(" AND ")] if where != "1=1" else []
+        )
+        if not all(f in self._ALLOWED_QUERY_FRAGMENTS for f in fragments):
+            raise ValueError("unexpected WHERE fragment")
+        sql = f"""
+            {_USAGE_EVENTS_SELECT}
+            WHERE {where}
+            ORDER BY timestamp
+            LIMIT ? OFFSET ?
+        """  # nosec B608 - ``where`` is assembled by build_where from _USAGE_EVENTS_WHERE; values parameterized
+        limit_val = filters.limit if filters.limit is not None else -1
+        params.extend([limit_val, filters.offset])
+        rows = await self.fetch_all(sql, tuple(params))
+        return [_row_to_metrics(r) for r in rows]
+
+    async def _fetch_all_events(self) -> list[UsageMetrics]:
+        """Read every usage_events row (full-table scan path for unfiltered aggregate/summary)."""
+        rows = await self.fetch_all(f"{_USAGE_EVENTS_SELECT} ORDER BY timestamp")  # nosec B608 - static SQL
+        return [_row_to_metrics(r) for r in rows]
 
     async def _aggregate_impl(
         self,
@@ -581,17 +515,7 @@ class SQLiteMeteringStorage(MeteringStorageBase):
             )
             events = await self._query_impl(agg_filters)
         else:
-            async with self._connect() as conn:
-                await self._ensure_table_once(conn)
-                cursor = await conn.execute(
-                    """
-                    SELECT id, task_id, agent_id, consumer_id, metrics, timestamp
-                    FROM usage_events
-                    ORDER BY timestamp
-                    """,
-                )
-                rows = await cursor.fetchall()
-            events = [_row_to_metrics(tuple(r)) for r in rows]
+            events = await self._fetch_all_events()
         return _dispatch_aggregate(events, group_by)
 
     async def record(self, metrics: UsageMetrics) -> None:
@@ -624,17 +548,7 @@ class SQLiteMeteringStorage(MeteringStorageBase):
             )
             events = await self._query_impl(summary_filters)
         else:
-            async with self._connect() as conn:
-                await self._ensure_table_once(conn)
-                cursor = await conn.execute(
-                    """
-                    SELECT id, task_id, agent_id, consumer_id, metrics, timestamp
-                    FROM usage_events
-                    ORDER BY timestamp
-                    """,
-                )
-                rows = await cursor.fetchall()
-            events = [_row_to_metrics(tuple(r)) for r in rows]
+            events = await self._fetch_all_events()
         return _compute_summary(events)
 
     async def summary(self, filters: MeteringQuery | None = None) -> UsageSummary:
@@ -643,19 +557,9 @@ class SQLiteMeteringStorage(MeteringStorageBase):
 
     async def _stats_impl(self) -> StorageStats:
         """Compute storage stats from SQLite."""
-        async with self._connect() as conn:
-            await self._ensure_table_once(conn)
-            cursor = await conn.execute(
-                """
-                SELECT COUNT(*), MIN(timestamp)
-                FROM usage_events
-                """,
-            )
-            row = await cursor.fetchone()
+        row = await self.fetch_one("SELECT COUNT(*), MIN(timestamp) FROM usage_events")
         count = row[0] if row and row[0] is not None else 0
-        oldest_ts: datetime | None = None
-        if row and row[1] is not None:
-            oldest_ts = datetime.fromisoformat(str(row[1]).replace("Z", "+00:00"))
+        oldest_ts = parse_iso(str(row[1])) if row and row[1] is not None else None
         return StorageStats(
             total_events=count,
             oldest_timestamp=oldest_ts,
@@ -670,23 +574,12 @@ class SQLiteMeteringStorage(MeteringStorageBase):
         """Delete events older than retention_ttl_seconds. Returns count removed."""
         if self._retention_ttl_seconds is None:
             return 0
-        from datetime import timedelta, timezone
-
         cutoff = datetime.now(timezone.utc) - timedelta(seconds=self._retention_ttl_seconds)
         cutoff = cutoff.replace(microsecond=0)
-        cutoff_str = cutoff.isoformat()
-        async with self._connect() as conn:
-            await self._ensure_table_once(conn)
-            cursor = await conn.execute(
-                """
-                DELETE FROM usage_events
-                WHERE timestamp < ?
-                """,
-                (cutoff_str,),
-            )
-            deleted = cursor.rowcount if cursor.rowcount is not None else 0
-            await conn.commit()
-            return max(0, deleted)
+        return await self.execute(
+            "DELETE FROM usage_events WHERE timestamp < ?",
+            (cutoff.isoformat(),),
+        )
 
     async def purge_expired(self) -> int:
         """Remove events older than retention_ttl_seconds. Returns count removed."""

--- a/src/asap/state/__init__.py
+++ b/src/asap/state/__init__.py
@@ -13,6 +13,7 @@ from .machine import can_transition, transition
 from .metering import (
     AsyncMeteringStore,
     InMemoryMeteringStore,
+    MeteringStorageBridge,
     MeteringStore,
     UsageAggregate,
     UsageEvent,
@@ -37,6 +38,7 @@ __all__ = [
     "SQLiteMeteringStore",
     "AsyncMeteringStore",
     "MeteringStore",
+    "MeteringStorageBridge",
     "InMemoryMeteringStore",
     "UsageEvent",
     "UsageMetrics",

--- a/src/asap/state/metering.py
+++ b/src/asap/state/metering.py
@@ -14,12 +14,19 @@ from __future__ import annotations
 import asyncio
 import warnings
 from collections.abc import Awaitable
-from datetime import datetime
-from typing import Protocol, runtime_checkable
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from pydantic import Field
 
 from asap.models.base import ASAPBaseModel
+
+if TYPE_CHECKING:
+    # Economics is the higher layer; importing it at runtime from the foundation
+    # layer would form a cycle (economics.storage imports state.stores). The
+    # metering_storage bridge below duck-types the MeteringStorage protocol at
+    # runtime and only needs the type for annotations.
+    from asap.economics.storage import MeteringQuery, MeteringStorage
 
 
 class UsageMetrics(ASAPBaseModel):
@@ -233,9 +240,104 @@ class InMemoryMeteringStore:
         )
 
 
+class MeteringStorageBridge:
+    """Adapt a ``MeteringStorage`` (economics, flat ``UsageMetrics``) to ``MeteringStore``.
+
+    The economics layer's ``MeteringStorage`` records flat ``UsageMetrics`` rows
+    (task_id + agent_id + consumer_id + metrics + timestamp in one model) and
+    exposes a richer query/aggregate/summary/stats/purge API. The state layer's
+    ``MeteringStore`` — consumed by ``handlers.record_task_usage`` — records
+    ``UsageEvent`` (identity + a ``UsageMetrics`` payload + timestamp) and
+    exposes a minimal record/query/aggregate.
+
+    This bridge lets a single ``MeteringStorage`` serve both the Usage REST API
+    (which wants the rich interface) and the handler recording path (which wants
+    ``MeteringStore``), without economics depending on state for the adapter.
+    It replaces the old ``economics.storage.metering_storage_adapter``.
+
+    Example:
+        >>> from asap.economics.storage import InMemoryMeteringStorage
+        >>> bridge = MeteringStorageBridge(InMemoryMeteringStorage())
+        >>> hasattr(bridge, "record") and hasattr(bridge, "query")
+        True
+    """
+
+    def __init__(self, storage: "MeteringStorage") -> None:
+        self._storage = storage
+
+    async def record(self, event: UsageEvent) -> None:
+        """Record a ``UsageEvent`` by flattening it into a ``UsageMetrics`` row."""
+        from asap.economics.metering import UsageMetrics
+
+        await self._storage.record(UsageMetrics.from_usage_event(event))
+
+    async def query(
+        self,
+        agent_id: str,
+        start: datetime,
+        end: datetime,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[UsageEvent]:
+        """Return ``UsageEvent`` rows for ``agent_id`` in ``[start, end]``."""
+        from asap.economics.storage import MeteringQuery
+
+        filters = MeteringQuery(
+            agent_id=agent_id,
+            start=start,
+            end=end,
+            limit=limit,
+            offset=offset,
+        )
+        events = await self._storage.query(filters)
+        return [m.to_usage_event() for m in events]
+
+    async def aggregate(self, agent_id: str, period: str) -> UsageAggregate:
+        """Aggregate usage for ``agent_id`` over ``period`` into a state ``UsageAggregate``."""
+        from asap.economics.metering import UsageAggregateByAgent
+
+        filters = _period_to_metering_query(agent_id, period)
+        aggs = await self._storage.aggregate("agent", filters=filters)
+        for agg in aggs:
+            if isinstance(agg, UsageAggregateByAgent) and agg.agent_id == agent_id:
+                return UsageAggregate(
+                    agent_id=agg.agent_id,
+                    period=period,
+                    total_tokens=agg.total_tokens,
+                    total_duration=agg.total_duration_ms,
+                    total_tasks=agg.total_tasks,
+                    total_api_calls=agg.total_api_calls,
+                )
+        return UsageAggregate(agent_id=agent_id, period=period)
+
+
+def _period_to_metering_query(agent_id: str, period: str) -> "MeteringQuery | None":
+    """Convert a period string (hour/day/week/today) to a ``MeteringQuery`` time window.
+
+    Returns ``None`` for unknown periods so the caller applies agent_id-only
+    filtering (no time range). Mirrors the helper that previously lived in
+    ``economics.storage._period_to_metering_query``; moved here so the bridge is
+    self-contained and economics no longer needs to own the conversion.
+    """
+    from asap.economics.storage import MeteringQuery
+
+    now = datetime.now(timezone.utc)
+    if period in ("hour", "h"):
+        start = now - timedelta(hours=1)
+        return MeteringQuery(agent_id=agent_id, start=start, end=now)
+    if period in ("day", "d", "today"):
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        return MeteringQuery(agent_id=agent_id, start=start, end=now)
+    if period in ("week", "w"):
+        start = now - timedelta(weeks=1)
+        return MeteringQuery(agent_id=agent_id, start=start, end=now)
+    return MeteringQuery(agent_id=agent_id)
+
+
 __all__ = [
     "AsyncMeteringStore",
     "InMemoryMeteringStore",
+    "MeteringStorageBridge",
     "MeteringStore",
     "UsageAggregate",
     "UsageEvent",

--- a/src/asap/state/stores/__init__.py
+++ b/src/asap/state/stores/__init__.py
@@ -13,6 +13,7 @@ import os
 from pathlib import Path
 
 from asap.state.snapshot import SnapshotStore, create_async_snapshot_store
+from asap.state.stores._sqlite_base import DEFAULT_DB_PATH as DEFAULT_DB_PATH
 from asap.state.stores.memory import (
     AsyncInMemorySnapshotStore,
     InMemoryMeteringStore,
@@ -26,7 +27,6 @@ from asap.state.stores.sqlite import (
 
 ASAP_STORAGE_BACKEND_ENV = "ASAP_STORAGE_BACKEND"
 ASAP_STORAGE_PATH_ENV = "ASAP_STORAGE_PATH"
-DEFAULT_DB_PATH = "asap_state.db"
 
 
 def create_snapshot_store() -> SnapshotStore:

--- a/src/asap/state/stores/__init__.py
+++ b/src/asap/state/stores/__init__.py
@@ -13,7 +13,12 @@ import os
 from pathlib import Path
 
 from asap.state.snapshot import SnapshotStore, create_async_snapshot_store
-from asap.state.stores._sqlite_base import DEFAULT_DB_PATH as DEFAULT_DB_PATH
+from asap.state.stores._sqlite_base import (
+    DEFAULT_DB_PATH as DEFAULT_DB_PATH,
+    AsyncSqliteRepository as AsyncSqliteRepository,
+    build_where as build_where,
+    parse_iso as parse_iso,
+)
 from asap.state.stores.memory import (
     AsyncInMemorySnapshotStore,
     InMemoryMeteringStore,
@@ -54,11 +59,14 @@ def create_snapshot_store() -> SnapshotStore:
 
 __all__ = [
     "AsyncInMemorySnapshotStore",
+    "AsyncSqliteRepository",
     "InMemorySnapshotStore",
     "InMemoryMeteringStore",
     "SQLiteAsyncSnapshotStore",
     "SQLiteSnapshotStore",
     "SQLiteMeteringStore",
+    "build_where",
     "create_async_snapshot_store",
     "create_snapshot_store",
+    "parse_iso",
 ]

--- a/src/asap/state/stores/_sqlite_base.py
+++ b/src/asap/state/stores/_sqlite_base.py
@@ -1,0 +1,281 @@
+"""Shared SQLite repository base for ASAP persistent stores (v2.5.1 S1).
+
+One source of truth for aiosqlite connection lifecycle, WAL pragma setup,
+idempotent schema init, WHERE-clause assembly, ISO timestamp parsing, and
+IN-clause placeholders. Subclasses supply ``schema_ddl`` and per-method SQL.
+
+The per-path WAL lock + LRU ``journal_mode`` metadata below serialize concurrent
+openings on the same DB file (``journal_mode=WAL`` raced before the lock).
+
+Example:
+    >>> repo = AsyncSqliteRepository(":memory:", schema_ddl=DDL)
+    >>> await repo.execute("INSERT INTO t(a) VALUES (?)", (1,))
+    1
+    >>> await repo.fetch_one("SELECT a FROM t")
+    (1,)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import weakref
+from collections import OrderedDict
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+# Single canonical default DB path (deletes the 5 copies across stores).
+DEFAULT_DB_PATH = "asap_state.db"
+
+# Per-DB asyncio lock: concurrent openings raced on journal_mode=WAL before the
+# lock existed. Weak values drop entries when locks are collectable (limits
+# growth in long test runs that spin many tmp_path DBs).
+_PRAGMA_SETUP_LOCKS: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
+_PRAGMA_DICT_GUARD = threading.Lock()
+
+# journal_mode=WAL is persistent per DB file; skip redundant SET after first
+# success. LRU-bounded so tmp_path-heavy suites do not grow this map without
+# bound; eviction only loses the in-memory hint (next open may re-run
+# journal_mode=WAL; harmless).
+_MAX_WAL_METADATA_KEYS = 512
+_WAL_INITIALIZED_LRU: OrderedDict[str, None] = OrderedDict()
+
+
+def _pragma_setup_lock(db_path: Path) -> asyncio.Lock:
+    """Per-DB asyncio lock keyed by resolved path (snapshot + metering share it)."""
+    key = str(db_path.resolve())
+    with _PRAGMA_DICT_GUARD:
+        lock = _PRAGMA_SETUP_LOCKS.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _PRAGMA_SETUP_LOCKS[key] = lock
+        return lock
+
+
+def _wal_mark_initialized(db_key: str) -> None:
+    """Record that journal_mode=WAL was applied for this resolved path (LRU-bounded)."""
+    with _PRAGMA_DICT_GUARD:
+        if db_key in _WAL_INITIALIZED_LRU:
+            _WAL_INITIALIZED_LRU.move_to_end(db_key)
+        else:
+            _WAL_INITIALIZED_LRU[db_key] = None
+            while len(_WAL_INITIALIZED_LRU) > _MAX_WAL_METADATA_KEYS:
+                _WAL_INITIALIZED_LRU.popitem(last=False)
+
+
+async def _apply_wal_pragmas(conn: aiosqlite.Connection, db_key: str) -> None:
+    """Apply WAL pragmas; busy_timeout runs before journal_mode to reduce lock errors."""
+    await conn.execute("PRAGMA busy_timeout=15000")
+    with _PRAGMA_DICT_GUARD:
+        need_journal_mode = db_key not in _WAL_INITIALIZED_LRU
+    if need_journal_mode:
+        await conn.execute("PRAGMA journal_mode=WAL")
+        _wal_mark_initialized(db_key)
+    await conn.execute("PRAGMA synchronous=NORMAL")
+
+
+def _assert_sql_in_placeholders(placeholders: str) -> str:
+    """Fail closed when dynamic IN-clause placeholders are not ``?,?,…`` only."""
+    if set(placeholders) - {"?", ","}:
+        raise ValueError("placeholders must be `?,?,…` only")
+    return placeholders
+
+
+def _build_sql_in_placeholders(count: int) -> str:
+    """Build ``?,?,…`` placeholders for SQLite ``IN`` clauses (value-bound)."""
+    return _assert_sql_in_placeholders(",".join("?" for _ in range(count)))
+
+
+def parse_iso(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp stored in SQLite; ``None``/empty -> ``None``.
+
+    Normalizes the trailing ``Z`` (UTC) to ``+00:00`` so ``datetime.fromisoformat``
+    accepts it across Python versions. Returns ``None`` on malformed input rather
+    than raising, so row mappers can treat missing/legacy timestamps uniformly.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def build_where(
+    filters: dict[str, Any],
+    allowed: dict[str, str],
+) -> tuple[str, list[Any]]:
+    """Assemble a WHERE clause from a filter dict against an allow-list.
+
+    ``allowed`` maps a logical filter key to its SQL fragment (e.g.
+    ``{"agent_id": "agent_id = ?", "start": "timestamp >= ?"}``). Filters whose
+    value is ``None`` are skipped. Unknown keys raise ``ValueError`` — this is
+    the allow-list guard that prevents unexpected fragments from leaking into
+    dynamic SQL even if a future edit forgets to parameterize.
+
+    Returns ``(where_sql, params)`` where ``where_sql`` is ``"1=1"`` when no
+    filters apply, suitable for direct interpolation after ``WHERE``. Values are
+    always returned in ``params`` for parameter binding; the SQL fragments in
+    ``allowed`` are a compile-time allow-list, never user-controlled.
+    """
+    conditions: list[str] = []
+    params: list[Any] = []
+    for key, value in filters.items():
+        if value is None:
+            continue
+        fragment = allowed.get(key)
+        if fragment is None:
+            raise ValueError(f"unknown filter {key!r}; allowed keys: {sorted(allowed)!r}")
+        conditions.append(fragment)
+        params.append(value)
+    where = " AND ".join(conditions) if conditions else "1=1"
+    return where, params
+
+
+class AsyncSqliteRepository:
+    """Shared aiosqlite plumbing for ASAP SQLite-backed stores.
+
+    Wraps connection lifecycle (WAL pragmas, per-path lock), idempotent schema
+    init, and the three common query shapes (execute / fetch_all / fetch_one).
+    Subclasses supply ``schema_ddl`` (one ``CREATE TABLE IF NOT EXISTS`` block)
+    and per-method SQL + row mappers; the boilerplate lives here once.
+
+    Atomic multi-step operations use :meth:`transaction`, which opens one
+    connection, issues ``BEGIN``, yields it, and ``COMMIT``s on success or
+    ``ROLLBACK``s on any exception (so a mid-step crash leaves no partial state).
+    """
+
+    def __init__(
+        self,
+        db_path: str | Path = DEFAULT_DB_PATH,
+        schema_ddl: str | None = None,
+    ) -> None:
+        self._db_path = Path(db_path)
+        self._schema_ddl = schema_ddl
+        self._initialized = False
+        self._init_lock = asyncio.Lock()
+        # ``:memory:`` creates a *new* empty DB on every connect, so keep one
+        # persistent connection alive and serialise access to it. File-backed
+        # DBs use per-call connections (handled in ``_connect``). This mirrors
+        # the SQLiteAuditStore pattern and makes ``:memory:`` usable in tests
+        # without each store re-implementing it.
+        self._is_memory = str(db_path) == ":memory:"
+        self._persistent_conn: aiosqlite.Connection | None = None
+        self._memory_lock = asyncio.Lock()
+
+    async def _acquire_connection(self) -> aiosqlite.Connection:
+        """Return an open connection (persistent for ``:memory:``).
+
+        Caller must hold ``_memory_lock`` when ``_is_memory`` is set, so this
+        method does not re-acquire it (``asyncio.Lock`` is non-reentrant).
+        """
+        if self._is_memory:
+            if self._persistent_conn is None:
+                self._persistent_conn = await aiosqlite.connect(":memory:")
+            return self._persistent_conn
+        return await aiosqlite.connect(self._db_path, timeout=15.0)
+
+    async def _release_connection(self, conn: aiosqlite.Connection) -> None:
+        """Close *conn* unless it is the persistent in-memory connection."""
+        if conn is not self._persistent_conn:
+            await conn.close()
+
+    @asynccontextmanager
+    async def _connect(self) -> AsyncIterator[aiosqlite.Connection]:
+        """Yield a connection with WAL pragmas applied (file-backed path only).
+
+        For ``:memory:`` the persistent connection is yielded under
+        ``_memory_lock``; WAL pragmas are skipped (in-memory DBs have no WAL).
+        The caller is released from managing close lifecycle in both cases.
+        """
+        if self._is_memory:
+            async with self._memory_lock:
+                conn = await self._acquire_connection()
+                try:
+                    await self._ensure_schema(conn)
+                    yield conn
+                finally:
+                    # Never close the persistent in-memory connection here.
+                    pass
+            return
+        db_key = str(self._db_path.resolve())
+        conn = await aiosqlite.connect(self._db_path, timeout=15.0)
+        try:
+            async with _pragma_setup_lock(self._db_path):
+                await _apply_wal_pragmas(conn, db_key)
+            await self._ensure_schema(conn)
+            yield conn
+        finally:
+            await conn.close()
+
+    async def _ensure_schema(self, conn: aiosqlite.Connection) -> None:
+        """Apply ``schema_ddl`` once, idempotently, under the per-instance lock."""
+        if self._initialized:
+            return
+        async with self._init_lock:
+            if self._initialized:
+                return
+            if self._schema_ddl:
+                await conn.executescript(self._schema_ddl)
+                await conn.commit()
+            self._initialized = True
+
+    async def execute(self, sql: str, params: tuple[Any, ...] = ()) -> int:
+        """Run a write query; commit; return affected row count (0 if unknown)."""
+        async with self._connect() as conn:
+            cursor = await conn.execute(sql, params)
+            await conn.commit()
+            return cursor.rowcount if cursor.rowcount is not None else 0
+
+    async def fetch_all(
+        self,
+        sql: str,
+        params: tuple[Any, ...] = (),
+    ) -> list[tuple[Any, ...]]:
+        """Run a read query; return all rows as tuples."""
+        async with self._connect() as conn:
+            cursor = await conn.execute(sql, params)
+            rows = await cursor.fetchall()
+            return [tuple(r) for r in rows]
+
+    async def fetch_one(
+        self,
+        sql: str,
+        params: tuple[Any, ...] = (),
+    ) -> tuple[Any, ...] | None:
+        """Run a read query; return the first row as a tuple, or ``None``."""
+        async with self._connect() as conn:
+            cursor = await conn.execute(sql, params)
+            row = await cursor.fetchone()
+            return tuple(row) if row else None
+
+    @asynccontextmanager
+    async def transaction(self) -> AsyncIterator[aiosqlite.Connection]:
+        """Yield one connection inside BEGIN/COMMIT; ROLLBACK on any exception.
+
+        Use for atomic multi-step operations (e.g. cascade revocation). The
+        caller runs reads/writes directly on the yielded ``conn``; the context
+        manager owns the transaction boundary. For ``:memory:`` the persistent
+        connection is reused (so the transaction sees prior writes).
+        """
+        async with self._connect() as conn:
+            await conn.execute("BEGIN")
+            try:
+                yield conn
+                await conn.commit()
+            except BaseException:
+                await conn.rollback()
+                raise
+
+
+__all__ = [
+    "DEFAULT_DB_PATH",
+    "AsyncSqliteRepository",
+    "build_where",
+    "parse_iso",
+]

--- a/src/asap/state/stores/_sync_bridge.py
+++ b/src/asap/state/stores/_sync_bridge.py
@@ -1,0 +1,120 @@
+"""Sync->async bridge for the synchronous :class:`SQLiteSnapshotStore` (v2.5.1 S1).
+
+``SQLiteSnapshotStore`` exposes a *synchronous* :class:`~asap.state.snapshot.SnapshotStore`
+interface but the backend is async (``aiosqlite``); ``_run_sync`` bridges that. When
+no event loop is running it uses ``asyncio.run``; when a loop is running (e.g. inside
+a FastAPI handler) it submits the coroutine to a shared 4-worker thread pool so the
+caller's loop is not blocked and we do not create a per-call executor.
+
+The coroutine wrappers keep a reference to the backend's impl methods so the sync
+store stays a thin facade over the async backend.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import concurrent.futures
+from typing import Any, Protocol, runtime_checkable
+
+from asap.models.entities import StateSnapshot
+from asap.models.types import TaskID
+
+# Shared executor for the sync bridge when called from a running loop. Reused
+# across all DB operations to avoid per-call ThreadPoolExecutor creation.
+_SYNC_BRIDGE_EXECUTOR: concurrent.futures.ThreadPoolExecutor | None = None
+
+
+@runtime_checkable
+class _SnapshotBackendProtocol(Protocol):
+    """Structural surface the coroutine wrappers call on a snapshot backend.
+
+    Defined locally (rather than importing ``_SQLiteSnapshotBackend``) to avoid an
+    import cycle: ``sqlite`` imports this module, so this module must not import
+    ``sqlite``. The methods match ``_SQLiteSnapshotBackend`` verbatim.
+    """
+
+    async def _save_impl(self, snapshot: StateSnapshot) -> None: ...
+
+    async def _get_impl(
+        self,
+        task_id: TaskID,
+        version: int | None,
+    ) -> StateSnapshot | None: ...
+
+    async def _list_versions_impl(self, task_id: TaskID) -> list[int]: ...
+
+    async def _delete_impl(
+        self,
+        task_id: TaskID,
+        version: int | None,
+    ) -> bool: ...
+
+
+def _shutdown_sync_bridge_executor() -> None:
+    """Best-effort shutdown for test suites and clean interpreter exit."""
+    global _SYNC_BRIDGE_EXECUTOR
+    if _SYNC_BRIDGE_EXECUTOR is not None:
+        _SYNC_BRIDGE_EXECUTOR.shutdown(wait=False)
+        _SYNC_BRIDGE_EXECUTOR = None
+
+
+def _get_sync_bridge_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """Return the shared executor for running async coros from sync code."""
+    global _SYNC_BRIDGE_EXECUTOR
+    if _SYNC_BRIDGE_EXECUTOR is None:
+        _SYNC_BRIDGE_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+            max_workers=4,
+            thread_name_prefix="asap-sqlite-sync",
+        )
+        atexit.register(_shutdown_sync_bridge_executor)
+    return _SYNC_BRIDGE_EXECUTOR
+
+
+def _run_sync(coro: Any) -> Any:
+    """Run an async coroutine from sync code (new loop or shared executor)."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    executor = _get_sync_bridge_executor()
+    future = executor.submit(asyncio.run, coro)
+    return future.result()
+
+
+async def _co_snapshot_save(backend: _SnapshotBackendProtocol, snapshot: StateSnapshot) -> None:
+    await backend._save_impl(snapshot)
+
+
+async def _co_snapshot_get(
+    backend: _SnapshotBackendProtocol,
+    task_id: TaskID,
+    version: int | None,
+) -> StateSnapshot | None:
+    return await backend._get_impl(task_id, version)
+
+
+async def _co_snapshot_list_versions(
+    backend: _SnapshotBackendProtocol,
+    task_id: TaskID,
+) -> list[int]:
+    return await backend._list_versions_impl(task_id)
+
+
+async def _co_snapshot_delete(
+    backend: _SnapshotBackendProtocol,
+    task_id: TaskID,
+    version: int | None,
+) -> bool:
+    return await backend._delete_impl(task_id, version)
+
+
+__all__ = [
+    "_co_snapshot_delete",
+    "_co_snapshot_get",
+    "_co_snapshot_list_versions",
+    "_co_snapshot_save",
+    "_get_sync_bridge_executor",
+    "_run_sync",
+    "_shutdown_sync_bridge_executor",
+]

--- a/src/asap/state/stores/_sync_bridge.py
+++ b/src/asap/state/stores/_sync_bridge.py
@@ -72,7 +72,14 @@ def _get_sync_bridge_executor() -> concurrent.futures.ThreadPoolExecutor:
 
 
 def _run_sync(coro: Any) -> Any:
-    """Run an async coroutine from sync code (new loop or shared executor)."""
+    """Run an async coroutine from sync code (new loop or shared executor).
+
+    When a loop is running (e.g. a sync ``SQLiteSnapshotStore`` call from inside
+    a FastAPI handler), ``future.result()`` blocks the calling thread until the
+    pool worker finishes — stalling the loop. Callers on an async server should
+    prefer ``SQLiteAsyncSnapshotStore``. Kept as-is for behavior parity with the
+    pre-S1 implementation; a non-blocking rewrite is a follow-up.
+    """
     try:
         asyncio.get_running_loop()
     except RuntimeError:

--- a/src/asap/state/stores/sqlite.py
+++ b/src/asap/state/stores/sqlite.py
@@ -1,15 +1,18 @@
-"""SQLite-backed SnapshotStore and MeteringStore (persistent, file-based)."""
+"""SQLite-backed SnapshotStore and MeteringStore (persistent, file-based).
+
+Both stores subclass :class:`AsyncSqliteRepository` (v2.5.1 S1): the base owns
+aiosqlite connection lifecycle, WAL pragma setup, and idempotent schema init;
+this module supplies per-store DDL, SQL, and row mappers. The sync->async bridge
+for :class:`SQLiteSnapshotStore` lives in :mod:`state.stores._sync_bridge`.
+
+The canonical ``usage_events`` DDL + :func:`_ensure_usage_events_schema` stay here
+because ``asap.economics.storage`` imports the helper directly (state is the lower
+layer, so the import direction is acyclic).
+"""
 
 from __future__ import annotations
 
-import asyncio
-import atexit
-import concurrent.futures
 import json
-import threading
-import weakref
-from collections import OrderedDict
-from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
@@ -20,59 +23,19 @@ from asap.models.entities import StateSnapshot
 from asap.models.ids import generate_id
 from asap.models.types import TaskID
 from asap.state.metering import UsageAggregate, UsageEvent, UsageMetrics
+from asap.state.stores._sqlite_base import DEFAULT_DB_PATH, AsyncSqliteRepository
+from asap.state.stores._sync_bridge import (
+    _co_snapshot_delete,
+    _co_snapshot_get,
+    _co_snapshot_list_versions,
+    _co_snapshot_save,
+    _run_sync,
+)
 
-DEFAULT_DB_PATH = "asap_state.db"
-
-# One asyncio lock per DB path: concurrent openings raced on journal_mode=WAL.
-# Weak values drop entries when locks are collectable (limits growth in long test runs).
-_PRAGMA_SETUP_LOCKS: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
-_PRAGMA_DICT_GUARD = threading.Lock()
-# journal_mode=WAL is persistent per DB file; skip redundant SET after first success.
-# LRU-bounded so tmp_path-heavy suites do not grow this map without bound; eviction only
-# loses the in-memory hint (next open may re-run journal_mode=WAL; harmless).
-_MAX_WAL_METADATA_KEYS = 512
-_WAL_INITIALIZED_LRU: OrderedDict[str, None] = OrderedDict()
-
-
-def _pragma_setup_lock(db_path: Path) -> asyncio.Lock:
-    """Per-DB asyncio lock (snapshot and metering share the same path key)."""
-    key = str(db_path.resolve())
-    with _PRAGMA_DICT_GUARD:
-        lock = _PRAGMA_SETUP_LOCKS.get(key)
-        if lock is None:
-            lock = asyncio.Lock()
-            _PRAGMA_SETUP_LOCKS[key] = lock
-        return lock
-
-
-def _wal_mark_initialized(db_key: str) -> None:
-    """Record that journal_mode=WAL was applied for this resolved path (LRU-bounded)."""
-    with _PRAGMA_DICT_GUARD:
-        if db_key in _WAL_INITIALIZED_LRU:
-            _WAL_INITIALIZED_LRU.move_to_end(db_key)
-        else:
-            _WAL_INITIALIZED_LRU[db_key] = None
-            while len(_WAL_INITIALIZED_LRU) > _MAX_WAL_METADATA_KEYS:
-                _WAL_INITIALIZED_LRU.popitem(last=False)
-
-
-async def _apply_wal_pragmas(conn: aiosqlite.Connection, db_key: str) -> None:
-    """Apply WAL pragmas; busy_timeout runs before journal_mode to reduce lock errors."""
-    await conn.execute("PRAGMA busy_timeout=15000")
-    with _PRAGMA_DICT_GUARD:
-        need_journal_mode = db_key not in _WAL_INITIALIZED_LRU
-    if need_journal_mode:
-        await conn.execute("PRAGMA journal_mode=WAL")
-        _wal_mark_initialized(db_key)
-    await conn.execute("PRAGMA synchronous=NORMAL")
-
-
-# Canonical usage_events DDL: the single source of truth for the table + BOTH
-# indexes (agent and consumer). Lives in the state stores module because state is
-# the lower layer (no dependency on economics), so economics.storage can import it
-# without forming an import cycle. Both SQLiteMeteringStore (state) and
-# SQLiteMeteringStorage (economics) call _ensure_usage_events_schema so the
-# physical schema is identical regardless of which store initializes first.
+# Canonical usage_events DDL: single source of truth for the table + BOTH indexes
+# (agent and consumer). State is the lower layer, so economics.storage can import
+# it without forming an import cycle; both stores call _ensure_usage_events_schema
+# so the physical schema is identical regardless of which store initializes first.
 _USAGE_EVENTS_DDL = """
 CREATE TABLE IF NOT EXISTS usage_events (
     id TEXT PRIMARY KEY,
@@ -88,257 +51,145 @@ CREATE INDEX IF NOT EXISTS idx_usage_consumer_timestamp
 ON usage_events (consumer_id, timestamp);
 """
 
+_SNAPSHOTS_DDL = """
+CREATE TABLE IF NOT EXISTS snapshots (
+    task_id TEXT NOT NULL,
+    id TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    data TEXT NOT NULL,
+    checkpoint INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (task_id, version)
+)
+"""
+
+_SNAPSHOT_COLS = "task_id, id, version, data, checkpoint, created_at"
+_SAVE_SQL = f"INSERT OR REPLACE INTO snapshots ({_SNAPSHOT_COLS}) VALUES (?, ?, ?, ?, ?, ?)"
+_GET_BY_VERSION_SQL = f"SELECT {_SNAPSHOT_COLS} FROM snapshots WHERE task_id = ? AND version = ?"
+_GET_LATEST_SQL = (
+    f"SELECT {_SNAPSHOT_COLS} FROM snapshots WHERE task_id = ? ORDER BY version DESC LIMIT 1"
+)
+_LIST_VERSIONS_SQL = "SELECT version FROM snapshots WHERE task_id = ? ORDER BY version"
+_DELETE_VERSION_SQL = "DELETE FROM snapshots WHERE task_id = ? AND version = ?"
+_DELETE_TASK_SQL = "DELETE FROM snapshots WHERE task_id = ?"
+
+_INSERT_EVENT_SQL = (
+    "INSERT INTO usage_events "
+    "(id, task_id, agent_id, consumer_id, metrics, timestamp) "
+    "VALUES (?, ?, ?, ?, ?, ?)"
+)
+_QUERY_EVENTS_SQL = (
+    "SELECT id, task_id, agent_id, consumer_id, metrics, timestamp "
+    "FROM usage_events "
+    "WHERE agent_id = ? AND timestamp >= ? AND timestamp <= ? "
+    "ORDER BY timestamp"
+)
+_AGGREGATE_SQL = """
+SELECT
+    SUM(CAST(json_extract(metrics, '$.tokens_in') AS INTEGER) + CAST(json_extract(metrics, '$.tokens_out') AS INTEGER)),
+    SUM(CAST(json_extract(metrics, '$.duration_ms') AS INTEGER)),
+    COUNT(*),
+    SUM(CAST(json_extract(metrics, '$.api_calls') AS INTEGER))
+FROM usage_events
+WHERE agent_id = ?
+"""
+
 
 async def _ensure_usage_events_schema(conn: aiosqlite.Connection) -> None:
     """Apply the canonical usage_events schema (table + both indexes), idempotently.
 
-    Uses IF NOT EXISTS on every statement so re-running on an already-initialized
-    DB is a no-op AND a pre-existing table missing an index (created by an older
-    code path) gets the missing index added.
+    Economics imports this and calls it with a raw connection; ``SQLiteMeteringStore``
+    instead relies on the base's ``_ensure_schema`` (same DDL), so the table is never
+    created twice on one instance.
     """
     await conn.executescript(_USAGE_EVENTS_DDL)
     await conn.commit()
 
 
-# Shared executor for sync bridge when called from async context.
-# Reused across all DB operations to avoid per-call ThreadPoolExecutor creation.
-_SYNC_BRIDGE_EXECUTOR: concurrent.futures.ThreadPoolExecutor | None = None
-
-
-def _shutdown_sync_bridge_executor() -> None:
-    """Best-effort shutdown for test suites and clean interpreter exit."""
-    global _SYNC_BRIDGE_EXECUTOR
-    if _SYNC_BRIDGE_EXECUTOR is not None:
-        _SYNC_BRIDGE_EXECUTOR.shutdown(wait=False)
-        _SYNC_BRIDGE_EXECUTOR = None
-
-
-def _get_sync_bridge_executor() -> concurrent.futures.ThreadPoolExecutor:
-    """Return the shared executor for running async coros from sync code."""
-    global _SYNC_BRIDGE_EXECUTOR
-    if _SYNC_BRIDGE_EXECUTOR is None:
-        _SYNC_BRIDGE_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
-            max_workers=4,
-            thread_name_prefix="asap-sqlite-sync",
-        )
-        atexit.register(_shutdown_sync_bridge_executor)
-    return _SYNC_BRIDGE_EXECUTOR
-
-
-def _run_sync(coro: Any) -> Any:
-    """Run an async coroutine from sync code (creates new loop or uses shared executor)."""
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(coro)
-    executor = _get_sync_bridge_executor()
-    future = executor.submit(asyncio.run, coro)
-    return future.result()
-
-
 def _snapshot_to_row(snapshot: StateSnapshot) -> tuple[str, str, int, str, int, str]:
-    data_json = json.dumps(snapshot.data)
-    created_at = snapshot.created_at.isoformat()
-    checkpoint = 1 if snapshot.checkpoint else 0
     return (
         snapshot.task_id,
         snapshot.id,
         snapshot.version,
-        data_json,
-        checkpoint,
-        created_at,
+        json.dumps(snapshot.data),
+        1 if snapshot.checkpoint else 0,
+        snapshot.created_at.isoformat(),
     )
 
 
 def _row_to_snapshot(row: tuple[Any, ...]) -> StateSnapshot:
     task_id, id_, version, data_json, checkpoint, created_at_str = row
-    data = json.loads(data_json)
-    created_at = datetime.fromisoformat(created_at_str.replace("Z", "+00:00"))
     return StateSnapshot(
         id=id_,
         task_id=task_id,
         version=version,
-        data=data,
+        data=json.loads(data_json),
         checkpoint=bool(checkpoint),
-        created_at=created_at,
+        created_at=datetime.fromisoformat(created_at_str.replace("Z", "+00:00")),
     )
 
 
 def _event_to_row(event: UsageEvent, event_id: str) -> tuple[str, str, str, str, str, str]:
-    metrics_json = event.metrics.model_dump_json()
-    ts = event.timestamp.isoformat()
     return (
         event_id,
         event.task_id,
         event.agent_id,
         event.consumer_id,
-        metrics_json,
-        ts,
+        event.metrics.model_dump_json(),
+        event.timestamp.isoformat(),
     )
 
 
 def _row_to_event(row: tuple[Any, ...]) -> UsageEvent:
-    (
-        _id,
-        task_id,
-        agent_id,
-        consumer_id,
-        metrics_json,
-        ts_str,
-    ) = row
-    metrics = UsageMetrics.model_validate_json(metrics_json)
-    ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    _id, task_id, agent_id, consumer_id, metrics_json, ts_str = row
     return UsageEvent(
         task_id=task_id,
         agent_id=agent_id,
         consumer_id=consumer_id,
-        metrics=metrics,
-        timestamp=ts,
+        metrics=UsageMetrics.model_validate_json(metrics_json),
+        timestamp=datetime.fromisoformat(ts_str.replace("Z", "+00:00")),
     )
 
 
-class _SQLiteSnapshotBackend:
-    """Shared SQLite snapshot table access (internal)."""
+class _SQLiteSnapshotBackend(AsyncSqliteRepository):
+    """Shared SQLite snapshot table access (internal).
+
+    The base's idempotent ``_ensure_schema`` replaces the old per-connect
+    ``_ensure_snapshots_table`` (both are ``IF NOT EXISTS``).
+    """
 
     def __init__(self, db_path: str | Path = DEFAULT_DB_PATH) -> None:
-        self._db_path = Path(db_path)
-
-    @asynccontextmanager
-    async def _connect(self) -> Any:
-        """Connection with WAL pragmas applied."""
-        db_key = str(self._db_path.resolve())
-        async with aiosqlite.connect(self._db_path, timeout=15.0) as conn:
-            async with _pragma_setup_lock(self._db_path):
-                await _apply_wal_pragmas(conn, db_key)
-            yield conn
-
-    async def _ensure_snapshots_table(self, conn: aiosqlite.Connection) -> None:
-        await conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS snapshots (
-                task_id TEXT NOT NULL,
-                id TEXT NOT NULL,
-                version INTEGER NOT NULL,
-                data TEXT NOT NULL,
-                checkpoint INTEGER NOT NULL,
-                created_at TEXT NOT NULL,
-                PRIMARY KEY (task_id, version)
-            )
-            """
-        )
-        await conn.commit()
+        super().__init__(db_path, schema_ddl=_SNAPSHOTS_DDL)
 
     async def _save_impl(self, snapshot: StateSnapshot) -> None:
-        async with self._connect() as conn:
-            await self._ensure_snapshots_table(conn)
-            row = _snapshot_to_row(snapshot)
-            await conn.execute(
-                """
-                INSERT OR REPLACE INTO snapshots
-                (task_id, id, version, data, checkpoint, created_at)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                row,
-            )
-            await conn.commit()
+        await self.execute(_SAVE_SQL, _snapshot_to_row(snapshot))
 
     async def _get_impl(
         self,
         task_id: TaskID,
         version: int | None,
     ) -> StateSnapshot | None:
-        async with self._connect() as conn:
-            await self._ensure_snapshots_table(conn)
-            if version is not None:
-                cursor = await conn.execute(
-                    """
-                    SELECT task_id, id, version, data, checkpoint, created_at
-                    FROM snapshots
-                    WHERE task_id = ? AND version = ?
-                    """,
-                    (task_id, version),
-                )
-                row = await cursor.fetchone()
-            else:
-                cursor = await conn.execute(
-                    """
-                    SELECT task_id, id, version, data, checkpoint, created_at
-                    FROM snapshots
-                    WHERE task_id = ?
-                    ORDER BY version DESC LIMIT 1
-                    """,
-                    (task_id,),
-                )
-                row = await cursor.fetchone()
-            if row is None:
-                return None
-            return _row_to_snapshot(tuple(row))
+        if version is not None:
+            row = await self.fetch_one(_GET_BY_VERSION_SQL, (task_id, version))
+        else:
+            row = await self.fetch_one(_GET_LATEST_SQL, (task_id,))
+        return _row_to_snapshot(row) if row is not None else None
 
     async def _list_versions_impl(self, task_id: TaskID) -> list[int]:
-        async with self._connect() as conn:
-            await self._ensure_snapshots_table(conn)
-            cursor = await conn.execute(
-                """
-                SELECT version FROM snapshots
-                WHERE task_id = ?
-                ORDER BY version
-                """,
-                (task_id,),
-            )
-            rows = await cursor.fetchall()
-            return [r[0] for r in rows]
+        rows = await self.fetch_all(_LIST_VERSIONS_SQL, (task_id,))
+        return [r[0] for r in rows]
 
-    async def _delete_impl(
-        self,
-        task_id: TaskID,
-        version: int | None,
-    ) -> bool:
-        async with self._connect() as conn:
-            await self._ensure_snapshots_table(conn)
-            if version is not None:
-                cursor = await conn.execute(
-                    "DELETE FROM snapshots WHERE task_id = ? AND version = ?",
-                    (task_id, version),
-                )
-            else:
-                cursor = await conn.execute(
-                    "DELETE FROM snapshots WHERE task_id = ?",
-                    (task_id,),
-                )
-            await conn.commit()
-            return bool(cursor.rowcount) if cursor.rowcount is not None else False
+    async def _delete_impl(self, task_id: TaskID, version: int | None) -> bool:
+        if version is not None:
+            affected = await self.execute(_DELETE_VERSION_SQL, (task_id, version))
+        else:
+            affected = await self.execute(_DELETE_TASK_SQL, (task_id,))
+        return affected > 0
 
     async def initialize(self) -> None:
-        """Create tables if not exists (call from async context if needed)."""
+        """Create the snapshots table if it does not yet exist."""
         async with self._connect() as conn:
-            await self._ensure_snapshots_table(conn)
-
-
-async def _co_snapshot_save(backend: _SQLiteSnapshotBackend, snapshot: StateSnapshot) -> None:
-    await backend._save_impl(snapshot)
-
-
-async def _co_snapshot_get(
-    backend: _SQLiteSnapshotBackend,
-    task_id: TaskID,
-    version: int | None,
-) -> StateSnapshot | None:
-    return await backend._get_impl(task_id, version)
-
-
-async def _co_snapshot_list_versions(
-    backend: _SQLiteSnapshotBackend,
-    task_id: TaskID,
-) -> list[int]:
-    return await backend._list_versions_impl(task_id)
-
-
-async def _co_snapshot_delete(
-    backend: _SQLiteSnapshotBackend,
-    task_id: TaskID,
-    version: int | None,
-) -> bool:
-    return await backend._delete_impl(task_id, version)
+            await self._ensure_schema(conn)
 
 
 class SQLiteAsyncSnapshotStore(_SQLiteSnapshotBackend):
@@ -412,38 +263,25 @@ class SQLiteSnapshotStore(_SQLiteSnapshotBackend):
         return await _co_snapshot_delete(self, task_id, version)
 
 
-class SQLiteMeteringStore:
-    """SQLite-backed MeteringStore; usage events persist across restarts."""
+class SQLiteMeteringStore(AsyncSqliteRepository):
+    """SQLite-backed MeteringStore; usage events persist across restarts.
+
+    ``schema_ddl=_USAGE_EVENTS_DDL`` makes the base's ``_ensure_schema`` install both
+    indexes (agent + consumer) once per instance — preserving the S0 fix where the
+    state store must not omit the consumer index. ``_ensure_usage_table`` delegates
+    to the base so the DDL never runs twice on one instance.
+    """
 
     def __init__(self, db_path: str | Path = DEFAULT_DB_PATH) -> None:
-        self._db_path = Path(db_path)
-
-    @asynccontextmanager
-    async def _connect(self) -> Any:
-        """Connection with WAL pragmas applied."""
-        db_key = str(self._db_path.resolve())
-        async with aiosqlite.connect(self._db_path, timeout=15.0) as conn:
-            async with _pragma_setup_lock(self._db_path):
-                await _apply_wal_pragmas(conn, db_key)
-            yield conn
+        super().__init__(db_path, schema_ddl=_USAGE_EVENTS_DDL)
 
     async def _ensure_usage_table(self, conn: aiosqlite.Connection) -> None:
-        await _ensure_usage_events_schema(conn)
+        await self._ensure_schema(conn)
 
     async def _record_impl(self, event: UsageEvent) -> None:
-        async with self._connect() as conn:
-            await self._ensure_usage_table(conn)
-            event_id = f"evt_{generate_id()}"
-            row = _event_to_row(event, event_id)
-            await conn.execute(
-                """
-                INSERT INTO usage_events
-                (id, task_id, agent_id, consumer_id, metrics, timestamp)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                row,
-            )
-            await conn.commit()
+        event_id = f"evt_{generate_id()}"
+        row = _event_to_row(event, event_id)
+        await self.execute(_INSERT_EVENT_SQL, row)
 
     async def _query_impl(
         self,
@@ -453,57 +291,29 @@ class SQLiteMeteringStore:
         limit: int | None = None,
         offset: int = 0,
     ) -> list[UsageEvent]:
-        async with self._connect() as conn:
-            await self._ensure_usage_table(conn)
-            start_s = start.isoformat()
-            end_s = end.isoformat()
-            query = """
-                SELECT id, task_id, agent_id, consumer_id, metrics, timestamp
-                FROM usage_events
-                WHERE agent_id = ? AND timestamp >= ? AND timestamp <= ?
-                ORDER BY timestamp
-            """
-            params: list[Any] = [agent_id, start_s, end_s]
-            if limit is not None:
-                query += " LIMIT ? OFFSET ?"
-                params.extend([limit, offset])
-            elif offset > 0:
-                query += " LIMIT -1 OFFSET ?"
-                params.append(offset)
-            cursor = await conn.execute(query, params)
-            rows = await cursor.fetchall()
-            return [_row_to_event(tuple(r)) for r in rows]
+        query = _QUERY_EVENTS_SQL
+        params: list[Any] = [agent_id, start.isoformat(), end.isoformat()]
+        if limit is not None:
+            query += " LIMIT ? OFFSET ?"
+            params.extend([limit, offset])
+        elif offset > 0:
+            query += " LIMIT -1 OFFSET ?"
+            params.append(offset)
+        rows = await self.fetch_all(query, tuple(params))
+        return [_row_to_event(r) for r in rows]
 
     async def _aggregate_impl(self, agent_id: str, period: str) -> UsageAggregate:
-        async with self._connect() as conn:
-            await self._ensure_usage_table(conn)
-            cursor = await conn.execute(
-                """
-                SELECT
-                    SUM(CAST(json_extract(metrics, '$.tokens_in') AS INTEGER) + CAST(json_extract(metrics, '$.tokens_out') AS INTEGER)),
-                    SUM(CAST(json_extract(metrics, '$.duration_ms') AS INTEGER)),
-                    COUNT(*),
-                    SUM(CAST(json_extract(metrics, '$.api_calls') AS INTEGER))
-                FROM usage_events
-                WHERE agent_id = ?
-                """,
-                (agent_id,),
-            )
-            row = await cursor.fetchone()
-            if row is None or (row[0] is None and row[1] is None):
-                return UsageAggregate(agent_id=agent_id, period=period)
-            total_tokens = row[0] or 0
-            total_duration = row[1] or 0
-            total_tasks = row[2] or 0
-            total_api_calls = row[3] or 0
-            return UsageAggregate(
-                agent_id=agent_id,
-                period=period,
-                total_tokens=total_tokens,
-                total_duration=total_duration,
-                total_tasks=total_tasks,
-                total_api_calls=total_api_calls,
-            )
+        row = await self.fetch_one(_AGGREGATE_SQL, (agent_id,))
+        if row is None or (row[0] is None and row[1] is None):
+            return UsageAggregate(agent_id=agent_id, period=period)
+        return UsageAggregate(
+            agent_id=agent_id,
+            period=period,
+            total_tokens=row[0] or 0,
+            total_duration=row[1] or 0,
+            total_tasks=row[2] or 0,
+            total_api_calls=row[3] or 0,
+        )
 
     async def record(self, event: UsageEvent) -> None:
         """Record a usage event."""
@@ -530,3 +340,13 @@ class SQLiteMeteringStore:
         """Create usage_events table if not exists."""
         async with self._connect() as conn:
             await self._ensure_usage_table(conn)
+
+
+__all__ = [
+    "DEFAULT_DB_PATH",
+    "SQLiteAsyncSnapshotStore",
+    "SQLiteMeteringStore",
+    "SQLiteSnapshotStore",
+    "_USAGE_EVENTS_DDL",
+    "_ensure_usage_events_schema",
+]

--- a/src/asap/transport/server.py
+++ b/src/asap/transport/server.py
@@ -145,7 +145,8 @@ from asap.state.metering import MeteringStore
 from asap.state.snapshot import SnapshotStore
 from asap.economics.audit import AuditEntry, AuditStore
 from asap.economics.sla_storage import SLAStorage
-from asap.economics.storage import MeteringStorage, metering_storage_adapter
+from asap.economics.storage import MeteringStorage
+from asap.state.metering import MeteringStorageBridge
 from asap.transport.agent_routes import create_agent_identity_router
 from asap.transport.capability_routes import create_capability_router
 from asap.transport.escalation_routes import create_escalation_router
@@ -1763,10 +1764,11 @@ def create_app(
             max_threads=max_threads,
         )
 
-    # Resolve metering: metering_storage takes precedence (enables usage API)
+    # Resolve metering: metering_storage takes precedence (enables usage API);
+    # the bridge adapts it to the MeteringStore interface handlers expect.
     effective_metering_store: MeteringStore | None = metering_store
     if metering_storage is not None and isinstance(metering_storage, MeteringStorage):
-        effective_metering_store = metering_storage_adapter(metering_storage)
+        effective_metering_store = MeteringStorageBridge(metering_storage)
 
     # Use default registry if none provided
     use_default_registry = registry is None

--- a/tests/economics/test_delegation_storage.py
+++ b/tests/economics/test_delegation_storage.py
@@ -9,8 +9,11 @@ import pytest
 from asap.economics.delegation_storage import (
     InMemoryDelegationStorage,
     SQLiteDelegationStorage,
+)
+from asap.state.stores._sqlite_base import (
     _assert_sql_in_placeholders,
     _build_sql_in_placeholders,
+    parse_iso,
 )
 
 if TYPE_CHECKING:
@@ -498,16 +501,13 @@ class TestSQLiteDelegationStorageCoverage:
         delegator = await sqlite_storage.get_delegator("unknown_tok")
         assert delegator is None
 
-    @pytest.mark.asyncio
-    async def test_parse_iso_datetime_edge_cases(
-        self, sqlite_storage: SQLiteDelegationStorage
-    ) -> None:
-        """_parse_iso_datetime handles None and invalid values."""
-        assert sqlite_storage._parse_iso_datetime(None) is None
-        assert sqlite_storage._parse_iso_datetime("") is None
-        assert sqlite_storage._parse_iso_datetime("not-a-date") is None
+    def test_parse_iso_datetime_edge_cases(self) -> None:
+        """parse_iso handles None and invalid values (canonical base helper)."""
+        assert parse_iso(None) is None
+        assert parse_iso("") is None
+        assert parse_iso("not-a-date") is None
         # Z suffix handled
-        result = sqlite_storage._parse_iso_datetime("2026-01-01T00:00:00Z")
+        result = parse_iso("2026-01-01T00:00:00Z")
         assert result is not None
 
     def test_build_sql_in_placeholders_formats_question_marks(self) -> None:

--- a/tests/state/test_metering_storage_bridge.py
+++ b/tests/state/test_metering_storage_bridge.py
@@ -1,0 +1,186 @@
+"""Tests for :class:`MeteringStorageBridge` (v2.5.1 S1).
+
+The bridge moved from ``economics.storage.metering_storage_adapter`` to the
+state foundation layer (``asap.state.metering.MeteringStorageBridge``) so the
+cross-layer adapter lives in the lower layer and economics no longer owns it.
+These tests cover the bridge directly (the old adapter tests in
+``tests/economics/test_storage.py`` cover the compat shim's delegation).
+
+Contract under test:
+- ``record`` flattens a ``UsageEvent`` into a ``UsageMetrics`` row and stores it;
+- ``query`` returns ``UsageEvent`` rows for the agent/time window;
+- ``aggregate`` returns a state ``UsageAggregate`` for the matching agent and an
+  empty one when no data matches;
+- period ``h`` excludes events older than one hour.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from asap.economics.metering import UsageMetrics
+from asap.economics.storage import InMemoryMeteringStorage
+from asap.state.metering import MeteringStorageBridge, UsageAggregate, UsageEvent
+from asap.state.metering import UsageMetrics as StateUsageMetrics
+
+
+def _event(
+    task_id: str = "t1",
+    agent_id: str = "a1",
+    consumer_id: str = "c1",
+    tokens_in: int = 10,
+    tokens_out: int = 20,
+    duration_ms: int = 100,
+    api_calls: int = 1,
+    timestamp: datetime | None = None,
+) -> UsageEvent:
+    return UsageEvent(
+        task_id=task_id,
+        agent_id=agent_id,
+        consumer_id=consumer_id,
+        metrics=StateUsageMetrics(
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            duration_ms=duration_ms,
+            api_calls=api_calls,
+        ),
+        timestamp=timestamp or datetime(2026, 2, 17, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+class TestMeteringStorageBridgeRecordQuery:
+    """record() + query() round-trip through the flat UsageMetrics row."""
+
+    async def test_record_then_query_returns_event(self) -> None:
+        bridge = MeteringStorageBridge(InMemoryMeteringStorage())
+        await bridge.record(_event())
+
+        results = await bridge.query(
+            agent_id="a1",
+            start=datetime(2026, 2, 17, 0, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 2, 18, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        assert len(results) == 1
+        assert results[0].task_id == "t1"
+        assert results[0].metrics.tokens_in == 10
+        assert results[0].metrics.tokens_out == 20
+
+    async def test_query_filters_by_agent_id(self) -> None:
+        bridge = MeteringStorageBridge(InMemoryMeteringStorage())
+        await bridge.record(_event(task_id="t1", agent_id="a1"))
+        await bridge.record(_event(task_id="t2", agent_id="a2"))
+
+        results = await bridge.query(
+            agent_id="a2",
+            start=datetime(2026, 2, 17, 0, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 2, 18, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        assert len(results) == 1
+        assert results[0].task_id == "t2"
+
+    async def test_query_outside_window_returns_empty(self) -> None:
+        bridge = MeteringStorageBridge(InMemoryMeteringStorage())
+        await bridge.record(_event())
+
+        results = await bridge.query(
+            agent_id="a1",
+            start=datetime(2026, 3, 1, 0, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 3, 2, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        assert results == []
+
+
+class TestMeteringStorageBridgeAggregate:
+    """aggregate() returns a state UsageAggregate for the matching agent."""
+
+    async def test_aggregate_matching_agent(self) -> None:
+        backend = InMemoryMeteringStorage()
+        bridge = MeteringStorageBridge(backend)
+        now = datetime.now(timezone.utc)
+        await backend.record(
+            UsageMetrics(
+                task_id="t1",
+                agent_id="a1",
+                consumer_id="c1",
+                tokens_in=10,
+                tokens_out=20,
+                duration_ms=100,
+                api_calls=3,
+                timestamp=now,
+            )
+        )
+
+        agg = await bridge.aggregate(agent_id="a1", period="hour")
+        assert isinstance(agg, UsageAggregate)
+        assert agg.agent_id == "a1"
+        assert agg.total_tokens == 30
+        assert agg.total_api_calls == 3
+        assert agg.total_tasks == 1
+
+    async def test_aggregate_no_matching_agent_returns_empty(self) -> None:
+        bridge = MeteringStorageBridge(InMemoryMeteringStorage())
+        agg = await bridge.aggregate(agent_id="nonexistent", period="day")
+        assert agg.agent_id == "nonexistent"
+        assert agg.total_tokens == 0
+        assert agg.total_tasks == 0
+
+    async def test_aggregate_period_h_excludes_old_events(self) -> None:
+        backend = InMemoryMeteringStorage()
+        bridge = MeteringStorageBridge(backend)
+        now = datetime.now(timezone.utc)
+        await backend.record(
+            UsageMetrics(
+                task_id="old",
+                agent_id="a1",
+                consumer_id="c1",
+                tokens_in=100,
+                tokens_out=100,
+                api_calls=0,
+                timestamp=now - timedelta(hours=2),
+            )
+        )
+        await backend.record(
+            UsageMetrics(
+                task_id="recent",
+                agent_id="a1",
+                consumer_id="c1",
+                tokens_in=5,
+                tokens_out=10,
+                api_calls=1,
+                timestamp=now - timedelta(minutes=30),
+            )
+        )
+
+        agg = await bridge.aggregate(agent_id="a1", period="h")
+        assert agg.agent_id == "a1"
+        assert agg.total_tokens == 15
+        assert agg.total_api_calls == 1
+
+    async def test_aggregate_unknown_period_no_time_filter(self) -> None:
+        backend = InMemoryMeteringStorage()
+        bridge = MeteringStorageBridge(backend)
+        await backend.record(
+            UsageMetrics(
+                task_id="t1",
+                agent_id="a1",
+                consumer_id="c1",
+                tokens_in=10,
+                tokens_out=20,
+                api_calls=0,
+                timestamp=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+
+        agg = await bridge.aggregate(agent_id="a1", period="all")
+        assert agg.agent_id == "a1"
+        assert agg.total_tokens == 30
+
+
+class TestMeteringStorageBridgeSatisfiesMeteringStore:
+    """The bridge structurally satisfies the state ``MeteringStore`` protocol."""
+
+    def test_has_record_query_aggregate(self) -> None:
+        bridge = MeteringStorageBridge(InMemoryMeteringStorage())
+        assert callable(bridge.record)
+        assert callable(bridge.query)
+        assert callable(bridge.aggregate)

--- a/tests/state/test_shared_db_path.py
+++ b/tests/state/test_shared_db_path.py
@@ -1,0 +1,85 @@
+"""Integration test: two store classes sharing one ``asap_state.db`` path (v2.5.1 S1).
+
+Exercises the shared per-path WAL lock under realistic interleaved writes — the
+scenario a server hits at startup when ``SQLiteDelegationStorage`` and
+``SQLiteMeteringStorage`` are both wired against the default ``asap_state.db``.
+Guards against the pre-S1 ``journal_mode=WAL`` race and the divergent-index DDL
+drift (S0 B2) regressing.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from asap.economics.delegation_storage import SQLiteDelegationStorage
+from asap.economics.metering import UsageMetrics
+from asap.economics.storage import MeteringQuery, SQLiteMeteringStorage
+
+
+async def test_two_stores_share_db_path_interleaved_writes(tmp_path: Path) -> None:
+    """Delegation + metering stores on the same file interleave without deadlock."""
+    db = tmp_path / "asap_state.db"
+    delegation = SQLiteDelegationStorage(db_path=db)
+    metering = SQLiteMeteringStorage(db_path=db)
+
+    # Interleave writes from both stores on the shared file. The per-path WAL
+    # lock serializes journal_mode setup so neither sees 'database is locked'.
+    await delegation.register_issued("tok-1", "urn:asap:agent:parent", "urn:asap:agent:child")
+    await metering.record(
+        UsageMetrics(
+            task_id="task-1",
+            agent_id="urn:asap:agent:parent",
+            consumer_id="urn:asap:agent:caller",
+            tokens_in=10,
+            tokens_out=20,
+            duration_ms=100,
+            api_calls=1,
+            timestamp=datetime.now(timezone.utc),
+        )
+    )
+    await delegation.revoke("tok-1", reason="rotated")
+    await metering.record(
+        UsageMetrics(
+            task_id="task-2",
+            agent_id="urn:asap:agent:parent",
+            consumer_id="urn:asap:agent:caller",
+            tokens_in=5,
+            tokens_out=5,
+            api_calls=0,
+            timestamp=datetime.now(timezone.utc),
+        )
+    )
+
+    # Both stores read their own tables back from the shared file.
+    assert await delegation.is_revoked("tok-1") is True
+    events = await metering.query(MeteringQuery(agent_id="urn:asap:agent:parent"))
+    assert len(events) == 2
+
+
+async def test_shared_db_path_both_indexes_present_regardless_of_init_order(
+    tmp_path: Path,
+) -> None:
+    """The canonical usage_events DDL installs both indexes no matter which store inits first."""
+    from aiosqlite import connect
+
+    db = tmp_path / "asap_state.db"
+    # Metering inits first (creates usage_events with both indexes).
+    metering = SQLiteMeteringStorage(db_path=db)
+    await metering.record(
+        UsageMetrics(
+            task_id="t",
+            agent_id="a",
+            consumer_id="c",
+            timestamp=datetime.now(timezone.utc),
+        )
+    )
+
+    async with connect(db) as conn:
+        cursor = await conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='usage_events'"
+        )
+        index_names = {str(row[0]) for row in await cursor.fetchall()}
+
+    assert "idx_usage_agent_timestamp" in index_names
+    assert "idx_usage_consumer_timestamp" in index_names

--- a/tests/state/test_sqlite_base.py
+++ b/tests/state/test_sqlite_base.py
@@ -1,0 +1,256 @@
+"""Unit tests for the shared :class:`AsyncSqliteRepository` base (v2.5.1 S1).
+
+Covers the four contract guarantees the migrations depend on:
+- ``execute`` / ``fetch_all`` / ``fetch_one`` round-trip;
+- ``transaction`` commits on success and rolls back on exception;
+- ``parse_iso`` handles valid/invalid/None uniformly;
+- ``build_where`` rejects unknown filter keys (allow-list guard).
+
+Tests use ``:memory:`` so no temp files are needed and runs are deterministic.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from asap.state.stores._sqlite_base import (
+    AsyncSqliteRepository,
+    _build_sql_in_placeholders,
+    build_where,
+    parse_iso,
+)
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS sample (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+)
+"""
+
+
+def _repo() -> AsyncSqliteRepository:
+    return AsyncSqliteRepository(":memory:", schema_ddl=_DDL)
+
+
+async def test_execute_fetch_one_round_trip() -> None:
+    repo = _repo()
+    inserted = await repo.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (1, "alpha"))
+    assert inserted == 1
+    row = await repo.fetch_one("SELECT id, name FROM sample WHERE id = ?", (1,))
+    assert row == (1, "alpha")
+
+
+async def test_fetch_all_returns_all_rows_as_tuples() -> None:
+    repo = _repo()
+    await repo.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (1, "a"))
+    await repo.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (2, "b"))
+    rows = await repo.fetch_all("SELECT id, name FROM sample ORDER BY id")
+    assert rows == [(1, "a"), (2, "b")]
+
+
+async def test_fetch_one_none_when_empty() -> None:
+    repo = _repo()
+    assert await repo.fetch_one("SELECT id FROM sample WHERE id = ?", (999,)) is None
+
+
+async def test_fetch_all_empty() -> None:
+    repo = _repo()
+    assert await repo.fetch_all("SELECT id FROM sample") == []
+
+
+async def test_transaction_commits_on_success() -> None:
+    repo = _repo()
+    async with repo.transaction() as conn:
+        await conn.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (1, "x"))
+    row = await repo.fetch_one("SELECT name FROM sample WHERE id = ?", (1,))
+    assert row == ("x",)
+
+
+async def test_transaction_rolls_back_on_exception() -> None:
+    repo = _repo()
+
+    with pytest.raises(RuntimeError, match="boom"):
+        async with repo.transaction() as conn:
+            await conn.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (1, "x"))
+            raise RuntimeError("boom")
+
+    # The row must NOT persist after the rollback.
+    assert await repo.fetch_one("SELECT id FROM sample") is None
+
+
+async def test_schema_ensure_is_idempotent() -> None:
+    """Multiple operations on one repo must not re-run the DDL or deadlock."""
+    repo = _repo()
+    await repo.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (1, "a"))
+    await repo.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (2, "b"))
+    assert await repo.fetch_all("SELECT id FROM sample ORDER BY id") == [(1,), (2,)]
+
+
+def test_parse_iso_valid_with_z() -> None:
+    assert parse_iso("2026-06-25T01:50:00Z") == datetime(2026, 6, 25, 1, 50, 0, tzinfo=timezone.utc)
+
+
+def test_parse_iso_valid_with_offset() -> None:
+    assert parse_iso("2026-06-25T01:50:00+00:00") == datetime(
+        2026, 6, 25, 1, 50, 0, tzinfo=timezone.utc
+    )
+
+
+def test_parse_iso_none_and_empty() -> None:
+    assert parse_iso(None) is None
+    assert parse_iso("") is None
+
+
+def test_parse_iso_invalid_returns_none() -> None:
+    assert parse_iso("not-a-timestamp") is None
+
+
+def test_build_where_no_filters() -> None:
+    where, params = build_where({}, {"agent_id": "agent_id = ?"})
+    assert where == "1=1"
+    assert params == []
+
+
+def test_build_where_skips_none_values() -> None:
+    where, params = build_where(
+        {"agent_id": None, "task_id": "t1"},
+        {"agent_id": "agent_id = ?", "task_id": "task_id = ?"},
+    )
+    assert where == "task_id = ?"
+    assert params == ["t1"]
+
+
+def test_build_where_assembles_multiple_conditions() -> None:
+    where, params = build_where(
+        {"agent_id": "a1", "start": "2026-06-25"},
+        {"agent_id": "agent_id = ?", "start": "timestamp >= ?"},
+    )
+    assert where == "agent_id = ? AND timestamp >= ?"
+    assert params == ["a1", "2026-06-25"]
+
+
+def test_build_where_rejects_unknown_key() -> None:
+    with pytest.raises(ValueError, match="unknown filter"):
+        build_where(
+            {"evil": "DROP TABLE"},
+            {"agent_id": "agent_id = ?"},
+        )
+
+
+def test_build_where_passes_typed_values_through() -> None:
+    where, params = build_where(
+        {"agent_id": "a1", "limit": 5},
+        {"agent_id": "agent_id = ?", "limit": "LIMIT ?"},
+    )
+    assert params == ["a1", 5]
+    assert where == "agent_id = ? AND LIMIT ?"
+
+
+# ---------------------------------------------------------------------------
+# _build_sql_in_placeholders / _assert_sql_in_placeholders — fail-closed guard
+# ---------------------------------------------------------------------------
+
+
+def test_build_sql_in_placeholders_single() -> None:
+    assert _build_sql_in_placeholders(1) == "?"
+
+
+def test_build_sql_in_placeholders_multiple() -> None:
+    assert _build_sql_in_placeholders(3) == "?,?,?"
+
+
+def test_build_sql_in_placeholders_zero() -> None:
+    assert _build_sql_in_placeholders(0) == ""
+
+
+def test_build_sql_in_placeholders_rejects_non_placeholder_chars() -> None:
+    """The fail-closed guard rejects anything that is not ``?``/``,``.
+
+    ``_build_sql_in_placeholders`` itself can only ever produce ``?``/``,`` from
+    ``len(count)``, so this asserts the guard at the boundary it protects: if a
+    future edit fed an attacker-influenced string here, it would raise instead of
+    leaking into dynamic SQL.
+    """
+    from asap.state.stores._sqlite_base import _assert_sql_in_placeholders
+
+    with pytest.raises(ValueError, match="placeholders must be"):
+        _assert_sql_in_placeholders("?; DROP TABLE t; --")
+
+
+# ---------------------------------------------------------------------------
+# File-backed _connect path (WAL pragmas + per-path lock)
+# ---------------------------------------------------------------------------
+
+
+async def test_file_backed_connect_applies_wal_and_round_trips(
+    tmp_path: Path,
+) -> None:
+    """A file-backed repo runs WAL pragmas and persists rows across connections."""
+    db = tmp_path / "wal_test.db"
+    repo = AsyncSqliteRepository(db, schema_ddl=_DDL)
+    await repo.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (1, "a"))
+
+    # A fresh repo on the same file must see the persisted row (proves the file
+    # path is used, not a transient :memory: DB) and must not deadlock on the
+    # per-path WAL lock when opened a second time.
+    repo2 = AsyncSqliteRepository(db, schema_ddl=_DDL)
+    row = await repo2.fetch_one("SELECT id, name FROM sample WHERE id = ?", (1,))
+    assert row == (1, "a")
+
+
+async def test_file_backed_transaction_rolls_back(tmp_path: Path) -> None:
+    """A file-backed transaction rolls back on exception (no partial write)."""
+    db = tmp_path / "txn_rollback.db"
+    repo = AsyncSqliteRepository(db, schema_ddl=_DDL)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        async with repo.transaction() as conn:
+            await conn.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (1, "x"))
+            raise RuntimeError("boom")
+
+    assert await repo.fetch_one("SELECT id FROM sample") is None
+
+
+async def test_two_repos_share_wal_lock_without_deadlock(tmp_path: Path) -> None:
+    """Concurrent openings on the same path share the per-path WAL lock safely."""
+    db = tmp_path / "shared.db"
+    repo_a = AsyncSqliteRepository(db, schema_ddl=_DDL)
+    repo_b = AsyncSqliteRepository(db, schema_ddl=_DDL)
+
+    # Interleaved operations from two repos on the same file must both succeed;
+    # the per-path lock serializes WAL setup so neither sees 'database is locked'.
+    await repo_a.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (1, "a"))
+    await repo_b.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (2, "b"))
+    rows = await repo_a.fetch_all("SELECT id FROM sample ORDER BY id")
+    assert rows == [(1,), (2,)]
+
+
+# ---------------------------------------------------------------------------
+# parse_iso — boundary coverage
+# ---------------------------------------------------------------------------
+
+
+def test_parse_iso_naive_datetime_preserved() -> None:
+    """Naive ISO timestamps (no tz) parse without forcing UTC.
+
+    Naive datetime is the condition under test (parse_iso must preserve a stored
+    naive timestamp rather than inventing a tz), so DTZ001 is intentional here.
+    """
+    assert parse_iso("2026-06-25T01:50:00") == datetime(2026, 6, 25, 1, 50, 0)  # noqa: DTZ001
+
+
+def test_parse_iso_whitespace_only_returns_none() -> None:
+    assert parse_iso("   ") is None
+
+
+def test_parse_iso_typeerror_on_non_str_returns_none() -> None:
+    """A non-string/None input (e.g. an int row value) returns None, not a crash.
+
+    Passing an int exercises the ``except (ValueError, TypeError)`` branch of
+    ``parse_iso``; the call is intentionally ill-typed to mimic a corrupted row.
+    """
+    result: object = parse_iso(12345)
+    assert result is None


### PR DESCRIPTION
## Summary

Sprint S1 of the v2.5.1 thermo-nuclear patch: collapses the four near-duplicate SQLite stores onto one shared repository base, deleting ~1100 lines of duplicated plumbing while preserving all public APIs and behavior.

- **New `AsyncSqliteRepository` base** (`state/stores/_sqlite_base.py`): single source of truth for aiosqlite connection lifecycle, WAL pragma setup (per-path lock + LRU), idempotent schema init, `transaction()` (BEGIN/COMMIT/ROLLBACK), `parse_iso`, `build_where` (allow-list guarded), and `:memory:` persistent-connection support.
- **5 stores migrated** onto the base: `state/stores/sqlite.py` (snapshot + metering backends; sync→async bridge extracted to `_sync_bridge.py`), `SQLiteMeteringStorage`, `SQLiteDelegationStorage` (cascade now uses base `transaction()` — S0 B1 atomicity invariant preserved), `SQLiteSLAStorage` (WHERE routed through `build_where`), `SQLiteAuditStore` (connection typed, inline `aiosqlite` import hoisted).
- **`MeteringStorage`→`MeteringStore` bridge moved** to the state foundation layer as `MeteringStorageBridge`; `economics.storage.metering_storage_adapter` becomes a thin compat shim (delegates to the bridge); `server.py` uses the bridge directly.

### Scope decision (Task 4.0)
The two `UsageMetrics` / two `InMemoryMeteringStore` were **not** collapsed — they are conceptually distinct (state `UsageMetrics` is a 4-field metrics payload inside `UsageEvent`; economics `UsageMetrics` is the flat event record with identity + timestamp). Collapsing them would break the public API (`usage_api.py`, `hooks.py`, `BatchUsageRequest`, `UsageEvent.metrics`), violating the v2.5.1 "behavior-preserving, no public API break" contract. The adapter implementation was still removed from economics (now a 1-line shim); the canonical bridge lives in the state layer for a future major-release model collapse.

## Behavior preservation
- No public API break: all existing imports (`from asap.economics.storage import SQLiteMeteringStorage, metering_storage_adapter`, `from asap.state.stores.sqlite import _ensure_usage_events_schema`, etc.) keep working.
- Sacred S0 B1 cascade atomicity regression tests pass unmodified.
- `metering_storage_adapter` kept as a compat shim — zero break for its 5 existing tests.

## Test plan
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — 480 files formatted
- [x] `uv run mypy src/ scripts/ tests/` — 444 files, no issues
- [x] `uv run pytest --tb=short --cov=asap --cov-report=xml --cov-fail-under=85` — **3668 passed, 12 skipped, 0 failed**, **92.93% coverage** (≥85% gate)
- [x] New unit tests: 26 for `AsyncSqliteRepository` base (`tests/state/test_sqlite_base.py`), 8 for `MeteringStorageBridge` (`tests/state/test_metering_storage_bridge.py`)
- [x] No public API break verified across all store imports
- [x] S0 B1 cascade atomicity tests green (regression guard)
- [x] AI slop removed (no migration-narrative comments, no defensive `assert # nosec`, no unused `__all__` re-exports)

### Note on LOC targets
The sprint's per-file LOC targets (storage ≤250, sqlite ≤280, delegation ≤150, sla ≤130) were not met. They assumed the Task 4.0 model collapse (deferred to avoid API break) and removal of the immutable Protocol/ABC/InMemory/helper blocks each sub-task was required to preserve. The duplicated plumbing deletion (the actual S1 goal) was achieved: ~1100 lines removed, 4 stores + 1 base now share one connection/WAL/schema implementation.