### PR TITLE
refactor(cli): move legacy re-exports to cli/_compat.py (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CLI legacy imports (#242)**: `DEFAULT_SCHEMAS_DIR`, `export_all_schemas`, and
+  `_repl_namespace` are no longer re-exported from `asap.cli` root. Import from
+  `asap.cli._compat` (shim) or the owning submodules (`asap.cli.schemas`,
+  `asap.schemas`, `asap.cli.repl`). The `_compat` shim is removed in v2.6.0.
+  See [migration guide](docs/migration.md#upgrading-from-v251).
+
 ### Fixed
 
 - **CI security (`pip-audit`)**: Raised `joserfc` to `>=1.6.7,<2` (CVE-2026-48990) and added overrides for `python-engineio>=4.13.2` (CVE-2026-48802 / CVE-2026-48809) and `python-socketio>=5.16.2` (CVE-2026-48804). See [SECURITY.md](SECURITY.md).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -827,6 +827,34 @@ IdP are unchanged.
 
 ---
 
+### Upgrading from v2.5.1
+
+Patch/minor releases after v2.5.1 may include small CLI surface trims that do
+not affect wire protocol or command behavior.
+
+#### CLI legacy import paths (#242)
+
+The v2.5.1 S3 CLI split moved command groups into submodules but kept three
+legacy names on `asap.cli` root for compatibility. Those root re-exports are
+removed; use `asap.cli._compat` or canonical modules until **v2.6.0**:
+
+```python
+# Before (no longer works)
+from asap.cli import DEFAULT_SCHEMAS_DIR, export_all_schemas, _repl_namespace
+
+# After — shim (removed in v2.6.0)
+from asap.cli._compat import DEFAULT_SCHEMAS_DIR, export_all_schemas, _repl_namespace
+
+# After — canonical (preferred)
+from asap.cli.schemas import DEFAULT_SCHEMAS_DIR
+from asap.schemas import export_all_schemas
+from asap.cli.repl import _repl_namespace
+```
+
+`asap = "asap.cli:main"` and `from asap.cli import app, main` are unchanged.
+
+---
+
 ### Upgrading from v2.4.1 to v2.5.0
 
 v2.5.0 is an **additive, backward-compatible** minor release. JSON-RPC envelopes,

--- a/engineering/tasks/deferred/issue-242-cli-compat-shim.md
+++ b/engineering/tasks/deferred/issue-242-cli-compat-shim.md
@@ -1,0 +1,56 @@
+# Issue #242: CLI `_compat.py` shim
+
+**Issue**: [#242](https://github.com/adriannoes/asap-protocol/issues/242)
+**Branch**: `refactor/cli-compat-shim-242`
+**Depends on**: PR #241 merged (v2.5.1 S3 cli split)
+
+## Relevant Files
+
+### New Files
+- `src/asap/cli/_compat.py` — Legacy public-symbol re-exports (`DEFAULT_SCHEMAS_DIR`, `export_all_schemas`, `_repl_namespace`)
+- `tests/cli/test_compat.py` — Contract tests for shim + trimmed `cli/__init__.py` surface
+
+### Modified Files
+- `src/asap/cli/__init__.py` — Remove legacy re-exports; `__all__` = `["app", "main"]`; ≤80 LOC
+- `tests/test_cli.py` — Repoint legacy imports to `asap.cli._compat` (L14, L1099, L1109)
+
+## Tasks
+
+### [x] 1.0 Contract tests (TDD red)
+
+- [x] 1.1 Write `tests/cli/test_compat.py` (7 cases)
+  - **What**: `__all__` on `_compat` and `cli/__init__`; canonical object identity; legacy symbols absent from `asap.cli`; LOC ceiling; REPL namespace smoke
+  - **Verify**: `uv run pytest tests/cli/test_compat.py -v --tb=short` fails until implementation lands
+
+### [x] 2.0 Implement shim
+
+- [x] 2.1 Create `src/asap/cli/_compat.py`
+  - **What**: Docstring + 3 re-exports from canonical modules + `__all__`
+  - **Verify**: `test_compat_all_exports`, `test_compat_symbols_are_canonical_objects` green
+
+- [x] 2.2 Trim `src/asap/cli/__init__.py`
+  - **What**: Remove legacy imports/re-exports; keep Typer wiring only
+  - **Verify**: `test_cli_init_line_count_within_ceiling`, `test_cli_init_does_not_export_legacy_symbols` green
+
+### [x] 3.0 Update consumers
+
+- [x] 3.1 Repoint `tests/test_cli.py` imports to `asap.cli._compat`
+  - **Verify**: `tests/test_cli.py` + `tests/cli/` + `tests/test_cli_edge_cases.py` green
+
+### [x] 4.0 Verification gates
+
+- [x] 4.1 Full CLI pytest suite
+- [x] 4.2 `ruff check src/asap/cli/ tests/cli/test_compat.py`
+- [x] 4.3 `mypy src/asap/cli/`
+- [x] 4.4 Smoke: `asap --version`, `asap --help`
+
+## Acceptance Checklist
+
+- [x] `src/asap/cli/_compat.py` with docstring + `__all__`
+- [x] `src/asap/cli/__init__.py` ≤ 80 LOC
+- [x] `from asap.cli._compat import DEFAULT_SCHEMAS_DIR, export_all_schemas, _repl_namespace` resolves
+- [x] `asap.cli` does **not** export legacy symbols at root
+- [x] Re-exports are canonical objects (`is` identity)
+- [x] `tests/cli/test_compat.py` green (7 cases)
+- [x] CLI test suites green; `ruff` + `mypy` clean
+- [x] `asap --version` / `asap --help` OK

--- a/src/asap/cli/__init__.py
+++ b/src/asap/cli/__init__.py
@@ -25,24 +25,11 @@ from asap.cli.compliance_check import register_compliance_check_command
 from asap.cli.delegation import register_delegation_commands
 from asap.cli.keys import register_keys_commands
 from asap.cli.manifest import register_manifest_commands
-from asap.cli.repl import _repl_namespace
 from asap.cli.repl import register_repl_command
-from asap.cli.schemas import DEFAULT_SCHEMAS_DIR
 from asap.cli.schemas import register_schemas_commands
 from asap.cli.trace import register_trace_command
 
-# Re-exported so legacy `patch("asap.cli.export_all_schemas")` and
-# `from asap.cli import DEFAULT_SCHEMAS_DIR, export_all_schemas, _repl_namespace`
-# keep resolving after the v2.5.1 S3 cli split (behavior-preserving surface).
-from asap.schemas import export_all_schemas
-
-__all__ = [
-    "DEFAULT_SCHEMAS_DIR",
-    "app",
-    "export_all_schemas",
-    "main",
-    "_repl_namespace",
-]
+__all__ = ["app", "main"]
 
 app = typer.Typer(help="ASAP Protocol CLI.")
 

--- a/src/asap/cli/_compat.py
+++ b/src/asap/cli/_compat.py
@@ -1,0 +1,18 @@
+"""Legacy public-symbol re-exports kept for backward compatibility.
+
+These names historically lived on ``asap.cli`` (inline in ``__init__.py``
+before the v2.5.1 S3 cli split). New code should import from the owning
+submodules directly:
+
+- ``DEFAULT_SCHEMAS_DIR`` → ``asap.cli.schemas``
+- ``export_all_schemas`` → ``asap.schemas``
+- ``_repl_namespace`` → ``asap.cli.repl``
+"""
+
+from __future__ import annotations
+
+from asap.cli.repl import _repl_namespace
+from asap.cli.schemas import DEFAULT_SCHEMAS_DIR
+from asap.schemas import export_all_schemas
+
+__all__ = ["DEFAULT_SCHEMAS_DIR", "export_all_schemas", "_repl_namespace"]

--- a/src/asap/cli/_compat.py
+++ b/src/asap/cli/_compat.py
@@ -1,8 +1,13 @@
 """Legacy public-symbol re-exports kept for backward compatibility.
 
 These names historically lived on ``asap.cli`` (inline in ``__init__.py``
-before the v2.5.1 S3 cli split). New code should import from the owning
-submodules directly:
+before the v2.5.1 S3 cli split). The root ``asap.cli`` package no longer
+re-exports them (issue #242); use this module or the canonical paths below.
+
+**Deprecation window:** scheduled for removal in **v2.6.0** (same timeline as
+other v2.5.1 transport/MCP shims — see ``docs/migration.md``).
+
+Canonical import paths for new code:
 
 - ``DEFAULT_SCHEMAS_DIR`` → ``asap.cli.schemas``
 - ``export_all_schemas`` → ``asap.schemas``

--- a/tests/cli/test_compat.py
+++ b/tests/cli/test_compat.py
@@ -48,7 +48,8 @@ def test_cli_init_does_not_export_legacy_symbols(name: str) -> None:
 
 def test_cli_init_line_count_within_ceiling() -> None:
     """cli/__init__.py stays within the 80 LOC ceiling (issue #242)."""
-    init_path = Path("src/asap/cli/__init__.py")
+    repo_root = Path(__file__).resolve().parents[2]
+    init_path = repo_root / "src/asap/cli/__init__.py"
     line_count = len(init_path.read_text(encoding="utf-8").splitlines())
     assert line_count <= 80
 

--- a/tests/cli/test_compat.py
+++ b/tests/cli/test_compat.py
@@ -1,0 +1,61 @@
+"""Contract tests for asap.cli._compat shim and trimmed cli/__init__.py surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import asap.cli
+import asap.cli._compat as compat
+from asap.cli import repl as repl_module
+from asap.cli import schemas as schemas_module
+from asap.schemas import export_all_schemas as canonical_export_all_schemas
+
+_LEGACY_SYMBOLS = ("DEFAULT_SCHEMAS_DIR", "export_all_schemas", "_repl_namespace")
+
+
+def test_compat_all_exports() -> None:
+    """_compat.__all__ declares exactly the three legacy symbols."""
+    assert set(compat.__all__) == set(_LEGACY_SYMBOLS)
+
+
+@pytest.mark.parametrize("name", list(compat.__all__))
+def test_compat_symbols_importable(name: str) -> None:
+    """Each name in _compat.__all__ is importable via getattr."""
+    obj = getattr(compat, name)
+    assert obj is not None
+
+
+def test_compat_symbols_are_canonical_objects() -> None:
+    """Re-exports are the same object as canonical imports."""
+    assert compat.DEFAULT_SCHEMAS_DIR is schemas_module.DEFAULT_SCHEMAS_DIR
+    assert compat.export_all_schemas is canonical_export_all_schemas
+    assert compat._repl_namespace is repl_module._repl_namespace
+
+
+def test_cli_init_public_all() -> None:
+    """cli.__init__.__all__ exposes only app and main."""
+    assert set(asap.cli.__all__) == {"app", "main"}
+
+
+@pytest.mark.parametrize("name", _LEGACY_SYMBOLS)
+def test_cli_init_does_not_export_legacy_symbols(name: str) -> None:
+    """Legacy symbols are not re-exported from asap.cli root."""
+    with pytest.raises(AttributeError):
+        getattr(asap.cli, name)
+
+
+def test_cli_init_line_count_within_ceiling() -> None:
+    """cli/__init__.py stays within the 80 LOC ceiling (issue #242)."""
+    init_path = Path("src/asap/cli/__init__.py")
+    line_count = len(init_path.read_text(encoding="utf-8").splitlines())
+    assert line_count <= 80
+
+
+def test_compat_repl_namespace_behavior_unchanged() -> None:
+    """_repl_namespace via shim returns dict with expected REPL keys."""
+    ns = compat._repl_namespace()
+    assert "Envelope" in ns
+    assert "TaskRequest" in ns
+    assert "sample_envelope" in ns

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,8 @@ import pytest
 from typer.testing import CliRunner
 
 from asap import __version__
-from asap.cli import DEFAULT_SCHEMAS_DIR, app
+from asap.cli import app
+from asap.cli._compat import DEFAULT_SCHEMAS_DIR
 from asap.crypto.keys import generate_keypair, serialize_private_key
 from asap.economics.delegation_storage import SQLiteDelegationStorage
 from asap.schemas import TOTAL_SCHEMA_COUNT
@@ -1096,7 +1097,7 @@ class TestReplNamespace:
     """Cover _repl_namespace and sample_envelope (line 471)."""
 
     def test_namespace_contains_expected_keys(self) -> None:
-        from asap.cli import _repl_namespace
+        from asap.cli._compat import _repl_namespace
 
         ns = _repl_namespace()
         assert "Envelope" in ns
@@ -1106,7 +1107,7 @@ class TestReplNamespace:
         assert "sample_envelope" in ns
 
     def test_sample_envelope_produces_valid_envelope(self) -> None:
-        from asap.cli import _repl_namespace
+        from asap.cli._compat import _repl_namespace
 
         ns = _repl_namespace()
         envelope = ns["sample_envelope"]()


### PR DESCRIPTION
## Summary

- Isola os 3 re-exports legados (`DEFAULT_SCHEMAS_DIR`, `export_all_schemas`, `_repl_namespace`) em `src/asap/cli/_compat.py` com docstring e `__all__` explícito.
- Enxuga `src/asap/cli/__init__.py` para 78 LOC — apenas wiring Typer; `__all__` = `["app", "main"]`.
- Adiciona 7 testes de contrato em `tests/cli/test_compat.py` (TDD) e reponta consumidores em `tests/test_cli.py`.

Closes #242

## Test plan

- [x] `uv run pytest tests/cli/test_compat.py -v --tb=short` — 11 passed (7 casos + parametrizações)
- [x] `uv run pytest tests/test_cli.py tests/test_cli_edge_cases.py tests/cli/ --tb=short` — 128 passed
- [x] `uv run ruff check src/asap/cli/ tests/cli/test_compat.py` — clean
- [x] `uv run mypy src/asap/cli/` — clean
- [x] `uv run asap --version` → 2.5.1
- [x] `uv run asap --help` — OK
- [x] `wc -l src/asap/cli/__init__.py` → 78 (≤80)