### PR TITLE
docs: add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,3 +93,12 @@ src/asap/
 - **Capabilities**: Constraint-based authorization with approval flows (v2.2).
 - **Transport**: mTLS optional (v1.2); ASAP-Version negotiation (v2.2).
 - **Compliance**: `asap-compliance` package validates specs.
+
+## Cursor Cloud specific instructions
+
+The VM update script already installs dependencies (`uv sync --all-extras --dev` at the repo root and `npm ci` in `apps/web`). `uv` lives in `~/.local/bin` and is on `PATH` via `~/.profile`/`~/.bashrc`. Python 3.13 is required and managed by `uv` (system `python3` is 3.12; always use `uv run`). Standard commands live in `AGENTS.md` Quick Start and [`.cursor/README.md`](.cursor/README.md#canonical-commands) — reference those rather than duplicating.
+
+Two independent products, testable in isolation (the web app is not wired to the local Python server):
+
+- **Python backend** (`asap-protocol`): dev server `uv run uvicorn asap.transport.server:app --reload` (port 8000). Non-obvious: the JSON-RPC endpoint is `POST /asap` (there is no `/asap/rpc`); health is `GET /health`. Quick smoke test uses method `asap.send` with an envelope whose payload is a `task.request` (see `tests/transport/integration/test_server_core.py` for the exact envelope shape); the built-in `echo` skill returns a `task.response`. No database/Redis needed (in-memory/SQLite by default).
+- **Web app** (`apps/web`): dev server `npm run dev` (binds `127.0.0.1:3000`). Non-obvious: `apps/web` is a standalone **npm** project (own `package-lock.json`), separate from the root **pnpm** workspace — do not run it through pnpm. It needs `apps/web/.env.local` (gitignored; copy from `.env.example`); for local dev set `REGISTRY_URL=http://127.0.0.1:3000/registry.json` (served from `public/registry.json`) and a placeholder `AUTH_SECRET`. There is no local `revoked_agents.json` file — a 404 on `REVOKED_URL` is expected and harmless. Playwright E2E needs `npx playwright install`; see `apps/web/docs/playwright-e2e.md` for sandbox browser-path issues.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the ASAP Protocol monorepo and documents durable, non-obvious startup caveats for future agents.

- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering the two independent products (Python backend + `apps/web` Next.js app), their dev commands, and non-obvious gotchas (JSON-RPC path `POST /asap`, `apps/web` being a standalone npm project separate from the root pnpm workspace, required `.env.local`, expected `revoked_agents.json` 404).
- Configures the VM update script (`uv sync --all-extras --dev` + `npm ci` in `apps/web`).

No application code was modified.

## Verification

**Python backend (`asap-protocol`)**
- `uv run ruff check .` / `uv run ruff format --check .` — pass
- `uv run mypy src/ scripts/ tests/` — pass (487 files)
- `uv run pytest -n auto --tb=short` — 3774 passed, 6 skipped
- Ran `uvicorn asap.transport.server:app`; `GET /health` → `{"status":"ok"}`; `POST /asap` `asap.send` echo round-trip returned `status: completed`.

**Web app (`apps/web`)**
- `npm run lint`, `npx tsc --noEmit`, `npx vitest run` (179 passed), `npm run build` — all pass
- Ran `npm run dev`; verified browse → search → agent-detail flow in browser.

[web_marketplace_browse_search_detail.mp4](https://cursor.com/agents/bc-3f1bc0fd-e19d-4af2-a73c-181421149a00/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_marketplace_browse_search_detail.mp4)

Marketplace browse grid (120 agents), real-time search filter, and agent detail page.

[Browse grid](https://cursor.com/agents/bc-3f1bc0fd-e19d-4af2-a73c-181421149a00/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_browse_grid.webp)
[Agent detail](https://cursor.com/agents/bc-3f1bc0fd-e19d-4af2-a73c-181421149a00/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_agent_detail.webp)

[backend_hello_world.log](https://cursor.com/agents/bc-3f1bc0fd-e19d-4af2-a73c-181421149a00/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbackend_hello_world.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f1bc0fd-e19d-4af2-a73c-181421149a00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f1bc0fd-e19d-4af2-a73c-181421149a00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

