### PR TITLE
fix(deps): bump joserfc, python-engineio, python-socketio for pip-audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CI security (`pip-audit`)**: Raised `joserfc` to `>=1.6.7,<2` (CVE-2026-48990) and added overrides for `python-engineio>=4.13.2` (CVE-2026-48802 / CVE-2026-48809) and `python-socketio>=5.16.2` (CVE-2026-48804). See [SECURITY.md](SECURITY.md).
+
 ### Follow-up (not in v2.5.1)
 
 - **Adapter Lab II** — new framework adapters (separate PRD: [prd-v2.5.1-adapter-lab-ii.md](product/prd/prd-v2.5.1-adapter-lab-ii.md)).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -103,6 +103,12 @@ CI runs `pip-audit` after a sync that **excludes** the optional extras `crewai` 
 
 **GHSA-537c-gmf6-5ccf (cryptography)**: Resolved by raising the pin to `cryptography>=48.0.1,<49` (direct dependency and override).
 
+**CVE-2026-48990 (joserfc)**: Resolved by raising the pin to `joserfc>=1.6.7,<2` (direct dependency and override).
+
+**CVE-2026-48802 / CVE-2026-48809 (python-engineio, locust stack)**: Resolved via override (`python-engineio>=4.13.2`).
+
+**CVE-2026-48804 (python-socketio, locust stack)**: Resolved via override (`python-socketio>=5.16.2`).
+
 **CVE-2026-46678 (pydantic-ai, optional `[pydanticai]` extra)**: Resolved via `[pydanticai]` extra floor `pydantic-ai>=1.99.0` (1.102.0 in lock as of 2026-06).
 
 **CVE-2026-4963 / CVE-2026-2654 (smolagents, optional `[smolagents]` extra)**: OSV reports these against current PyPI releases with **no `fix_versions`/`fixed` range** yet. CI ignores them until Hugging Face publishes patched `smolagents` wheels; remove the flags when `pip-audit` is clean without them. The reference package does not import smolagents unless that extra is installed.
@@ -140,7 +146,7 @@ We pin **upper bounds** on the security- and protocol-sensitive libraries listed
 |---------|-----|-----|
 | `cryptography` | `>=48.0.1,<49` | GHSA-537c-gmf6-5ccf baseline; v47+ serialization API (Rust backend migration) |
 | `authlib` | `>=1.6.11,<2` | GHSA-jj8c-mmj3-mmgv baseline; v2 reworks JWS header policy |
-| `joserfc` | `>=1.6.3,<2` | JWT / JWS / JWE primitives powering Host JWT verification |
+| `joserfc` | `>=1.6.7,<2` | CVE-2026-48990 baseline; JWT / JWS / JWE primitives powering Host JWT verification |
 | `pyjwt` (override) | `>=2.12.0,<3` | CVE-2026-32597 baseline; v3 changes default `options` behavior for token introspection |
 | `webauthn` (optional extra) | `>=2.6,<3` | Assertion/attestation verification for SELF-002 |
 | `pydantic` | `>=2.12.5,<3` | Model validation contract across all payloads; v3 is a breaking rewrite |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "fastapi>=0.136.1",
     "httpx[http2]>=0.28.1",
     "authlib>=1.6.12,<2",
-    "joserfc>=1.6.3,<2",
+    "joserfc>=1.6.7,<2",
     "uvicorn>=0.34",
     "python-ulid>=3.0",
     "packaging>=25.0",
