### PR TITLE
refactor(auth): extract parse_scope to break middleware import cycle (#243)

### DIFF
--- a/src/asap/auth/_scope_parse.py
+++ b/src/asap/auth/_scope_parse.py
@@ -1,0 +1,31 @@
+"""Scope claim parsing helpers for ASAP Protocol."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def parse_scope(claim: Any) -> list[str]:
+    """Normalize a scope claim to a list of strings.
+
+    JWT/OAuth2 scope can be a space-separated string (RFC 6749) or a list.
+
+    Args:
+        claim: Raw scope value from JWT claims or introspection response.
+
+    Returns:
+        List of scope strings (empty if claim is None or invalid).
+
+    Example:
+        >>> parse_scope("asap:read asap:execute")
+        ['asap:read', 'asap:execute']
+        >>> parse_scope(["a", "b"])
+        ['a', 'b']
+    """
+    if claim is None:
+        return []
+    if isinstance(claim, list):
+        return [str(s) for s in claim]
+    if isinstance(claim, str):
+        return [s.strip() for s in claim.split() if s.strip()]
+    return []

--- a/src/asap/auth/_scope_parse.py
+++ b/src/asap/auth/_scope_parse.py
@@ -1,4 +1,12 @@
-"""Scope claim parsing helpers for ASAP Protocol."""
+"""Scope claim parsing helpers for ASAP Protocol.
+
+Kept as a tiny leaf module so ``asap.auth.scopes`` and
+``asap.auth.middleware`` can both normalize OAuth2/JWT scope claims without
+importing each other. ``scopes.require_scope`` references
+``middleware.OAuth2Claims`` at runtime, while middleware needs
+``parse_scope`` during bearer token validation, so this module breaks that
+import cycle.
+"""
 
 from __future__ import annotations
 

--- a/src/asap/auth/middleware.py
+++ b/src/asap/auth/middleware.py
@@ -20,6 +20,7 @@ from joserfc import jwk
 from joserfc.errors import JoseError
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from asap.auth._scope_parse import parse_scope
 from asap.auth.jwks import JWKSValidator
 from asap.observability import get_logger
 
@@ -326,11 +327,6 @@ class OAuth2Middleware(BaseHTTPMiddleware):
                 content={"detail": ERROR_INVALID_TOKEN},
                 headers={"WWW-Authenticate": "Bearer"},
             )
-
-        # Imported here (not at module top) to break the scopes <-> middleware
-        # import cycle: scopes.require_scope references OAuth2Claims at runtime,
-        # so scopes must import middleware, which in turn needs parse_scope.
-        from asap.auth.scopes import parse_scope
 
         scope_list = parse_scope(claims.get("scope"))
         if not self._validate_scope(scope_list):

--- a/src/asap/auth/scopes.py
+++ b/src/asap/auth/scopes.py
@@ -6,10 +6,11 @@ required scopes on protected routes.
 
 from __future__ import annotations
 
-from typing import Any, Callable, cast
+from typing import Callable, cast
 
 from fastapi import HTTPException, Request
 
+from asap.auth._scope_parse import parse_scope
 from asap.auth.middleware import OAuth2Claims
 
 # Scope constants for ASAP operations
@@ -23,30 +24,13 @@ ERROR_AUTH_REQUIRED = "Authentication required"
 ERROR_INSUFFICIENT_SCOPE = "Insufficient scope"
 
 
-def parse_scope(claim: Any) -> list[str]:
-    """Normalize a scope claim to a list of strings.
-
-    JWT/OAuth2 scope can be a space-separated string (RFC 6749) or a list.
-
-    Args:
-        claim: Raw scope value from JWT claims or introspection response.
-
-    Returns:
-        List of scope strings (empty if claim is None or invalid).
-
-    Example:
-        >>> parse_scope("asap:read asap:execute")
-        ['asap:read', 'asap:execute']
-        >>> parse_scope(["a", "b"])
-        ['a', 'b']
-    """
-    if claim is None:
-        return []
-    if isinstance(claim, list):
-        return [str(s) for s in claim]
-    if isinstance(claim, str):
-        return [s.strip() for s in claim.split() if s.strip()]
-    return []
+__all__ = [
+    "SCOPE_READ",
+    "SCOPE_EXECUTE",
+    "SCOPE_ADMIN",
+    "parse_scope",
+    "require_scope",
+]
 
 
 def require_scope(scope: str) -> Callable[[Request], OAuth2Claims]:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Extracts `parse_scope` into dependency-free `src/asap/auth/_scope_parse.py` so `middleware.py` and `scopes.py` can import at module top-level without the documented inline-import cycle workaround.

Fixes #243

## Merge order (batch #243–#249)

| Order | PR | Issue |
|------:|-----|-------|
| **1st** | **#266 (this)** | **#243** |
| 2nd | #263 | #245 SQLite lock |
| 3rd | #262 | #248 WS tests rewire |
| 4th | #265 | #247 streaming binding |
| 5th | #264 | #249 JTI status |

**Rebase:** not required for this PR. Merge directly to `main`.

## Changes

- `src/asap/auth/_scope_parse.py` — new leaf module
- `src/asap/auth/scopes.py` — re-export
- `src/asap/auth/middleware.py` — top-level import, inline import removed

## Testing

```bash
uv run pytest tests/auth/ -v
```

351 passed. CI green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2d8e-dfea-7656-9874-65cecdc35d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2d8e-dfea-7656-9874-65cecdc35d1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

