### PR TITLE
feat(models): forbid extra fields on TaskRequestConfig and CommonMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Ingress validation (#209)**: `TaskRequestConfig` and `CommonMetadata` now reject
+  unknown fields (`extra="forbid"`, inherited from `ASAPBaseModel`). Previously these
+  models allowed arbitrary extension keys; clients sending custom `config` or
+  `metadata` properties must use known fields only or nest extensions under
+  `TaskRequest.input` / envelope `extensions`. See
+  [migration guide](docs/migration.md#upgrading-from-v251).
+
 - **CLI legacy imports (#242)**: `DEFAULT_SCHEMAS_DIR`, `export_all_schemas`, and
   `_repl_namespace` are no longer re-exported from `asap.cli` root. Import from
   `asap.cli._compat` (shim) or the owning submodules (`asap.cli.schemas`,
@@ -31,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Follow-up (not in v2.5.1)
 
 - **Adapter Lab II** — new framework adapters (separate PRD: [prd-v2.5.1-adapter-lab-ii.md](product/prd/prd-v2.5.1-adapter-lab-ii.md)).
-- `extra="forbid"` on ingress payload models (`TaskRequestConfig`, `CommonMetadata`).
 - Redis-backed `JtiReplayCache` and distributed Next.js rate limits.
 - `@asap-protocol/mcp-auth` HTTP/SSE middleware (deferred from v2.5.0 — see [2.5.0] TypeScript note and [typescript-mcp-auth-spike.md](engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md)).
 - Collapse the dual `UsageMetrics`/`InMemoryMeteringStore` pair retained in S1 for API stability.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -829,8 +829,9 @@ IdP are unchanged.
 
 ### Upgrading from v2.5.1
 
-Patch/minor releases after v2.5.1 may include small CLI surface trims that do
-not affect wire protocol or command behavior.
+Patch/minor releases after v2.5.1 may include small CLI surface trims and
+tighter ingress validation (e.g. rejecting unknown `config` / `metadata` keys)
+without changing the JSON-RPC envelope wire format.
 
 #### CLI legacy import paths (#242)
 
@@ -904,6 +905,34 @@ startup. Operator tokens must:
 If you set `OAuth2Config.required_scope` for `/asap` tasks, it is **not** applied
 to `/usage`, `/sla`, or `/audit`: those enforce only ``asap:admin`` via the route
 dependency, so an admin-only token is accepted regardless of the global scope.
+
+#### Ingress validation: `TaskRequestConfig` and `CommonMetadata` (#209)
+
+`TaskRequest.config` and `Conversation.metadata` now reject unknown keys
+(`extra="forbid"`). Custom extension data that previously rode in ad-hoc
+`config` or `metadata` properties must move to `TaskRequest.input` or envelope
+`extensions`.
+
+```python
+# Before (accepted arbitrary keys)
+TaskRequest(
+    conversation_id="conv_1",
+    skill_id="research",
+    input={"query": "AI"},
+    config={"timeout_seconds": 60, "custom_flag": True},
+)
+
+# After — drop unknown config keys or relocate them
+TaskRequest(
+    conversation_id="conv_1",
+    skill_id="research",
+    input={"query": "AI", "custom_flag": True},
+    config={"timeout_seconds": 60},
+)
+```
+
+`TaskResponse.metrics` still allows extra fields (unchanged in this release).
+
 
 ---
 

--- a/schemas/entities/conversation.schema.json
+++ b/schemas/entities/conversation.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "CommonMetadata": {
       "additionalProperties": false,
-      "description": "Common metadata keys (extra allowed).",
+      "description": "Common metadata keys (unknown keys rejected).",
       "properties": {
         "purpose": {
           "anyOf": [

--- a/schemas/entities/manifest.schema.json
+++ b/schemas/entities/manifest.schema.json
@@ -33,115 +33,9 @@
       "title": "AuthScheme",
       "type": "object"
     },
-    "HardwareCapability": {
-      "additionalProperties": false,
-      "description": "Optional hardware hosting profile for edge and physical agents.\n\nAll fields are optional; registrants may omit the object entirely.\nClosed enums support marketplace filtering (v2.4+).",
-      "properties": {
-        "class": {
-          "description": "Hardware class hosting the agent",
-          "enum": [
-            "cloud",
-            "sbc",
-            "edge_accelerator",
-            "microcontroller",
-            "desktop"
-          ],
-          "title": "Class",
-          "type": "string"
-        },
-        "model": {
-          "description": "Specific board or SoC (e.g. jetson_orin_nano_super_8gb)",
-          "maxLength": 100,
-          "title": "Model",
-          "type": "string"
-        },
-        "io": {
-          "description": "Physical I/O interfaces available to the agent",
-          "items": {
-            "enum": [
-              "gpio",
-              "i2c",
-              "spi",
-              "uart",
-              "csi_camera",
-              "usb_camera",
-              "audio_in",
-              "audio_out",
-              "bluetooth",
-              "lora",
-              "ble"
-            ],
-            "type": "string"
-          },
-          "title": "Io",
-          "type": "array",
-          "uniqueItems": true
-        }
-      },
-      "title": "HardwareCapability",
-      "type": "object"
-    },
-    "InferenceCapability": {
-      "additionalProperties": false,
-      "description": "Optional local and cloud inference modes advertised by the agent.",
-      "properties": {
-        "modes": {
-          "description": "Supported inference execution modes",
-          "items": {
-            "enum": [
-              "cloud",
-              "local_cpu",
-              "local_cuda",
-              "local_metal",
-              "local_npu"
-            ],
-            "type": "string"
-          },
-          "title": "Modes",
-          "type": "array",
-          "uniqueItems": true
-        },
-        "local_models": {
-          "description": "Self-reported local models (optional throughput)",
-          "items": {
-            "$ref": "#/$defs/LocalModelInfo"
-          },
-          "title": "Local Models",
-          "type": "array"
-        }
-      },
-      "title": "InferenceCapability",
-      "type": "object"
-    },
-    "LocalModelInfo": {
-      "additionalProperties": false,
-      "description": "Metadata for a model running on-device (self-reported).",
-      "properties": {
-        "id": {
-          "description": "Model identifier (e.g. Hugging Face repo or GGUF name)",
-          "maxLength": 200,
-          "title": "Id",
-          "type": "string"
-        },
-        "quantization": {
-          "description": "Quantization label (e.g. Q4_K_M)",
-          "maxLength": 50,
-          "title": "Quantization",
-          "type": "string"
-        },
-        "throughput_tokens_per_second": {
-          "description": "Self-reported throughput (tokens per second)",
-          "minimum": 0,
-          "title": "Throughput Tokens Per Second",
-          "type": "number"
-        }
-      },
-      "title": "LocalModelInfo",
-      "type": "object"
-    },
     "Capability": {
       "additionalProperties": false,
-      "description": "Collection of an agent's features and supported operations.\n\nCapabilities describe what an agent can do, including skills,\nstate persistence, streaming support, MCP tool integration, and\noptional hardware / inference advertising (v2.4+).\n\nAttributes:\n    asap_version: ASAP protocol version supported (e.g., \"0.1\")\n    skills: List of skills the agent can perform\n    state_persistence: Whether the agent supports state snapshots\n    streaming: Whether the agent supports streaming responses\n    mcp_tools: List of MCP tool names the agent can execute\n    hardware: Optional hardware class, model, and I/O (v2.4+)\n    inference: Optional inference modes and local models (v2.4+)\n\nExample:\n    >>> capability = Capability(\n    ...     asap_version=\"0.1\",\n    ...     skills=[Skill(id=\"research\", description=\"Research skill\")],\n    ...     state_persistence=True,\n    ...     streaming=True,\n    ...     mcp_tools=[\"web_search\"]\n    ... )",
+      "description": "Collection of an agent's features and supported operations.\n\nCapabilities describe what an agent can do, including skills,\nstate persistence, streaming support, and MCP tool integration.\n\nAttributes:\n    asap_version: ASAP protocol version supported (e.g., \"0.1\")\n    skills: List of skills the agent can perform\n    state_persistence: Whether the agent supports state snapshots\n    streaming: Whether the agent supports streaming responses\n    mcp_tools: List of MCP tool names the agent can execute\n    hardware: Optional hardware class, model, and I/O (v2.4+)\n    inference: Optional inference modes and local models (v2.4+)\n\nExample:\n    >>> capability = Capability(\n    ...     asap_version=\"0.1\",\n    ...     skills=[Skill(id=\"research\", description=\"Research skill\")],\n    ...     state_persistence=True,\n    ...     streaming=True,\n    ...     mcp_tools=[\"web_search\"]\n    ... )",
       "properties": {
         "asap_version": {
           "default": "0.1",
@@ -232,6 +126,162 @@
         "asap"
       ],
       "title": "Endpoint",
+      "type": "object"
+    },
+    "HardwareCapability": {
+      "additionalProperties": false,
+      "description": "Optional hardware hosting profile for edge and physical agents (v2.4+).\n\nAll fields are optional; registrants may omit the object entirely.",
+      "properties": {
+        "class": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HardwareClass"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Hardware class hosting the agent"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "maxLength": 100,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Specific board or SoC (e.g. jetson_orin_nano_super_8gb)",
+          "title": "Model"
+        },
+        "io": {
+          "description": "Physical I/O interfaces available to the agent",
+          "items": {
+            "$ref": "#/$defs/HardwareIoType"
+          },
+          "title": "Io",
+          "type": "array"
+        }
+      },
+      "title": "HardwareCapability",
+      "type": "object"
+    },
+    "HardwareClass": {
+      "description": "Hardware class for edge and physical agents (manifest v2.4+).",
+      "enum": [
+        "cloud",
+        "sbc",
+        "edge_accelerator",
+        "microcontroller",
+        "desktop"
+      ],
+      "title": "HardwareClass",
+      "type": "string"
+    },
+    "HardwareIoType": {
+      "description": "Physical I/O interfaces advertised on a manifest (v2.4+).",
+      "enum": [
+        "gpio",
+        "i2c",
+        "spi",
+        "uart",
+        "csi_camera",
+        "usb_camera",
+        "audio_in",
+        "audio_out",
+        "bluetooth",
+        "lora",
+        "ble"
+      ],
+      "title": "HardwareIoType",
+      "type": "string"
+    },
+    "InferenceCapability": {
+      "additionalProperties": false,
+      "description": "Optional local and cloud inference modes advertised by the agent (v2.4+).",
+      "properties": {
+        "modes": {
+          "description": "Supported inference execution modes",
+          "items": {
+            "$ref": "#/$defs/InferenceMode"
+          },
+          "title": "Modes",
+          "type": "array"
+        },
+        "local_models": {
+          "description": "Self-reported local models (optional throughput)",
+          "items": {
+            "$ref": "#/$defs/LocalModelInfo"
+          },
+          "title": "Local Models",
+          "type": "array"
+        }
+      },
+      "title": "InferenceCapability",
+      "type": "object"
+    },
+    "InferenceMode": {
+      "description": "Inference execution modes (manifest v2.4+).",
+      "enum": [
+        "cloud",
+        "local_cpu",
+        "local_cuda",
+        "local_metal",
+        "local_npu"
+      ],
+      "title": "InferenceMode",
+      "type": "string"
+    },
+    "LocalModelInfo": {
+      "additionalProperties": false,
+      "description": "Self-reported metadata for a model running on-device (v2.4+).\n\nAttributes:\n    id: Model identifier (e.g. Hugging Face repo or GGUF name)\n    quantization: Quantization label (e.g. Q4_K_M)\n    throughput_tokens_per_second: Optional self-reported throughput",
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Model identifier",
+          "title": "Id"
+        },
+        "quantization": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Quantization label",
+          "title": "Quantization"
+        },
+        "throughput_tokens_per_second": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Self-reported throughput (tokens per second)",
+          "title": "Throughput Tokens Per Second"
+        }
+      },
+      "title": "LocalModelInfo",
       "type": "object"
     },
     "SLADefinition": {
@@ -346,7 +396,7 @@
       "type": "object"
     },
     "VerificationState": {
-      "description": "Verification status for marketplace trust badge (Task 3.6).\n\nWhen status is VERIFIED, the agent displays a Verified badge in the registry UI.",
+      "description": "Verification status for marketplace trust badge.",
       "enum": [
         "verified",
         "pending",
@@ -357,7 +407,7 @@
     },
     "VerificationStatus": {
       "additionalProperties": false,
-      "description": "Verification status for marketplace trust badge (Task 3.6).\n\nWhen status is 'verified', the agent displays a Verified badge in the\nregistry UI. Admins add this after manual review of verification requests.",
+      "description": "Verification status for marketplace trust badge.",
       "properties": {
         "status": {
           "$ref": "#/$defs/VerificationState",
@@ -386,7 +436,7 @@
     }
   },
   "additionalProperties": false,
-  "description": "Self-describing metadata about an agent's capabilities.\n\nThe manifest is analogous to A2A's Agent Card but extended with\nadditional ASAP-specific features. It provides all information\nneeded to interact with an agent.\n\nAttributes:\n    id: Unique agent identifier (matches Agent.id)\n    name: Human-readable agent name\n    version: Semantic version of the agent\n    description: Description of what the agent does\n    capabilities: Detailed capability information\n    endpoints: Network endpoints for communication\n    auth: Optional authentication configuration\n    signature: Optional cryptographic signature for manifest verification\n    sla: Optional SLA guarantees (availability, latency, error rate)\n    ttl_seconds: How long to consider agent alive without re-check (default 300)\n\nExample:\n    >>> manifest = Manifest(\n    ...     id=\"urn:asap:agent:research-v1\",\n    ...     name=\"Research Agent\",\n    ...     version=\"1.0.0\",\n    ...     description=\"Performs web research and summarization\",\n    ...     capabilities=Capability(\n    ...         asap_version=\"0.1\",\n    ...         skills=[Skill(id=\"web_research\", description=\"Research skill\")],\n    ...         state_persistence=True\n    ...     ),\n    ...     endpoints=Endpoint(asap=\"https://api.example.com/asap\")\n    ... )\n    >>> # With SLA (optional):\n    >>> manifest_with_sla = Manifest(\n    ...     id=\"urn:asap:agent:research-v1\",\n    ...     name=\"Research Agent\",\n    ...     version=\"1.0.0\",\n    ...     description=\"Performs web research\",\n    ...     capabilities=Capability(\n    ...         asap_version=\"0.1\",\n    ...         skills=[Skill(id=\"web_research\", description=\"Research skill\")],\n    ...         state_persistence=True,\n    ...     ),\n    ...     endpoints=Endpoint(asap=\"https://api.example.com/asap\"),\n    ...     sla=SLADefinition(\n    ...         availability=\"99.5%\",\n    ...         max_latency_p95_ms=500,\n    ...         max_error_rate=\"1%\",\n    ...         support_hours=\"24/7\",\n    ...     ),\n    ... )",
+  "description": "Self-describing metadata about an agent's capabilities.\n\nThe manifest is analogous to A2A's Agent Card but extended with\nadditional ASAP-specific features. It provides all information\nneeded to interact with an agent.\n\nAttributes:\n    id: Unique agent identifier (matches Agent.id)\n    name: Human-readable agent name\n    version: Semantic version of the agent\n    description: Description of what the agent does\n    capabilities: Detailed capability information\n    endpoints: Network endpoints for communication\n    supported_versions: Supported HTTP wire versions (discovery)\n    auth: Optional authentication configuration\n    signature: Optional cryptographic signature for manifest verification\n    sla: Optional SLA guarantees (availability, latency, error rate)\n    ttl_seconds: How long to consider agent alive without re-check (default 300)\n\nExample:\n    >>> manifest = Manifest(\n    ...     id=\"urn:asap:agent:research-v1\",\n    ...     name=\"Research Agent\",\n    ...     version=\"1.0.0\",\n    ...     description=\"Performs web research and summarization\",\n    ...     capabilities=Capability(\n    ...         asap_version=\"0.1\",\n    ...         skills=[Skill(id=\"web_research\", description=\"Research skill\")],\n    ...         state_persistence=True\n    ...     ),\n    ...     endpoints=Endpoint(asap=\"https://api.example.com/asap\")\n    ... )\n    >>> # With SLA (optional):\n    >>> manifest_with_sla = Manifest(\n    ...     id=\"urn:asap:agent:research-v1\",\n    ...     name=\"Research Agent\",\n    ...     version=\"1.0.0\",\n    ...     description=\"Performs web research\",\n    ...     capabilities=Capability(\n    ...         asap_version=\"0.1\",\n    ...         skills=[Skill(id=\"web_research\", description=\"Research skill\")],\n    ...         state_persistence=True,\n    ...     ),\n    ...     endpoints=Endpoint(asap=\"https://api.example.com/asap\"),\n    ...     sla=SLADefinition(\n    ...         availability=\"99.5%\",\n    ...         max_latency_p95_ms=500,\n    ...         max_error_rate=\"1%\",\n    ...         support_hours=\"24/7\",\n    ...     ),\n    ... )",
   "properties": {
     "id": {
       "description": "Unique agent identifier (URN format)",
@@ -415,6 +465,15 @@
     "endpoints": {
       "$ref": "#/$defs/Endpoint",
       "description": "Communication endpoints"
+    },
+    "supported_versions": {
+      "description": "Supported ASAP HTTP wire versions (discovery / ASAP-Version)",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Supported Versions",
+      "type": "array"
     },
     "auth": {
       "anyOf": [
@@ -463,7 +522,7 @@
         }
       ],
       "default": null,
-      "description": "Verification status for marketplace trust badge (Task 3.6)"
+      "description": "Verification status for marketplace trust badge"
     },
     "ttl_seconds": {
       "default": 300,

--- a/schemas/envelope.schema.json
+++ b/schemas/envelope.schema.json
@@ -471,7 +471,7 @@
     },
     "TaskRequestConfig": {
       "additionalProperties": false,
-      "description": "TaskRequest.config (extra allowed).",
+      "description": "TaskRequest.config (unknown keys rejected).",
       "properties": {
         "timeout_seconds": {
           "anyOf": [
@@ -645,6 +645,53 @@
       "title": "TaskStatus",
       "type": "string"
     },
+    "TaskStream": {
+      "additionalProperties": false,
+      "description": "Chunk of streamed task output (SSE or WebSocket).\n\nUsed with Envelope payload_type ``TaskStream`` for incremental results\nfrom a streaming handler. The client correlates chunks via\n``Envelope.correlation_id`` matching the original ``TaskRequest``.\n\nAttributes:\n    chunk: Text fragment for this event (e.g. token or word).\n    progress: Optional completion ratio in ``[0, 1]``.\n    final: When True, no further chunks are expected for this task.\n    status: Optional task status (e.g. WORKING until final COMPLETED).",
+      "properties": {
+        "chunk": {
+          "default": "",
+          "description": "Streamed text fragment",
+          "title": "Chunk",
+          "type": "string"
+        },
+        "progress": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional progress from 0.0 to 1.0",
+          "title": "Progress"
+        },
+        "final": {
+          "default": false,
+          "description": "True when this is the last chunk",
+          "title": "Final",
+          "type": "boolean"
+        },
+        "status": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TaskStatus"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Task status hint (e.g. COMPLETED on final chunk)"
+        }
+      },
+      "title": "TaskStream",
+      "type": "object"
+    },
     "TaskUpdate": {
       "additionalProperties": false,
       "description": "Update on task execution progress or status.\n\nTaskUpdate provides real-time updates during task execution, including\nprogress information or requests for additional input.\n\nAttributes:\n    task_id: ID of the task being updated\n    update_type: Type of update (progress, input_required, etc.)\n    status: Current task status\n    progress: Optional progress information (percent, message, ETA)\n    input_request: Optional request for additional input from user",
@@ -764,6 +811,9 @@
       "anyOf": [
         {
           "$ref": "#/$defs/TaskRequest"
+        },
+        {
+          "$ref": "#/$defs/TaskStream"
         },
         {
           "$ref": "#/$defs/TaskResponse"

--- a/schemas/payloads/task_request.schema.json
+++ b/schemas/payloads/task_request.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "TaskRequestConfig": {
       "additionalProperties": false,
-      "description": "TaskRequest.config (extra allowed).",
+      "description": "TaskRequest.config (unknown keys rejected).",
       "properties": {
         "timeout_seconds": {
           "anyOf": [

--- a/src/asap/models/entities.py
+++ b/src/asap/models/entities.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from typing import Any
 
 from packaging.version import InvalidVersion, Version
-from pydantic import ConfigDict, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from asap.errors import UnsupportedAuthSchemeError
 from asap.models.base import ASAPBaseModel
@@ -57,9 +57,7 @@ from asap.models.types import (
 
 
 class CommonMetadata(ASAPBaseModel):
-    """Common metadata keys (extra allowed)."""
-
-    model_config = ConfigDict(extra="allow")
+    """Common metadata keys (unknown keys rejected)."""
 
     purpose: str | None = Field(default=None, description="Conversation purpose")
     ttl_hours: int | None = Field(default=None, ge=1, description="Time-to-live in hours")

--- a/src/asap/models/payloads.py
+++ b/src/asap/models/payloads.py
@@ -24,9 +24,7 @@ from asap.models.types import (
 
 
 class TaskRequestConfig(ASAPBaseModel):
-    """TaskRequest.config (extra allowed)."""
-
-    model_config = ConfigDict(extra="allow")
+    """TaskRequest.config (unknown keys rejected)."""
 
     timeout_seconds: int | None = Field(
         default=None, ge=1, description="Maximum execution time in seconds"

--- a/tests/models/test_entities.py
+++ b/tests/models/test_entities.py
@@ -813,6 +813,20 @@ class TestConversation:
         assert conversation.metadata.purpose == "quarterly_report_research"
         assert conversation.metadata.ttl_hours == 72
 
+    def test_common_metadata_rejects_unknown_fields(self) -> None:
+        """CommonMetadata forbids extra properties in conversation metadata."""
+        from datetime import datetime, timezone
+
+        from asap.models.entities import Conversation
+
+        with pytest.raises(ValidationError):
+            Conversation(
+                id=generate_id(),
+                participants=["urn:asap:agent:a", "urn:asap:agent:b"],
+                created_at=datetime.now(timezone.utc),
+                metadata={"purpose": "research", "unknown_key": "value"},
+            )
+
     def test_conversation_json_schema(self):
         """Test that Conversation generates valid JSON Schema."""
         from asap.models.entities import Conversation

--- a/tests/models/test_entities.py
+++ b/tests/models/test_entities.py
@@ -819,13 +819,15 @@ class TestConversation:
 
         from asap.models.entities import Conversation
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError) as exc_info:
             Conversation(
                 id=generate_id(),
                 participants=["urn:asap:agent:a", "urn:asap:agent:b"],
                 created_at=datetime.now(timezone.utc),
                 metadata={"purpose": "research", "unknown_key": "value"},
             )
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("metadata", "unknown_key")
 
     def test_conversation_json_schema(self):
         """Test that Conversation generates valid JSON Schema."""

--- a/tests/models/test_payloads.py
+++ b/tests/models/test_payloads.py
@@ -1,5 +1,8 @@
 """Tests for Task payload models (requests, responses, updates, cancellations)."""
 
+import pytest
+from pydantic import ValidationError
+
 from asap.models.enums import MessageRole, TaskStatus, UpdateType
 
 
@@ -58,6 +61,18 @@ class TestTaskRequest:
         assert request.config.timeout_seconds == 600
         assert request.config.streaming is True
         assert request.config.persist_state is True
+
+    def test_task_request_config_rejects_unknown_fields(self) -> None:
+        """TaskRequestConfig forbids extra properties in config."""
+        from asap.models.payloads import TaskRequest
+
+        with pytest.raises(ValidationError):
+            TaskRequest(
+                conversation_id="conv_123",
+                skill_id="web_research",
+                input={"query": "test"},
+                config={"timeout_seconds": 60, "unknown_flag": True},
+            )
 
     def test_task_request_json_schema(self):
         """Test that TaskRequest generates valid JSON Schema."""

--- a/tests/models/test_payloads.py
+++ b/tests/models/test_payloads.py
@@ -66,13 +66,15 @@ class TestTaskRequest:
         """TaskRequestConfig forbids extra properties in config."""
         from asap.models.payloads import TaskRequest
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError) as exc_info:
             TaskRequest(
                 conversation_id="conv_123",
                 skill_id="web_research",
                 input={"query": "test"},
                 config={"timeout_seconds": 60, "unknown_flag": True},
             )
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("config", "unknown_flag")
 
     def test_task_request_json_schema(self):
         """Test that TaskRequest generates valid JSON Schema."""

--- a/tests/properties/test_model_properties.py
+++ b/tests/properties/test_model_properties.py
@@ -17,6 +17,7 @@ from asap.models.entities import (
     Artifact,
     AuthScheme,
     Capability,
+    CommonMetadata,
     Conversation,
     Endpoint,
     Manifest,
@@ -41,6 +42,7 @@ from asap.models.payloads import (
     TaskCancel,
     TaskMetrics,
     TaskRequest,
+    TaskRequestConfig,
     TaskResponse,
     TaskUpdate,
 )
@@ -88,6 +90,41 @@ def st_json_dict() -> st.SearchStrategy[dict]:
         ),
         max_size=8,
     )
+
+
+
+@st.composite
+def st_common_metadata(draw: st.DrawFn) -> CommonMetadata:
+    """Strategy for CommonMetadata (only known keys)."""
+    fields = {
+        "purpose": draw(st.none() | st.text(max_size=100)),
+        "ttl_hours": draw(st.none() | st.integers(min_value=1, max_value=8760)),
+        "source": draw(st.none() | st.text(max_size=80)),
+        "timestamp": draw(st.none() | st.just("2026-01-01T00:00:00Z")),
+        "tags": draw(st.none() | st.lists(st.text(max_size=30), max_size=5)),
+    }
+    present = {k: v for k, v in fields.items() if v is not None}
+    if not present:
+        return CommonMetadata()
+    return CommonMetadata(**present)
+
+
+@st.composite
+def st_task_request_config(draw: st.DrawFn) -> TaskRequestConfig:
+    """Strategy for TaskRequestConfig (only known keys)."""
+    fields = {
+        "timeout_seconds": draw(st.none() | st.integers(min_value=1, max_value=3600)),
+        "priority": draw(st.none() | st.sampled_from(["low", "normal", "high"])),
+        "idempotency_key": draw(st.none() | st.text(alphabet="a-z0-9-", max_size=40)),
+        "streaming": draw(st.none() | st.booleans()),
+        "persist_state": draw(st.none() | st.booleans()),
+        "model": draw(st.none() | st.text(alphabet="a-z0-9.-", max_size=40)),
+        "temperature": draw(st.none() | st.floats(min_value=0, max_value=2, allow_nan=False)),
+    }
+    present = {k: v for k, v in fields.items() if v is not None}
+    if not present:
+        return TaskRequestConfig()
+    return TaskRequestConfig(**present)
 
 
 def st_mime_type() -> st.SearchStrategy[str]:
@@ -233,7 +270,7 @@ def st_conversation(draw: st.DrawFn) -> Conversation:
         id=draw(st_ulid_like()),
         participants=draw(st.lists(st_agent_urn(), min_size=1, max_size=4)),
         created_at=draw(st_datetime_utc()),
-        metadata=draw(st.none() | st_json_dict()),
+        metadata=draw(st.none() | st_common_metadata()),
     )
 
 
@@ -303,7 +340,7 @@ def st_task_request(draw: st.DrawFn) -> TaskRequest:
         parent_task_id=draw(st.none() | st_ulid_like()),
         skill_id=draw(st.text(alphabet="a-z0-9_", min_size=1, max_size=40)),
         input=draw(st_json_dict()),
-        config=draw(st.none() | st_json_dict()),
+        config=draw(st.none() | st_task_request_config()),
     )
 
 

--- a/tests/properties/test_model_properties.py
+++ b/tests/properties/test_model_properties.py
@@ -92,7 +92,6 @@ def st_json_dict() -> st.SearchStrategy[dict]:
     )
 
 
-
 @st.composite
 def st_common_metadata(draw: st.DrawFn) -> CommonMetadata:
     """Strategy for CommonMetadata (only known keys)."""


### PR DESCRIPTION
## Summary

- Removes `extra="allow"` overrides on `TaskRequestConfig` and `CommonMetadata` — both now inherit `ASAPBaseModel` (`extra="forbid"`)
- **Breaking:** clients sending unknown keys in `config` or `metadata` receive `ValidationError`
- `TaskMetrics` unchanged (out of scope)
- Docs: `CHANGELOG.md` breaking note, `docs/migration.md`

## Merge order (issue #209 train)

**Merge 2 of 4** — after #277 (operator auth). Rebase on `main` if `CHANGELOG.md` / `docs/migration.md` conflict.

## Test plan

- [x] `uv run pytest tests/models/ -q --tb=short` (238 passed)
- [x] New tests: unknown fields rejected on `TaskRequestConfig` and `CommonMetadata`
- [x] `uv run ruff check src/asap/models/` + `uv run mypy src/asap/models/`

Refs: #209