### PR TITLE
fix(transport): add JTI replay protection on agent status route (#249)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1101,6 +1101,7 @@ nonce_store = RedisNonceStore(redis_client)
 3. **Generate Strong Nonces**: Use cryptographically secure random generators (e.g., `secrets.token_urlsafe()`)
 4. **Distributed Deployments**: Use a shared nonce store (Redis, database) for multi-instance deployments
 5. **Monitor Rejections**: Track `InvalidTimestampError` and `InvalidNonceError` to detect potential attacks
+6. **Host JWT polling**: `GET /asap/agent/status` performs a read-only `jti` replay check so polling can reuse one Host JWT, but any token already consumed by register, revoke, or rotate-key is rejected.
 
 ---
 

--- a/src/asap/auth/agent_jwt.py
+++ b/src/asap/auth/agent_jwt.py
@@ -115,6 +115,15 @@ class JtiReplayCache:
             oldest = min(self._expiry_by_key, key=lambda k: self._expiry_by_key[k])
             del self._expiry_by_key[oldest]
 
+    def contains(self, partition_key: str, jti: str) -> bool:
+        """Return whether ``jti`` is still recorded for ``partition_key``."""
+        if not jti or not str(jti).strip():
+            return False
+        now = time.time()
+        self._prune_expired(now)
+        key = (partition_key, jti)
+        return key in self._expiry_by_key and self._expiry_by_key[key] > now
+
     def check_and_record(self, partition_key: str, jti: str) -> bool:
         """Record ``jti`` for ``partition_key``.
 
@@ -221,6 +230,7 @@ async def verify_host_jwt(
     *,
     expected_audience: str | list[str] | None = None,
     jti_replay_cache: JtiReplayCache | None = None,
+    record_jti: bool = True,
 ) -> JwtVerifyResult:
     """Verify a Host JWT signature and resolve the host (or inline registration).
 
@@ -235,6 +245,11 @@ async def verify_host_jwt(
 
     When no host row exists for ``iss``, verification still succeeds (dynamic
     registration) with ``host=None`` and valid ``claims``.
+
+    When ``jti_replay_cache`` is set, callers may pass ``record_jti=False`` for
+    read-only replay checks. This preserves reusable polling tokens on
+    read-only routes while still rejecting Host JWTs whose ``jti`` was already
+    consumed by a recording route (issue #249).
     """
     try:
         header, unverified_payload = _unverified_header_and_payload(token)
@@ -271,7 +286,12 @@ async def verify_host_jwt(
     if jti_replay_cache is not None:
         partition = str(iss)
         jti = str(claims["jti"])
-        if not jti_replay_cache.check_and_record(partition, jti):
+        jti_ok = (
+            jti_replay_cache.check_and_record(partition, jti)
+            if record_jti
+            else not jti_replay_cache.contains(partition, jti)
+        )
+        if not jti_ok:
             return JwtVerifyResult(ok=False, error="jti replay detected")
 
     host = await host_store.get_by_public_key(str(iss))

--- a/src/asap/transport/_auth_helpers.py
+++ b/src/asap/transport/_auth_helpers.py
@@ -35,6 +35,7 @@ async def verify_host_bearer(
     *,
     jti_replay_cache: JtiReplayCache | None,
     require_active_host: bool = True,
+    record_jti: bool = True,
 ) -> tuple[JwtVerifyResult | None, JSONResponse | None]:
     """Verify a Host JWT Bearer token and enforce host liveness.
 
@@ -42,7 +43,9 @@ async def verify_host_bearer(
     strict behaviour previously inlined in ``agent_routes``: 401 when no token
     or signature/claim verification fails, 400 on a missing ``iss`` claim, and
     403 when the resolved host is ``revoked`` (gated by ``require_active_host``
-    so non-identity routes can opt out if needed).
+    so non-identity routes can opt out if needed). Pass ``record_jti=False`` to
+    perform a read-only replay check against ``jti_replay_cache`` without
+    consuming the token for subsequent polling requests.
 
     Returns ``(result, None)`` on success or ``(None, JSONResponse)`` on
     failure. Callers should propagate the error response unchanged.
@@ -69,6 +72,7 @@ async def verify_host_bearer(
         host_store,
         expected_audience=expected_audience,
         jti_replay_cache=jti_replay_cache,
+        record_jti=record_jti,
     )
     if not result.ok:
         # ``verify_host_jwt`` short-circuits revoked hosts to ``ok=False`` with

--- a/src/asap/transport/agent_routes.py
+++ b/src/asap/transport/agent_routes.py
@@ -503,7 +503,14 @@ async def _handle_agent_register(
 
 async def _handle_agent_status(request: Request, agent_id: str) -> JSONResponse:
     """Return agent session status and lifecycle for the authenticated host."""
-    result, err = await verify_host_bearer(request, jti_replay_cache=None)
+    jti_cache: JtiReplayCache = request.app.state.identity_jti_cache
+    # Status polling may legitimately reuse the same Host JWT, but issue #249
+    # still requires rejecting tokens already consumed on recording routes.
+    result, err = await verify_host_bearer(
+        request,
+        jti_replay_cache=jti_cache,
+        record_jti=False,
+    )
     if err is not None:
         return err
     if result is None:

--- a/src/asap/transport/server.py
+++ b/src/asap/transport/server.py
@@ -837,8 +837,11 @@ def create_app(
             message processing events.
         identity_host_store: Optional HostStore; default in-memory when both stores omitted.
         identity_agent_store: Optional AgentStore; must be set with identity_host_store or both omitted.
-        identity_jti_cache: Optional ``jti`` replay cache for Host JWT on mutating agent routes.
-            Defaults to a new in-memory cache per app.
+        identity_jti_cache: Optional ``jti`` replay cache for Host JWT on agent routes.
+            Mutating routes record ``jti`` values; ``GET /asap/agent/status`` uses
+            the same cache in read-only mode so polling can reuse a token while
+            still rejecting Host JWTs already consumed elsewhere. Defaults to a
+            new in-memory cache per app.
         identity_jwt_audience: Expected ``aud`` value(s) for Host JWT verification on
             ``/asap/agent/*``. Defaults to ``manifest.id`` so tokens are bound to this
             server instance. Set explicitly for multi-audience or migration scenarios.

--- a/tests/auth/test_agent_jwt.py
+++ b/tests/auth/test_agent_jwt.py
@@ -549,6 +549,18 @@ def test_jti_replay_cache_same_jti_allowed_after_ttl(monkeypatch: pytest.MonkeyP
     assert cache.check_and_record("part", "jti-1")
 
 
+def test_jti_replay_cache_contains_respects_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``contains()`` reports only unexpired replay keys for a partition."""
+    cache = JtiReplayCache(ttl_seconds=1.0)
+    t0 = 20_000.0
+    monkeypatch.setattr("asap.auth.agent_jwt.time.time", lambda: t0)
+    assert not cache.contains("part", "jti-1")
+    assert cache.check_and_record("part", "jti-1")
+    assert cache.contains("part", "jti-1")
+    monkeypatch.setattr("asap.auth.agent_jwt.time.time", lambda: t0 + 2.0)
+    assert not cache.contains("part", "jti-1")
+
+
 def test_jti_replay_cache_rejects_blank_jti() -> None:
     """Empty or whitespace ``jti`` must not be recorded as a replay key."""
     cache = JtiReplayCache()

--- a/tests/transport/test_server.py
+++ b/tests/transport/test_server.py
@@ -1813,7 +1813,7 @@ class TestAgentStatusEndpoint:
         sample_manifest: Manifest,
         isolated_rate_limiter: "ASAPRateLimiter | None",
     ) -> None:
-        """GET status does not record ``jti``; same token can poll repeatedly."""
+        """GET status preserves polling by not recording ``jti`` on each read."""
         app, _a, _h = _app_with_identity_stores(sample_manifest, isolated_rate_limiter)
         host_sk = Ed25519PrivateKey.generate()
         agent_sk = Ed25519PrivateKey.generate()
@@ -1833,6 +1833,87 @@ class TestAgentStatusEndpoint:
         u = f"/asap/agent/status?agent_id={aid}"
         assert client.get(u, headers=headers).status_code == 200
         assert client.get(u, headers=headers).status_code == 200
+
+    def test_status_rejects_host_jwt_replayed_from_recording_route(
+        self,
+        sample_manifest: Manifest,
+        isolated_rate_limiter: "ASAPRateLimiter | None",
+    ) -> None:
+        """Status rejects Host JWTs whose ``jti`` was already consumed elsewhere."""
+        app, _a, _h = _app_with_identity_stores(sample_manifest, isolated_rate_limiter)
+        host_sk = Ed25519PrivateKey.generate()
+        agent_sk = Ed25519PrivateKey.generate()
+        reg_tok = create_host_jwt(
+            host_sk,
+            aud=_HOST_JWT_AUDIENCE,
+            agent_public_key=ed25519_public_jwk(agent_sk),
+            ttl_seconds=120,
+        )
+        client = TestClient(app)
+        aid = client.post(
+            "/asap/agent/register",
+            headers={"Authorization": f"Bearer {reg_tok}"},
+        ).json()["agent_id"]
+
+        replay = client.get(
+            f"/asap/agent/status?agent_id={aid}",
+            headers={"Authorization": f"Bearer {reg_tok}"},
+        )
+        assert replay.status_code == 401
+        assert replay.json() == {"detail": "jti replay detected"}
+
+    @pytest.mark.parametrize("recording_route", ["/asap/agent/revoke", "/asap/agent/rotate-key"])
+    def test_status_rejects_host_jwt_replayed_after_recording_route(
+        self,
+        sample_manifest: Manifest,
+        isolated_rate_limiter: "ASAPRateLimiter | None",
+        recording_route: str,
+    ) -> None:
+        """Status rejects Host JWTs already consumed by revoke or rotate-key."""
+        app, _agent_store, _host_store = _app_with_identity_stores(
+            sample_manifest, isolated_rate_limiter
+        )
+        host_sk = Ed25519PrivateKey.generate()
+        agent_sk = Ed25519PrivateKey.generate()
+        reg_tok = create_host_jwt(
+            host_sk,
+            aud=_HOST_JWT_AUDIENCE,
+            agent_public_key=ed25519_public_jwk(agent_sk),
+            ttl_seconds=120,
+        )
+        client = TestClient(app)
+        aid = client.post(
+            "/asap/agent/register",
+            headers={"Authorization": f"Bearer {reg_tok}"},
+        ).json()["agent_id"]
+
+        recording_tok = create_host_jwt(host_sk, aud=_HOST_JWT_AUDIENCE, ttl_seconds=120)
+        recording_headers = {"Authorization": f"Bearer {recording_tok}"}
+        if recording_route == "/asap/agent/revoke":
+            route_response = client.post(
+                recording_route,
+                headers=recording_headers,
+                json={"agent_id": aid},
+            )
+            assert route_response.status_code == 200
+            assert route_response.json()["status"] == "revoked"
+        else:
+            route_response = client.post(
+                recording_route,
+                headers=recording_headers,
+                json={
+                    "agent_id": aid,
+                    "new_public_key": ed25519_public_jwk(Ed25519PrivateKey.generate()),
+                },
+            )
+            assert route_response.status_code == 200
+
+        replay = client.get(
+            f"/asap/agent/status?agent_id={aid}",
+            headers=recording_headers,
+        )
+        assert replay.status_code == 401
+        assert replay.json() == {"detail": "jti replay detected"}
 
     def test_status_wrong_host_returns_403(
         self,

--- a/tests/transport/unit/test_auth_helpers.py
+++ b/tests/transport/unit/test_auth_helpers.py
@@ -14,6 +14,7 @@ from starlette.requests import Request
 
 from asap.auth.agent_jwt import (
     HOST_REVOKED_ERROR,
+    JtiReplayCache,
     JwtVerifyResult,
     create_host_jwt,
 )
@@ -140,6 +141,46 @@ async def test_verify_host_bearer_valid_token_returns_result() -> None:
     assert result.ok is True
     assert isinstance(result.claims, dict)
     assert result.claims.get("iss")
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore:EdDSA is deprecated:UserWarning")
+async def test_verify_host_bearer_read_only_jti_check_preserves_polling() -> None:
+    """Read-only JTI checks allow polling but reject tokens spent elsewhere."""
+    host_sk = Ed25519PrivateKey.generate()
+    host_store = InMemoryHostStore()
+    await _seed_active_host(host_sk, host_store)
+    app = _identity_app(host_store)
+    token = create_host_jwt(host_sk, aud=_HOST_JWT_AUDIENCE, ttl_seconds=120)
+    cache = JtiReplayCache()
+
+    for _ in range(2):
+        result, err = await verify_host_bearer(
+            _http_request(app, authorization=f"Bearer {token}"),
+            jti_replay_cache=cache,
+            record_jti=False,
+        )
+        assert err is None
+        assert result is not None
+        assert result.ok is True
+
+    recorded_result, recorded_err = await verify_host_bearer(
+        _http_request(app, authorization=f"Bearer {token}"),
+        jti_replay_cache=cache,
+    )
+    assert recorded_err is None
+    assert recorded_result is not None
+    assert recorded_result.ok is True
+
+    replay_result, replay_err = await verify_host_bearer(
+        _http_request(app, authorization=f"Bearer {token}"),
+        jti_replay_cache=cache,
+        record_jti=False,
+    )
+    assert replay_result is None
+    assert replay_err is not None
+    assert replay_err.status_code == 401
+    assert replay_err.body == b'{"detail":"jti replay detected"}'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Enables JTI replay protection on `GET /asap/agent/status` while preserving poll-friendly behavior: status checks the shared replay cache (`record_jti=False`) without recording each poll, but rejects JWTs whose `jti` was already consumed on recording identity routes (`register`, `revoke`, `rotate-key`).

Fixes #249

## Merge order (batch #243–#249)

| Order | PR | Issue |
|------:|-----|-------|
| 1st | #266 | #243 |
| 2nd | #263 | #245 |
| 3rd | #262 | #248 |
| 4th | #265 | #247 |
| **5th** | **#264 (this)** | **#249** |

**Rebase:** not required if prior PRs are already on `main`. Merge last (auth/identity).

Scope: single commit, #249 files only (no #245/#243).

## Testing

```bash
uv run pytest tests/transport/test_server.py -k "status_rejects or status_same_host" tests/transport/unit/test_auth_helpers.py -k jti -v
```

CI green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2d8e-dfea-7656-9874-65cecdc35d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2d8e-dfea-7656-9874-65cecdc35d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

