### PR TITLE
docs: track v2.6.0 removal of asap.cli._compat (#275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI legacy imports (#242)**: `DEFAULT_SCHEMAS_DIR`, `export_all_schemas`, and
   `_repl_namespace` are no longer re-exported from `asap.cli` root. Import from
   `asap.cli._compat` (shim) or the owning submodules (`asap.cli.schemas`,
-  `asap.schemas`, `asap.cli.repl`). The `_compat` shim is removed in v2.6.0.
+  `asap.schemas`, `asap.cli.repl`). The `_compat` shim is removed in v2.6.0
+  ([#275](https://github.com/adriannoes/asap-protocol/issues/275)).
   See [migration guide](docs/migration.md#upgrading-from-v251).
 
 ### Fixed
@@ -72,6 +73,9 @@ Deprecated import paths keep working via shims until v2.6.0.
 
 ### Deprecated (remove in v2.6.0)
 
+- `from asap.cli._compat import ...` — use `asap.cli.schemas`, `asap.schemas`, or
+  `asap.cli.repl` directly ([#242](https://github.com/adriannoes/asap-protocol/issues/242);
+  removal tracked in [#275](https://github.com/adriannoes/asap-protocol/issues/275)).
 - `from asap.transport.websocket import ...` — use `asap.transport.ws` directly.
 - `from asap.adapters.mcp import ...` — use `asap.mcp.auth` directly.
 - `RemoteFatalRPCError` / `RemoteRecoverableRPCError` — use `RemoteRPCError` + `is_recoverable`.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -836,7 +836,8 @@ not affect wire protocol or command behavior.
 
 The v2.5.1 S3 CLI split moved command groups into submodules but kept three
 legacy names on `asap.cli` root for compatibility. Those root re-exports are
-removed; use `asap.cli._compat` or canonical modules until **v2.6.0**:
+removed; use `asap.cli._compat` or canonical modules until **v2.6.0**
+([#275](https://github.com/adriannoes/asap-protocol/issues/275)):
 
 ```python
 # Before (no longer works)

--- a/engineering/tasks/deferred/issue-242-cli-compat-shim.md
+++ b/engineering/tasks/deferred/issue-242-cli-compat-shim.md
@@ -1,6 +1,8 @@
 # Issue #242: CLI `_compat.py` shim
 
-**Issue**: [#242](https://github.com/adriannoes/asap-protocol/issues/242)
+**Issue**: [#242](https://github.com/adriannoes/asap-protocol/issues/242) (closed)
+**PR**: [#274](https://github.com/adriannoes/asap-protocol/pull/274) (merged 2026-07-07)
+**Follow-up (v2.6.0)**: [#275](https://github.com/adriannoes/asap-protocol/issues/275) — remove `_compat` shim
 **Branch**: `refactor/cli-compat-shim-242`
 **Depends on**: PR #241 merged (v2.5.1 S3 cli split)
 

--- a/engineering/tasks/deferred/issue-275-cli-compat-removal-v2.6.0.md
+++ b/engineering/tasks/deferred/issue-275-cli-compat-removal-v2.6.0.md
@@ -1,0 +1,48 @@
+# Issue #275: Remove `asap.cli._compat` (v2.6.0)
+
+**Issue**: [#275](https://github.com/adriannoes/asap-protocol/issues/275)
+**Target release**: v2.6.0
+**Depends on**: #242 shipped ([#274](https://github.com/adriannoes/asap-protocol/pull/274))
+
+## Context
+
+The v2.5.1 S3 CLI split moved legacy re-exports into `asap.cli._compat` to keep
+`cli/__init__.py` ≤80 LOC. The shim is a **deprecation bridge**, not a permanent
+API — same pattern as `asap.transport.websocket` and `asap.adapters.mcp`.
+
+## Relevant Files
+
+### Remove
+- `src/asap/cli/_compat.py`
+
+### Modify
+- `tests/test_cli.py` — import from canonical modules
+- `tests/cli/test_compat.py` — remove shim contract tests; keep LOC ceiling if needed
+- `docs/migration.md` — breaking change note for v2.6.0
+- `CHANGELOG.md` — `[2.6.0]` breaking removal entry
+
+## Tasks
+
+### 1.0 Repoint consumers
+
+- [ ] 1.1 Grep `asap.cli._compat` — zero in-repo hits after change
+- [ ] 1.2 Update `tests/test_cli.py` to canonical imports
+
+### 2.0 Remove shim
+
+- [ ] 2.1 Delete `src/asap/cli/_compat.py`
+- [ ] 2.2 Adjust `tests/cli/test_compat.py` (drop shim tests; retain `__init__.py` LOC guard if desired)
+
+### 3.0 Docs & release
+
+- [ ] 3.1 `CHANGELOG.md` `[2.6.0]` breaking note
+- [ ] 3.2 `docs/migration.md` — v2.6.0 upgrade section
+
+### 4.0 Verification
+
+- [ ] `uv run pytest tests/test_cli.py tests/test_cli_edge_cases.py tests/cli/`
+- [ ] `uv run ruff check src/asap/cli/` + `uv run mypy src/asap/cli/`
+
+## Acceptance
+
+See issue #275 checklist.

--- a/engineering/tasks/v2.3.0/deferred-backlog.md
+++ b/engineering/tasks/v2.3.0/deferred-backlog.md
@@ -8,5 +8,6 @@ Post-release tracking items referenced from [sprint-S5-release.md](./sprint-S5-r
 | `apps/web` npm audit (postcss / Next) | [#140](https://github.com/adriannoes/asap-protocol/issues/140) | Moderate advisories until upstream fix |
 | Adoption metrics dashboard | [#141](https://github.com/adriannoes/asap-protocol/issues/141) | PRD metric; out of repo |
 | Registry API backend (gated) | [#142](https://github.com/adriannoes/asap-protocol/issues/142) | Product gate |
+| Remove `asap.cli._compat` shim | [#275](https://github.com/adriannoes/asap-protocol/issues/275) | v2.6.0; follow-up from #242 / #274 |
 
 Optional maintainer items (no dedicated issue unless opened): Vercel preview for `apps/example-nextjs`; broader deferred product themes (intent search, orchestration primitives) per roadmap.

--- a/src/asap/cli/_compat.py
+++ b/src/asap/cli/_compat.py
@@ -4,8 +4,9 @@ These names historically lived on ``asap.cli`` (inline in ``__init__.py``
 before the v2.5.1 S3 cli split). The root ``asap.cli`` package no longer
 re-exports them (issue #242); use this module or the canonical paths below.
 
-**Deprecation window:** scheduled for removal in **v2.6.0** (same timeline as
-other v2.5.1 transport/MCP shims — see ``docs/migration.md``).
+**Deprecation window:** scheduled for removal in **v2.6.0** (tracked in
+GitHub issue #275; same timeline as other v2.5.1 transport/MCP shims — see
+``docs/migration.md``).
 
 Canonical import paths for new code:
 


### PR DESCRIPTION
## Summary

Cross-links GitHub issue #275 (remove `asap.cli._compat` in v2.6.0) across the repo so the #242/#274 deprecation window is not lost.

## Changes

- New task doc: `engineering/tasks/deferred/issue-275-cli-compat-removal-v2.6.0.md`
- Updated #242 task doc with PR #274 + follow-up #275
- `CHANGELOG.md` — link #275 in [Unreleased]; add `_compat` to [2.5.1] deprecated list
- `docs/migration.md` — link #275 in CLI legacy imports section
- `deferred-backlog.md` — new row for #275
- `src/asap/cli/_compat.py` — docstring references #275

Refs: #275