### PR TITLE
fix(transport): bind correlation_id on streaming paths (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **CI security (`pip-audit`)**: Raised `joserfc` to `>=1.6.7,<2` (CVE-2026-48990) and added overrides for `python-engineio>=4.13.2` (CVE-2026-48802 / CVE-2026-48809) and `python-socketio>=5.16.2` (CVE-2026-48804). See [SECURITY.md](SECURITY.md).
+- **Streaming correlation binding (#247)**: SSE and WebSocket streaming now require `TaskStream` chunks to echo the request envelope `id` (not an arbitrary request `correlation_id`), and streamed response payloads reject missing or mismatched `correlation_id` values.
 
 ### Follow-up (not in v2.5.1)
 

--- a/src/asap/models/envelope.py
+++ b/src/asap/models/envelope.py
@@ -31,6 +31,14 @@ def _parse_payload(payload_type: str, payload: dict[str, Any]) -> PayloadType | 
     return cast(PayloadType, payload_class.model_validate(payload))
 
 
+# Structural correlation_id requirement: unary response payloads and streamed
+# TaskStream chunks must always carry a non-empty correlation_id so transport
+# pairing can then enforce request-id binding separately (B6/BUG #6, CR#4).
+CORRELATION_REQUIRED_PAYLOAD_KEYS = frozenset(
+    {"taskresponse", "taskstream", "mcptoolresult", "mcpresourcedata"}
+)
+
+
 class Envelope(ASAPBaseModel):
     """ASAP protocol message envelope.
 
@@ -137,10 +145,8 @@ class Envelope(ASAPBaseModel):
 
     @model_validator(mode="after")
     def validate_response_correlation(self) -> "Envelope":
-        response_type_keys = {"taskresponse", "mcptoolresult", "mcpresourcedata"}
-
         if (
-            _normalize_payload_type(self.payload_type) in response_type_keys
+            _normalize_payload_type(self.payload_type) in CORRELATION_REQUIRED_PAYLOAD_KEYS
             and not self.correlation_id
         ):
             raise ValueError(f"{self.payload_type} must have correlation_id for request tracking")

--- a/src/asap/transport/client/_send.py
+++ b/src/asap/transport/client/_send.py
@@ -48,7 +48,11 @@ from asap.transport.compression import (
     compress_payload,
     get_accept_encoding_header,
 )
-from asap.transport.errors import ProtocolCorrelationError, assert_correlation_binds
+from asap.transport.errors import (
+    ProtocolCorrelationError,
+    assert_correlation_binds,
+    assert_stream_correlation_binds,
+)
 from asap.transport.jsonrpc import ASAP_METHOD
 from asap.transport.websocket import WebSocketRemoteError
 from asap.utils.sanitization import sanitize_url
@@ -622,7 +626,9 @@ class _SendMixin:
         """POST to ``/asap/stream`` and yield each SSE ``data:`` line as an ``Envelope``.
 
         Requires HTTP transport (not WebSocket). Each event body is a full envelope,
-        typically with ``payload_type`` ``TaskStream``.
+        typically with ``payload_type`` ``TaskStream``. Streamed response payloads
+        and ``TaskStream`` chunks are correlation-bound to ``envelope.id`` before
+        they are yielded (CR#4).
 
         Args:
             envelope: Outgoing request envelope (e.g. ``TaskRequest``).
@@ -712,4 +718,9 @@ class _SendMixin:
                         if not json_str:
                             continue
                         data = json.loads(json_str)
-                        yield Envelope.model_validate(data)
+                        stream_envelope = Envelope.model_validate(data)
+                        # BINDING: streamed chunks still answer the specific
+                        # request that opened this SSE stream, so reject chunks
+                        # whose correlation_id points at a different request.
+                        assert_stream_correlation_binds(str(envelope.id), stream_envelope)
+                        yield stream_envelope

--- a/src/asap/transport/errors.py
+++ b/src/asap/transport/errors.py
@@ -103,14 +103,7 @@ def assert_correlation_binds(request_envelope_id: str, response: "Envelope") -> 
         ProtocolCorrelationError: If ``response`` is a response payload type
             whose ``correlation_id`` does not equal ``request_envelope_id``.
     """
-    if _normalize_payload_type(response.payload_type) not in RESPONSE_PAYLOAD_KEYS:
-        return
-    if response.correlation_id == request_envelope_id:
-        return
-    raise ProtocolCorrelationError(
-        request_id=request_envelope_id,
-        correlation_id=response.correlation_id,
-    )
+    _assert_correlation_binds(request_envelope_id, response, RESPONSE_PAYLOAD_KEYS)
 
 
 def assert_stream_correlation_binds(request_envelope_id: str, response: "Envelope") -> None:
@@ -131,7 +124,16 @@ def assert_stream_correlation_binds(request_envelope_id: str, response: "Envelop
         ProtocolCorrelationError: If ``response`` is a stream-bound payload type
             whose ``correlation_id`` does not equal ``request_envelope_id``.
     """
-    if _normalize_payload_type(response.payload_type) not in STREAM_BOUND_PAYLOAD_KEYS:
+    _assert_correlation_binds(request_envelope_id, response, STREAM_BOUND_PAYLOAD_KEYS)
+
+
+def _assert_correlation_binds(
+    request_envelope_id: str,
+    response: "Envelope",
+    bound_keys: frozenset[str],
+) -> None:
+    """Raise when a bound payload's ``correlation_id`` does not match the request id."""
+    if _normalize_payload_type(response.payload_type) not in bound_keys:
         return
     if response.correlation_id == request_envelope_id:
         return

--- a/src/asap/transport/errors.py
+++ b/src/asap/transport/errors.py
@@ -12,10 +12,10 @@ The taxonomy code and JSON-RPC slot reuse ``asap:protocol/malformed_envelope``
 (``RemoteRPCError``, whose ``is_recoverable`` property distinguishes fatal
 from retryable remote JSON-RPC failures after the v2.5.1 twin-class collapse).
 
-This module is also the single source of truth for the response-binding check
-(``assert_correlation_binds``) shared by the HTTP client (``send``/``batch``)
-and the WebSocket recv loop, so the binding contract cannot drift between
-pairing sites (B6/BUG #6).
+This module is also the single source of truth for the response-binding checks
+(``assert_correlation_binds`` / ``assert_stream_correlation_binds``) shared by
+the HTTP client and WebSocket transport, so the binding contract cannot drift
+between unary and streaming pairing sites (B6/BUG #6, CR#4).
 """
 
 from __future__ import annotations
@@ -28,13 +28,23 @@ from asap.models.envelope import _normalize_payload_type
 if TYPE_CHECKING:
     from asap.models.envelope import Envelope
 
-__all__ = ["RESPONSE_PAYLOAD_KEYS", "ProtocolCorrelationError", "assert_correlation_binds"]
+__all__ = [
+    "RESPONSE_PAYLOAD_KEYS",
+    "STREAM_BOUND_PAYLOAD_KEYS",
+    "ProtocolCorrelationError",
+    "assert_correlation_binds",
+    "assert_stream_correlation_binds",
+]
 
 
-# Response payload types whose correlation_id must bind to the request id
-# (B6/BUG #6). Server-push notifications, acks and streaming chunks are
-# intentionally loose because they are not paired to a single request id.
+# Unary response payload types whose correlation_id must bind to the request id
+# (B6/BUG #6).
 RESPONSE_PAYLOAD_KEYS = frozenset({"taskresponse", "mcptoolresult", "mcpresourcedata"})
+
+# Streaming pairing is stricter than unary receive(): ``TaskStream`` chunks are
+# also bound because they are emitted in answer to one specific request stream
+# (CR#4).
+STREAM_BOUND_PAYLOAD_KEYS = RESPONSE_PAYLOAD_KEYS | frozenset({"taskstream"})
 
 
 class ProtocolCorrelationError(FatalError):
@@ -81,8 +91,8 @@ def assert_correlation_binds(request_envelope_id: str, response: "Envelope") -> 
     batch.
 
     Non-response payload types (server-push notifications, acks, streaming
-    chunks) intentionally skip the binding check because they are not paired to
-    a specific request id.
+    chunks) intentionally skip the binding check because unary pairing sites do
+    not bind them to a specific request id.
 
     Args:
         request_envelope_id: The ``id`` of the request envelope we are pairing
@@ -94,6 +104,34 @@ def assert_correlation_binds(request_envelope_id: str, response: "Envelope") -> 
             whose ``correlation_id`` does not equal ``request_envelope_id``.
     """
     if _normalize_payload_type(response.payload_type) not in RESPONSE_PAYLOAD_KEYS:
+        return
+    if response.correlation_id == request_envelope_id:
+        return
+    raise ProtocolCorrelationError(
+        request_id=request_envelope_id,
+        correlation_id=response.correlation_id,
+    )
+
+
+def assert_stream_correlation_binds(request_envelope_id: str, response: "Envelope") -> None:
+    """Assert that a streamed envelope binds to the request that opened the stream.
+
+    Streaming transport pairs each yielded chunk to a single request initiated
+    by the client. In addition to regular response payloads, ``TaskStream``
+    chunks MUST carry ``correlation_id == request_envelope_id`` so a
+    buggy/malicious server cannot splice another request's chunks into the
+    active stream (CR#4).
+
+    Args:
+        request_envelope_id: The ``id`` of the request envelope that opened the
+            stream.
+        response: The streamed envelope received from the peer.
+
+    Raises:
+        ProtocolCorrelationError: If ``response`` is a stream-bound payload type
+            whose ``correlation_id`` does not equal ``request_envelope_id``.
+    """
+    if _normalize_payload_type(response.payload_type) not in STREAM_BOUND_PAYLOAD_KEYS:
         return
     if response.correlation_id == request_envelope_id:
         return

--- a/src/asap/transport/ws/client.py
+++ b/src/asap/transport/ws/client.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any, Union, cast
 from asap.models.envelope import Envelope
 from asap.observability import get_logger
 from asap.transport.circuit_breaker import CircuitBreaker
+from asap.transport.errors import assert_stream_correlation_binds
 from asap.transport.ws._ack import PendingAck, _AckRetransmit
 from asap.transport.ws._errors import WebSocketRemoteError
 from asap.transport.ws._recv import _RecvDispatch
@@ -333,7 +334,9 @@ class WebSocketTransport(_RecvDispatch, _AckRetransmit):
         """Send one JSON-RPC frame and yield each streaming ``result.envelope``.
 
         Stops after an envelope whose payload has ``final=True`` (e.g. ``TaskStream``).
-        Skips heartbeat pongs and ``asap.ack`` notifications.
+        Skips heartbeat pongs and ``asap.ack`` notifications. Streamed response
+        payloads and ``TaskStream`` chunks are correlation-bound to
+        ``envelope.id`` before they are yielded (CR#4).
         """
         request_id = await self._send_frame(envelope, register_ack=True)
         ws = self._ws
@@ -358,6 +361,9 @@ class WebSocketTransport(_RecvDispatch, _AckRetransmit):
             if not result or "envelope" not in result:
                 raise WebSocketRemoteError(-32603, "Missing result.envelope in response", data=data)
             env = Envelope.model_validate(result["envelope"])
+            # BINDING: WS streaming frames must still belong to the request
+            # that opened this stream, not some concurrent request.
+            assert_stream_correlation_binds(str(envelope.id), env)
             yield env
             if env.payload_dict.get("final") is True:
                 break

--- a/tests/transport/test_client.py
+++ b/tests/transport/test_client.py
@@ -2195,3 +2195,43 @@ class TestClientCorrelationBinding:
             assert "correlation_id" in message
             assert repr(sample_request_envelope.id) in message
             assert repr("different-id") in message
+
+    async def test_stream_rejects_mismatched_taskresponse_correlation_id(
+        self, sample_request_envelope: Envelope
+    ) -> None:
+        """CR#4: ``stream`` also rejects a streamed ``TaskResponse`` bound elsewhere."""
+        mismatched_response = Envelope(
+            asap_version="0.1",
+            sender="urn:asap:agent:server",
+            recipient="urn:asap:agent:client",
+            payload_type="task.response",
+            payload=TaskResponse(
+                task_id="task_stream_response",
+                status=TaskStatus.COMPLETED,
+                result={"echoed": {"message": "Hello!"}},
+            ).model_dump(),
+            correlation_id="different-id",
+        )
+
+        def mock_transport(_: httpx.Request) -> httpx.Response:
+            stream_body = (
+                f"data: {json.dumps(mismatched_response.model_dump(mode='json'))}\n\n".encode(
+                    "utf-8"
+                )
+            )
+            return httpx.Response(
+                status_code=200,
+                headers={"content-type": "text/event-stream"},
+                content=stream_body,
+            )
+
+        async with ASAPClient(
+            "http://localhost:8000", transport=httpx.MockTransport(mock_transport)
+        ) as client:
+            with pytest.raises(ProtocolCorrelationError) as exc_info:
+                _ = [chunk async for chunk in client.stream(sample_request_envelope)]
+
+            message = str(exc_info.value)
+            assert "correlation_id" in message
+            assert repr(sample_request_envelope.id) in message
+            assert repr("different-id") in message

--- a/tests/transport/test_client.py
+++ b/tests/transport/test_client.py
@@ -28,6 +28,7 @@ from asap.transport.client import (
     ASAPTimeoutError,
     RetryConfig,
 )
+from asap.transport.errors import ProtocolCorrelationError
 
 if TYPE_CHECKING:
     from asap.transport.rate_limit import ASAPRateLimiter
@@ -2132,8 +2133,6 @@ class TestClientCorrelationBinding:
         self, sample_request_envelope: Envelope
     ) -> None:
         """``send`` raises ``ProtocolCorrelationError`` when response correlation_id != request id."""
-        from asap.transport.errors import ProtocolCorrelationError
-
         # Non-empty but different from sample_request_envelope.id so it passes the
         # structural non-empty check but must fail the binding check.
         mismatched_response = Envelope(
@@ -2157,6 +2156,40 @@ class TestClientCorrelationBinding:
         ) as client:
             with pytest.raises(ProtocolCorrelationError) as exc_info:
                 await client.send(sample_request_envelope)
+
+            message = str(exc_info.value)
+            assert "correlation_id" in message
+            assert repr(sample_request_envelope.id) in message
+            assert repr("different-id") in message
+
+    async def test_stream_rejects_mismatched_taskstream_correlation_id(
+        self, sample_request_envelope: Envelope
+    ) -> None:
+        """CR#4: ``stream`` rejects a ``TaskStream`` chunk bound to a different request id."""
+        mismatched_chunk = Envelope(
+            asap_version="0.1",
+            sender="urn:asap:agent:server",
+            recipient="urn:asap:agent:client",
+            payload_type="TaskStream",
+            payload={"chunk": "partial", "final": True, "progress": 1.0},
+            correlation_id="different-id",
+        )
+
+        def mock_transport(_: httpx.Request) -> httpx.Response:
+            stream_body = (
+                f"data: {json.dumps(mismatched_chunk.model_dump(mode='json'))}\n\n".encode("utf-8")
+            )
+            return httpx.Response(
+                status_code=200,
+                headers={"content-type": "text/event-stream"},
+                content=stream_body,
+            )
+
+        async with ASAPClient(
+            "http://localhost:8000", transport=httpx.MockTransport(mock_transport)
+        ) as client:
+            with pytest.raises(ProtocolCorrelationError) as exc_info:
+                _ = [chunk async for chunk in client.stream(sample_request_envelope)]
 
             message = str(exc_info.value)
             assert "correlation_id" in message

--- a/tests/transport/test_streaming.py
+++ b/tests/transport/test_streaming.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator
 import httpx
 import pytest
 from httpx import ASGITransport
+from pydantic import ValidationError
 
 from asap.models.constants import ASAP_DEFAULT_TRANSPORT_VERSION, ASAP_VERSION_HEADER
 from asap.models.entities import Manifest
@@ -29,7 +30,6 @@ async def _word_stream_handler(envelope: Envelope, manifest: Any) -> AsyncIterat
     req = TaskRequest.model_validate(envelope.payload_dict)
     text = str(req.input.get("text", "hello stream"))
     words = text.split() or ["empty"]
-    cid = envelope.correlation_id or envelope.id or "corr"
     n = len(words)
     for i, w in enumerate(words):
         is_final = i == n - 1
@@ -45,7 +45,7 @@ async def _word_stream_handler(envelope: Envelope, manifest: Any) -> AsyncIterat
             recipient=envelope.sender,
             payload_type="TaskStream",
             payload=pl.model_dump(mode="json"),
-            correlation_id=cid,
+            correlation_id=envelope.id,
             trace_id=envelope.trace_id,
         )
 
@@ -65,6 +65,21 @@ async def test_taskstream_envelope_roundtrip(sample_manifest: Manifest) -> None:
     assert restored.payload_type == "TaskStream"
     assert isinstance(restored.payload, TaskStream)
     assert restored.payload.chunk == "x"
+
+
+def test_taskstream_envelope_requires_correlation_id(sample_manifest: Manifest) -> None:
+    """``TaskStream`` envelopes must carry ``correlation_id`` for stream pairing."""
+    payload = TaskStream(chunk="x", progress=0.5, final=False, status=TaskStatus.WORKING)
+
+    with pytest.raises(ValidationError, match="TaskStream must have correlation_id"):
+        Envelope(
+            asap_version="0.1",
+            sender="urn:asap:agent:a",
+            recipient=sample_manifest.id,
+            payload_type="TaskStream",
+            payload=payload.model_dump(mode="json"),
+            correlation_id=None,
+        )
 
 
 @pytest.mark.anyio
@@ -118,6 +133,7 @@ async def test_asap_stream_sse_endpoint(
                         events.append(Envelope.model_validate(json.loads(payload_json)))
 
     assert len(events) == 2
+    assert all(event.correlation_id == env.id for event in events)
     assert events[0].payload_dict.get("chunk") == "one "
     assert events[0].payload_dict.get("final") is False
     assert events[-1].payload_dict.get("final") is True

--- a/tests/transport/test_websocket.py
+++ b/tests/transport/test_websocket.py
@@ -16,8 +16,10 @@ from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
 from asap.models.entities import Manifest
+from asap.models.enums import TaskStatus
 from asap.models.envelope import Envelope
-from asap.models.payloads import MessageAck, TaskRequest
+from asap.models.payloads import MessageAck, TaskRequest, TaskResponse
+from asap.transport.errors import ProtocolCorrelationError
 from asap.transport.jsonrpc import ASAP_METHOD, JsonRpcRequest
 from asap.transport.server import create_app
 from asap.transport.websocket import (
@@ -427,10 +429,6 @@ class TestWebSocketTransportCorrelation(NoRateLimitTestBase):
         loop must raise ``ProtocolCorrelationError`` rather than pairing it with
         the in-flight request. Deterministic: ``_ws`` is mocked, no real server.
         """
-        from asap.models.enums import TaskStatus
-        from asap.models.payloads import TaskResponse
-        from asap.transport.errors import ProtocolCorrelationError
-
         request = Envelope(
             asap_version="0.1",
             sender="urn:asap:agent:client",
@@ -2640,6 +2638,7 @@ class TestSendAndReceiveStream:
         chunk: str = "part",
         final: bool = False,
         frame_id: str | None = None,
+        correlation_id: str = "c1",
     ) -> str:
         env = Envelope(
             asap_version="0.1",
@@ -2647,7 +2646,7 @@ class TestSendAndReceiveStream:
             recipient="urn:asap:agent:client",
             payload_type="TaskStream",
             payload={"chunk": chunk, "final": final, "progress": 0.5},
-            correlation_id="c1",
+            correlation_id=correlation_id,
         )
         return json.dumps(
             {
@@ -2669,16 +2668,21 @@ class TestSendAndReceiveStream:
         transport = self._transport()
         ws = _mock_ws()
         transport._ws = ws
+        request = _sample_envelope_cov()
         req_id = self._REQ_ID
         ws.recv = AsyncMock(
             side_effect=[
-                self._stream_result_frame(req_id, chunk="a", final=False),
-                self._stream_result_frame(req_id, chunk="b", final=True),
+                self._stream_result_frame(
+                    req_id, chunk="a", final=False, correlation_id=str(request.id)
+                ),
+                self._stream_result_frame(
+                    req_id, chunk="b", final=True, correlation_id=str(request.id)
+                ),
             ]
         )
         chunks: list[str] = []
         with patch.object(transport, "_next_request_id", return_value=req_id):
-            async for env in transport.send_and_receive_stream(_sample_envelope_cov()):
+            async for env in transport.send_and_receive_stream(request):
                 chunks.append(str(env.payload_dict.get("chunk")))
         assert chunks == ["a", "b"]
 
@@ -2687,6 +2691,7 @@ class TestSendAndReceiveStream:
         transport = self._transport()
         ws = _mock_ws()
         transport._ws = ws
+        request = _sample_envelope_cov()
         req_id = self._REQ_ID
         ack = json.dumps({"jsonrpc": "2.0", "method": ASAP_ACK_METHOD, "params": {}})
         pong = json.dumps({"type": HEARTBEAT_FRAME_TYPE_PONG})
@@ -2694,12 +2699,12 @@ class TestSendAndReceiveStream:
             side_effect=[
                 pong,
                 ack,
-                self._stream_result_frame(req_id, final=True),
+                self._stream_result_frame(req_id, final=True, correlation_id=str(request.id)),
             ]
         )
         count = 0
         with patch.object(transport, "_next_request_id", return_value=req_id):
-            async for _ in transport.send_and_receive_stream(_sample_envelope_cov()):
+            async for _ in transport.send_and_receive_stream(request):
                 count += 1
         assert count == 1
 
@@ -2729,16 +2734,17 @@ class TestSendAndReceiveStream:
         transport = self._transport()
         ws = _mock_ws()
         transport._ws = ws
+        request = _sample_envelope_cov()
         req_id = self._REQ_ID
         ws.recv = AsyncMock(
             side_effect=[
-                self._stream_result_frame(req_id, frame_id="other"),
-                self._stream_result_frame(req_id, final=True),
+                self._stream_result_frame(req_id, frame_id="other", correlation_id=str(request.id)),
+                self._stream_result_frame(req_id, final=True, correlation_id=str(request.id)),
             ]
         )
         count = 0
         with patch.object(transport, "_next_request_id", return_value=req_id):
-            async for _ in transport.send_and_receive_stream(_sample_envelope_cov()):
+            async for _ in transport.send_and_receive_stream(request):
                 count += 1
         assert count == 1
 
@@ -2757,14 +2763,43 @@ class TestSendAndReceiveStream:
                 pass
 
     @pytest.mark.asyncio
+    async def test_rejects_mismatched_taskstream_correlation_id(self) -> None:
+        """CR#4: WS streaming rejects a ``TaskStream`` chunk bound to another request."""
+        transport = self._transport()
+        ws = _mock_ws()
+        transport._ws = ws
+        request = _sample_envelope_cov()
+        req_id = self._REQ_ID
+        ws.recv = AsyncMock(
+            return_value=self._stream_result_frame(
+                req_id,
+                chunk="wrong",
+                final=True,
+                correlation_id="different-id",
+            )
+        )
+        with (
+            patch.object(transport, "_next_request_id", return_value=req_id),
+            pytest.raises(ProtocolCorrelationError, match="correlation_id mismatch"),
+        ):
+            async for _ in transport.send_and_receive_stream(request):
+                pass
+
+    @pytest.mark.asyncio
     async def test_mid_stream_disconnect_propagates(self) -> None:
         transport = self._transport()
         ws = _mock_ws()
         transport._ws = ws
+        request = _sample_envelope_cov()
         req_id = self._REQ_ID
         ws.recv = AsyncMock(
             side_effect=[
-                self._stream_result_frame(req_id, chunk="ok", final=False),
+                self._stream_result_frame(
+                    req_id,
+                    chunk="ok",
+                    final=False,
+                    correlation_id=str(request.id),
+                ),
                 OSError("connection lost"),
             ]
         )
@@ -2772,7 +2807,7 @@ class TestSendAndReceiveStream:
             patch.object(transport, "_next_request_id", return_value=req_id),
             pytest.raises(OSError, match="connection lost"),
         ):
-            async for _ in transport.send_and_receive_stream(_sample_envelope_cov()):
+            async for _ in transport.send_and_receive_stream(request):
                 pass
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Binds `correlation_id` on streaming transport paths (#247) so spliced or mismatched chunks are rejected before the caller can act on them.

## Merge note

Merged `main` (includes #262 WS test rewire) and resolved the import conflict in `tests/transport/test_websocket.py` — keeps both `ProtocolCorrelationError` / `TaskResponse` (#247) and `INTERNAL_ERROR` (#248) imports.

## Merge order

Merge after #262 (now on `main`). Ready for CI + merge.

## Related

- Closes #247
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2d8e-dfea-7656-9874-65cecdc35d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2d8e-dfea-7656-9874-65cecdc35d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

