### PR TITLE
fix(state): serialize SQLite execute() writes with asyncio lock (#245)

### DIFF
--- a/src/asap/state/stores/_sqlite_base.py
+++ b/src/asap/state/stores/_sqlite_base.py
@@ -145,11 +145,14 @@ class AsyncSqliteRepository:
     Subclasses supply ``schema_ddl`` (one ``CREATE TABLE IF NOT EXISTS`` block)
     and per-method SQL + row mappers; the boilerplate lives here once.
 
-    Write operations on one repository instance are serialized by a per-instance
-    ``asyncio.Lock`` acquired by both :meth:`execute` and :meth:`transaction`.
-    This closes the pre-``BEGIN IMMEDIATE`` setup window from issue #245 where a
-    same-instance ``execute()`` could commit before a concurrent transaction had
-    acquired SQLite's write lock.
+    Writes use a two-level serialization model. On one repository instance, a
+    per-instance ``asyncio.Lock`` acquired by both :meth:`execute` and
+    :meth:`transaction` closes the pre-``BEGIN IMMEDIATE`` setup window from
+    issue #245 where a same-instance ``execute()`` could commit before another
+    write had reached SQLite's lock boundary. Across repository instances,
+    SQLite ``BEGIN IMMEDIATE`` plus ``PRAGMA busy_timeout=15000`` serialize
+    contended writers at the database level instead of failing fast with
+    ``database is locked``.
 
     Atomic multi-step operations use :meth:`transaction`, which opens one
     connection, issues ``BEGIN IMMEDIATE``, yields it, and ``COMMIT``s on success

--- a/src/asap/state/stores/_sqlite_base.py
+++ b/src/asap/state/stores/_sqlite_base.py
@@ -145,9 +145,16 @@ class AsyncSqliteRepository:
     Subclasses supply ``schema_ddl`` (one ``CREATE TABLE IF NOT EXISTS`` block)
     and per-method SQL + row mappers; the boilerplate lives here once.
 
+    Write operations on one repository instance are serialized by a per-instance
+    ``asyncio.Lock`` acquired by both :meth:`execute` and :meth:`transaction`.
+    This closes the pre-``BEGIN IMMEDIATE`` setup window from issue #245 where a
+    same-instance ``execute()`` could commit before a concurrent transaction had
+    acquired SQLite's write lock.
+
     Atomic multi-step operations use :meth:`transaction`, which opens one
-    connection, issues ``BEGIN``, yields it, and ``COMMIT``s on success or
-    ``ROLLBACK``s on any exception (so a mid-step crash leaves no partial state).
+    connection, issues ``BEGIN IMMEDIATE``, yields it, and ``COMMIT``s on success
+    or ``ROLLBACK``s on any exception (so a mid-step crash leaves no partial
+    state).
     """
 
     def __init__(
@@ -159,6 +166,10 @@ class AsyncSqliteRepository:
         self._schema_ddl = schema_ddl
         self._initialized = False
         self._init_lock = asyncio.Lock()
+        # Issue #245: acquire before _connect()/BEGIN IMMEDIATE so no same-instance
+        # execute() can slip into the setup window before the transaction has its
+        # SQLite write lock. This lock is intentionally non-reentrant.
+        self._write_lock = asyncio.Lock()
         # ``:memory:`` creates a *new* empty DB on every connect, so keep one
         # persistent connection alive and serialise access to it. File-backed
         # DBs use per-call connections (handled in ``_connect``). This mirrors
@@ -226,8 +237,14 @@ class AsyncSqliteRepository:
             self._initialized = True
 
     async def execute(self, sql: str, params: tuple[Any, ...] = ()) -> int:
-        """Run a write query; commit; return affected row count (0 if unknown)."""
-        async with self._connect() as conn:
+        """Run a write query; commit; return affected row count (0 if unknown).
+
+        The per-instance write lock serializes this with :meth:`transaction`.
+        Because ``asyncio.Lock`` is non-reentrant, callers must not invoke
+        :meth:`execute` from inside the same instance's active
+        :meth:`transaction` block.
+        """
+        async with self._write_lock, self._connect() as conn:
             cursor = await conn.execute(sql, params)
             await conn.commit()
             return cursor.rowcount if cursor.rowcount is not None else 0
@@ -270,8 +287,15 @@ class AsyncSqliteRepository:
         concurrent issuer cannot insert a child that escapes the cascade's
         snapshot (CR#6). ``busy_timeout=15000`` (set in ``_apply_wal_pragmas``)
         makes a contended ``BEGIN IMMEDIATE`` wait instead of failing fast.
+
+        The same per-instance write lock used by :meth:`execute` is acquired
+        before opening the connection, so a same-instance ``execute()`` cannot
+        interleave during the setup window before ``BEGIN IMMEDIATE`` runs. This
+        lock is non-reentrant: while this context manager is active, the caller
+        must use the yielded ``conn`` directly instead of calling
+        :meth:`execute` or nesting :meth:`transaction` on the same instance.
         """
-        async with self._connect() as conn:
+        async with self._write_lock, self._connect() as conn:
             await conn.execute("BEGIN IMMEDIATE")
             try:
                 yield conn

--- a/tests/state/test_sqlite_base.py
+++ b/tests/state/test_sqlite_base.py
@@ -291,6 +291,68 @@ async def test_file_backed_transaction_serializes_same_repo_execute_before_begin
     assert events.index("transaction:committed") < events.index("execute:committed")
 
 
+async def test_file_backed_execute_serializes_concurrent_same_repo_writes(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Issue #245: concurrent same-instance ``execute()`` calls must serialize.
+
+    The per-instance write lock is acquired before ``_connect()``. If that lock
+    regresses, a second ``execute()`` can enter connection/schema setup on the
+    same repository instance while the first write is still in flight.
+    """
+    db = tmp_path / "issue_245_execute_serialize.db"
+    repo = AsyncSqliteRepository(db, schema_ddl=_DDL)
+    await repo.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (1, "seed"))
+
+    first_execute_in_setup = asyncio.Event()
+    allow_first_execute_to_continue = asyncio.Event()
+    events: list[str] = []
+    original_ensure_schema = repo._ensure_schema  # noqa: SLF001
+    setup_call_count = 0
+
+    async def _gated_ensure_schema(conn: aiosqlite.Connection) -> None:
+        nonlocal setup_call_count
+        setup_call_count += 1
+        if setup_call_count == 1:
+            first_execute_in_setup.set()
+            await asyncio.wait_for(allow_first_execute_to_continue.wait(), timeout=5.0)
+        await original_ensure_schema(conn)
+
+    monkeypatch.setattr(repo, "_ensure_schema", _gated_ensure_schema)
+
+    async def _run_first_execute() -> None:
+        await repo.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (2, "first"))
+        events.append("execute:first")
+
+    async def _run_second_execute() -> None:
+        await asyncio.wait_for(first_execute_in_setup.wait(), timeout=5.0)
+        await repo.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (3, "second"))
+        events.append("execute:second")
+
+    first_execute_task = asyncio.create_task(_run_first_execute())
+    second_execute_task = asyncio.create_task(_run_second_execute())
+    try:
+        await asyncio.wait_for(first_execute_in_setup.wait(), timeout=5.0)
+        await asyncio.sleep(0.05)
+        assert setup_call_count == 1, (
+            "same-instance execute() reached connection/schema setup while the "
+            "first execute() still held the per-instance write lock"
+        )
+        assert "execute:second" not in events, (
+            "same-instance execute() committed before the first execute() "
+            "released the per-instance write lock"
+        )
+    finally:
+        allow_first_execute_to_continue.set()
+
+    await asyncio.gather(first_execute_task, second_execute_task)
+
+    rows = await repo.fetch_all("SELECT id, name FROM sample ORDER BY id")
+    assert rows == [(1, "seed"), (2, "first"), (3, "second")]
+    assert events.index("execute:first") < events.index("execute:second")
+
+
 # ---------------------------------------------------------------------------
 # parse_iso — boundary coverage
 # ---------------------------------------------------------------------------

--- a/tests/state/test_sqlite_base.py
+++ b/tests/state/test_sqlite_base.py
@@ -11,10 +11,13 @@ Tests use ``:memory:`` so no temp files are needed and runs are deterministic.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from pathlib import Path
 
+import aiosqlite
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 from asap.state.stores._sqlite_base import (
     AsyncSqliteRepository,
@@ -226,6 +229,66 @@ async def test_two_repos_share_wal_lock_without_deadlock(tmp_path: Path) -> None
     await repo_b.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (2, "b"))
     rows = await repo_a.fetch_all("SELECT id FROM sample ORDER BY id")
     assert rows == [(1,), (2,)]
+
+
+async def test_file_backed_transaction_serializes_same_repo_execute_before_begin_immediate(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Issue #245: ``execute()`` must wait during the transaction setup window.
+
+    ``transaction()`` performs connection/WAL/schema setup before issuing
+    ``BEGIN IMMEDIATE``. Without the shared per-instance write lock, a
+    same-instance ``execute()`` can commit during that pre-BEGIN window and
+    escape the transaction's intended critical section.
+    """
+    db = tmp_path / "issue_245_setup_window.db"
+    repo = AsyncSqliteRepository(db, schema_ddl=_DDL)
+    await repo.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (1, "seed"))
+
+    transaction_in_setup = asyncio.Event()
+    allow_transaction_to_begin = asyncio.Event()
+    events: list[str] = []
+    original_ensure_schema = repo._ensure_schema  # noqa: SLF001
+    setup_call_count = 0
+
+    async def _gated_ensure_schema(conn: aiosqlite.Connection) -> None:
+        nonlocal setup_call_count
+        setup_call_count += 1
+        if setup_call_count == 1:
+            transaction_in_setup.set()
+            await asyncio.wait_for(allow_transaction_to_begin.wait(), timeout=5.0)
+        await original_ensure_schema(conn)
+
+    monkeypatch.setattr(repo, "_ensure_schema", _gated_ensure_schema)
+
+    async def _run_transaction() -> None:
+        async with repo.transaction() as conn:
+            await conn.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (2, "txn"))
+        events.append("transaction:committed")
+
+    async def _run_execute() -> None:
+        await asyncio.wait_for(transaction_in_setup.wait(), timeout=5.0)
+        await repo.execute("INSERT INTO sample(id, name) VALUES (?, ?)", (3, "execute"))
+        events.append("execute:committed")
+
+    transaction_task = asyncio.create_task(_run_transaction())
+    execute_task = asyncio.create_task(_run_execute())
+    try:
+        await asyncio.wait_for(transaction_in_setup.wait(), timeout=5.0)
+        await asyncio.sleep(0.05)
+        assert "execute:committed" not in events, (
+            "same-instance execute() committed before transaction() reached "
+            "BEGIN IMMEDIATE; write serialization did not cover the setup window"
+        )
+    finally:
+        allow_transaction_to_begin.set()
+
+    await asyncio.gather(transaction_task, execute_task)
+
+    rows = await repo.fetch_all("SELECT id, name FROM sample ORDER BY id")
+    assert rows == [(1, "seed"), (2, "txn"), (3, "execute")]
+    assert events.index("transaction:committed") < events.index("execute:committed")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Serializes SQLite writes in `AsyncSqliteRepository` by adding a per-instance `asyncio.Lock` acquired by both `execute()` and `transaction()`, closing the isolation gap tracked in CR#6 follow-up.

Fixes #245

## Merge order (batch #243–#249)

| Order | PR | Issue |
|------:|-----|-------|
| 1st | #266 | #243 |
| **2nd** | **#263 (this)** | **#245** |
| 3rd | #262 | #248 |
| 4th | #265 | #247 |
| 5th | #264 | #249 |

**Rebase:** not required. Merge directly to `main`.

## Changes

- `src/asap/state/stores/_sqlite_base.py` — write lock on `execute()` and `transaction()`
- `tests/state/test_sqlite_base.py` — concurrency regressions

## Testing

```bash
uv run pytest tests/state/test_sqlite_base.py -v
```

CI green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2d8e-dfea-7656-9874-65cecdc35d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2d8e-dfea-7656-9874-65cecdc35d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