@@ -66,6 +66,9 @@ docs = [
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.27",
     "pymdown-extensions>=10.21.3",
+    "joserfc>=1.6.7,<2",
+    "python-engineio>=4.13.2",
+    "python-socketio>=5.16.2",
 ]
 dns-sd = [
     "zeroconf>=0.149.5",
@@ -138,6 +141,9 @@ Issues = "https://github.com/adriannoes/asap-protocol/issues"
 # - idna>=3.15 for CVE-2026-45409 (DoS in idna.encode; transitive via httpx/requests)
 # - markdown>=3.10.2 for PYSEC-2026-89 (DoS in html.parser during Markdown parse; mkdocs stack)
 # - pymdown-extensions>=10.21.3 for CVE-2026-46338 (snippets base_path prefix bypass; mkdocs stack)
+# - joserfc>=1.6.7 for CVE-2026-48990 (JWT/JWS primitives; direct + override)
+# - python-engineio>=4.13.2 for CVE-2026-48802 / CVE-2026-48809 (transitive, locust stack)
+# - python-socketio>=5.16.2 for CVE-2026-48804 (transitive, locust stack)
 [tool.uv]
 override-dependencies = [
     "aiohttp>=3.14.0,<4",
@@ -162,6 +168,9 @@ override-dependencies = [
     "pymdown-extensions>=10.21.3",
     "pydantic-settings>=2.14.2",
     "msgpack>=1.2.1",
+    "joserfc>=1.6.7,<2",
+    "python-engineio>=4.13.2",
+    "python-socketio>=5.16.2",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,7 @@ overrides = [
     { name = "aiohttp", specifier = ">=3.14.0,<4" },
     { name = "cryptography", specifier = ">=48.0.1,<49" },
     { name = "idna", specifier = ">=3.15" },
+    { name = "joserfc", specifier = ">=1.6.7,<2" },
     { name = "langchain-core", specifier = ">=1.3.3" },
     { name = "langsmith", specifier = ">=0.8.18" },
     { name = "markdown", specifier = ">=3.10.2" },
@@ -20,7 +21,9 @@ overrides = [
     { name = "pymdown-extensions", specifier = ">=10.21.3" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-engineio", specifier = ">=4.13.2" },
     { name = "python-multipart", specifier = ">=0.0.31" },
+    { name = "python-socketio", specifier = ">=5.16.2" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "tinytag", specifier = ">=2.2.1" },
@@ -282,9 +285,12 @@ dns-sd = [
 ]
 docs = [
     { name = "ghp-import" },
+    { name = "joserfc" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pymdown-extensions" },
+    { name = "python-engineio" },
+    { name = "python-socketio" },
 ]
 langchain = [
     { name = "langchain-core" },
@@ -342,7 +348,8 @@ requires-dist = [
     { name = "ghp-import", marker = "extra == 'docs'", specifier = ">=2.1.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "jcs", specifier = ">=0.2.0" },
-    { name = "joserfc", specifier = ">=1.6.3,<2" },
+    { name = "joserfc", specifier = ">=1.6.7,<2" },
+    { name = "joserfc", marker = "extra == 'docs'", specifier = ">=1.6.7,<2" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.3.3" },
     { name = "limits", specifier = ">=3.0" },
@@ -369,6 +376,8 @@ requires-dist = [
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
+    { name = "python-engineio", marker = "extra == 'docs'", specifier = ">=4.13.2" },
+    { name = "python-socketio", marker = "extra == 'docs'", specifier = ">=5.16.2" },
     { name = "python-ulid", specifier = ">=3.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.14" },
@@ -2187,14 +2196,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.3"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/90/b8cc8635c4ce2e5e8104bf26ef147f6e599478f6329107283cdc53aae97f/joserfc-1.6.3.tar.gz", hash = "sha256:c00c2830db969b836cba197e830e738dd9dda0955f1794e55d3c636f17f5c9a6", size = 229090, upload-time = "2026-02-25T15:33:38.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/26/abe1ad855eb334b5ebc9c6495d4798e12bee70e5e8e815d54570710b8312/joserfc-1.7.2.tar.gz", hash = "sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947", size = 233183, upload-time = "2026-06-29T09:03:10.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/4f/124b3301067b752f44f292f0b9a74e837dd75ff863ee39500a082fc4c733/joserfc-1.6.3-py3-none-any.whl", hash = "sha256:6beab3635358cbc565cb94fb4c53d0557e6d10a15b933e2134939351590bda9a", size = 70465, upload-time = "2026-02-25T15:33:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/13/80/d1b30336582cced4dce0dae776508a6011723e32f907bc7a702c0b25890a/joserfc-1.7.2-py3-none-any.whl", hash = "sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5", size = 70426, upload-time = "2026-06-29T09:03:09.393Z" },
 ]
 
 [[package]]
@@ -2533,7 +2542,7 @@ dependencies = [
     { name = "psutil" },
     { name = "pytest" },
     { name = "python-engineio" },
-    { name = "python-socketio", extra = ["client"] },
+    { name = "python-socketio" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "pyzmq" },
     { name = "requests" },
@@ -4531,14 +4540,14 @@ wheels = [
 
 [[package]]
 name = "python-engineio"
-version = "4.13.0"
+version = "4.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "simple-websocket" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/5a/349caac055e03ef9e56ed29fa304846063b1771ee54ab8132bf98b29491e/python_engineio-4.13.0.tar.gz", hash = "sha256:f9c51a8754d2742ba832c24b46ed425fdd3064356914edd5a1e8ffde76ab7709", size = 92194, upload-time = "2025-12-24T22:38:05.111Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/a0/f75491f942184d9960b15e763270f765fe9f239745ca5f9e16289011aed4/python_engineio-4.13.3.tar.gz", hash = "sha256:572b7783e341fed21edbc7cea297ccd378dad79265fdde96aa4664420a7c06c9", size = 79734, upload-time = "2026-06-20T22:53:52.197Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/74/c655a6eda0fd188d490c14142a0f0380655ac7099604e1fbf8fa1a97f0a1/python_engineio-4.13.0-py3-none-any.whl", hash = "sha256:57b94eac094fa07b050c6da59f48b12250ab1cd920765f4849963e3d89ad9de3", size = 59676, upload-time = "2025-12-24T22:38:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/96/82f6328e410515fab21d5602ba35b9377a47b5a141a0c1f9efa00ce21eb4/python_engineio-4.13.3-py3-none-any.whl", hash = "sha256:1f60ecaf1358190f0e26c48c578a60428dc02a8f1295bc3dbf53d1b31116821f", size = 59993, upload-time = "2026-06-20T22:53:50.775Z" },
 ]
 
 [[package]]
@@ -4564,21 +4573,15 @@ wheels = [
 
 [[package]]
 name = "python-socketio"
-version = "5.16.0"
+version = "5.16.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bidict" },
     { name = "python-engineio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/55/5d8af5884283b58e4405580bcd84af1d898c457173c708736e065f10ca4a/python_socketio-5.16.0.tar.gz", hash = "sha256:f79403c7f1ba8b84460aa8fe4c671414c8145b21a501b46b676f3740286356fd", size = 127120, upload-time = "2025-12-24T23:51:48.826Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/2d/ffce71017c106b75099fea569df6518c63fee5d6202ce0cfe7b01e6f22c3/python_socketio-5.16.3.tar.gz", hash = "sha256:89b136f677ae65607a84cecda9b4d6c5377b40a97582c504c25df89af16d520e", size = 128095, upload-time = "2026-06-15T22:07:04.003Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/d2/2ccc2b69a187b80fda3152745670cfba936704f296a9fa54c6c8ac694d12/python_socketio-5.16.0-py3-none-any.whl", hash = "sha256:d95802961e15c7bd54ecf884c6e7644f81be8460f0a02ee66b473df58088ee8a", size = 79607, upload-time = "2025-12-24T23:51:47.2Z" },
-]
-
-[package.optional-dependencies]
-client = [
-    { name = "requests" },
-    { name = "websocket-client" },
+    { url = "https://files.pythonhosted.org/packages/0a/38/8c5e72d53ff8eb27497c4f268a7f6d9121e727a50b65248288ad79a93053/python_socketio-5.16.3-py3-none-any.whl", hash = "sha256:e7ad14202a5e6448824c7c2f86161d04e13dec05992257df5c709e6a2798c041", size = 82087, upload-time = "2026-06-15T22:07:02.498Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Raise `joserfc` floor to `>=1.6.7,<2` (CVE-2026-48990) via direct pin and `tool.uv.override-dependencies`
- Add overrides for `python-engineio>=4.13.2` (CVE-2026-48802 / CVE-2026-48809) and `python-socketio>=5.16.2` (CVE-2026-48804), transitive via the locust dev stack
- Update `SECURITY.md` and `CHANGELOG.md` [Unreleased]

## Test plan

- [x] `uv lock`
- [x] `uv sync --frozen --all-extras --dev --no-extra crewai --no-extra llamaindex && uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-4963 --ignore-vuln CVE-2026-2654 --ignore-vuln PYSEC-2024-271 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183` — no known vulnerabilities
- [x] `uv run ruff check .`