### PR TITLE
feat(auth): add Redis-backed JtiReplayCache (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   requires an OAuth2 Bearer JWT with scope ``asap:admin`` on ``/usage``,
   ``/sla``, and ``/audit``. Default remains open (local/operator ergonomics)
   with the existing startup warnings. Requires ``oauth2_config``.
+- **Redis-backed JTI replay cache (#209)**: Optional
+  :class:`~asap.auth.jti_replay_cache.RedisJtiReplayCache` for multi-worker
+  Host/Agent JWT replay protection. Default remains in-memory
+  :class:`~asap.auth.agent_jwt.JtiReplayCache`. Requires
+  ``pip install 'asap-protocol[redis]'``. Inject via
+  ``create_app(identity_jti_cache=...)`` or ``MCPAuthConfig.jti_replay_cache``.
 
 ### Changed
 
@@ -38,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Follow-up (not in v2.5.1)
 
 - **Adapter Lab II** — new framework adapters (separate PRD: [prd-v2.5.1-adapter-lab-ii.md](product/prd/prd-v2.5.1-adapter-lab-ii.md)).
-- Redis-backed `JtiReplayCache` and distributed Next.js rate limits.
+- Distributed Next.js rate limits (Upstash Redis).
 - `@asap-protocol/mcp-auth` HTTP/SSE middleware (deferred from v2.5.0 — see [2.5.0] TypeScript note and [typescript-mcp-auth-spike.md](engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md)).
 - Collapse the dual `UsageMetrics`/`InMemoryMeteringStore` pair retained in S1 for API stability.
 - Reduce the `asap.transport.client` package aggregate LOC below the S2 target.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -933,6 +933,25 @@ TaskRequest(
 
 `TaskResponse.metrics` still allows extra fields (unchanged in this release).
 
+#### Redis-backed JTI replay cache (#209)
+
+Single-process deployments keep the default in-memory
+:class:`~asap.auth.agent_jwt.JtiReplayCache`. Multi-worker or multi-instance
+hosts should share replay state via
+:class:`~asap.auth.jti_replay_cache.RedisJtiReplayCache` (requires
+``pip install 'asap-protocol[redis]'``):
+
+```python
+from asap.auth.jti_replay_cache import RedisJtiReplayCache
+from asap.transport.server import create_app
+
+jti_cache = RedisJtiReplayCache.from_url("redis://localhost:6379/0")
+app = create_app(manifest, identity_jti_cache=jti_cache, ...)
+```
+
+MCP Auth Bridge deployments can pass the same instance through
+``MCPAuthConfig(jti_replay_cache=jti_cache)``.
+
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "types-jsonschema>=4.0.0",
     "ruff>=0.14.14",
     "pip-audit>=2.7",
+    "fakeredis>=2.26.0",
 ]
 docs = [
     "ghp-import>=2.1.0",

--- a/src/asap/auth/agent_jwt.py
+++ b/src/asap/auth/agent_jwt.py
@@ -30,6 +30,7 @@ from asap.auth.identity import (
     extend_session,
     jwk_thumbprint_sha256,
 )
+from asap.auth.jti_replay_cache import JtiReplayCacheProtocol
 from asap.models.ids import generate_id
 
 # Encode/decode: EdDSA (RFC 8037 Ed25519); joserfc also accepts "Ed25519" alias.
@@ -229,7 +230,7 @@ async def verify_host_jwt(
     host_store: HostStore,
     *,
     expected_audience: str | list[str] | None = None,
-    jti_replay_cache: JtiReplayCache | None = None,
+    jti_replay_cache: JtiReplayCacheProtocol | None = None,
     record_jti: bool = True,
 ) -> JwtVerifyResult:
     """Verify a Host JWT signature and resolve the host (or inline registration).
@@ -307,7 +308,7 @@ async def verify_agent_jwt(
     agent_store: AgentStore,
     *,
     expected_audience: str | list[str] | None = None,
-    jti_replay_cache: JtiReplayCache | None = None,
+    jti_replay_cache: JtiReplayCacheProtocol | None = None,
 ) -> JwtVerifyResult:
     """Verify an Agent JWT: typ, signatures, host/agent rows, exp/iat/jti, capabilities.
 

--- a/src/asap/auth/jti_replay_cache.py
+++ b/src/asap/auth/jti_replay_cache.py
@@ -1,0 +1,101 @@
+"""JWT ``jti`` replay protection backends (in-memory default, optional Redis).
+
+Multi-instance deployments should inject :class:`RedisJtiReplayCache` via
+``create_app(identity_jti_cache=...)`` or ``MCPAuthConfig.jti_replay_cache``
+so replay state is shared across workers. Requires ``pip install 'asap-protocol[redis]'``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from redis import Redis
+
+
+@runtime_checkable
+class JtiReplayCacheProtocol(Protocol):
+    """Structural interface for ``jti`` replay guards."""
+
+    def contains(self, partition_key: str, jti: str) -> bool:
+        """Return whether ``jti`` is still recorded for ``partition_key``."""
+        ...
+
+    def check_and_record(self, partition_key: str, jti: str) -> bool:
+        """Record ``jti`` for ``partition_key``; return False on replay."""
+        ...
+
+
+def _jti_blank(jti: str) -> bool:
+    return not jti or not str(jti).strip()
+
+
+def _redis_key(prefix: str, partition_key: str, jti: str) -> str:
+    return f"{prefix}:{partition_key}:{jti}"
+
+
+class RedisJtiReplayCache:
+    """Redis-backed ``jti`` replay guard (default 90s TTL per key).
+
+    Uses ``SET key 1 NX EX ttl`` for atomic first-use recording and ``EXISTS``
+    for read-only replay checks (Host JWT polling routes).
+
+    Example:
+        >>> cache = RedisJtiReplayCache.from_url("redis://localhost:6379/0")
+        >>> cache.check_and_record("host-thumbprint", "jwt_abc")
+        True
+    """
+
+    def __init__(
+        self,
+        client: Redis,
+        *,
+        ttl_seconds: float = 90.0,
+        key_prefix: str = "asap:jti-replay",
+    ) -> None:
+        self._client = client
+        self._ttl = ttl_seconds
+        self._key_prefix = key_prefix
+
+    @classmethod
+    def from_url(
+        cls,
+        url: str,
+        *,
+        ttl_seconds: float = 90.0,
+        key_prefix: str = "asap:jti-replay",
+        **redis_kwargs: Any,
+    ) -> RedisJtiReplayCache:
+        """Build a cache from a Redis URI (requires the optional ``redis`` extra)."""
+        try:
+            import redis
+        except ImportError as exc:
+            msg = (
+                "Redis JTI replay cache requires the 'redis' package. "
+                "Install it with: pip install 'asap-protocol[redis]'"
+            )
+            raise ImportError(msg) from exc
+        client = redis.Redis.from_url(url, **redis_kwargs)
+        return cls(client, ttl_seconds=ttl_seconds, key_prefix=key_prefix)
+
+    def contains(self, partition_key: str, jti: str) -> bool:
+        """Return whether ``jti`` is still recorded for ``partition_key``."""
+        if _jti_blank(jti):
+            return False
+        key = _redis_key(self._key_prefix, partition_key, jti)
+        return bool(self._client.exists(key))
+
+    def check_and_record(self, partition_key: str, jti: str) -> bool:
+        """Record ``jti`` for ``partition_key``.
+
+        Returns:
+            True if this is the first use within the TTL window.
+
+            False if the same ``(partition_key, jti)`` was seen within the TTL
+            (replay).
+        """
+        if _jti_blank(jti):
+            return False
+        key = _redis_key(self._key_prefix, partition_key, jti)
+        ttl_int = max(1, int(self._ttl))
+        return bool(self._client.set(key, "1", nx=True, ex=ttl_int))

--- a/src/asap/auth/jti_replay_cache.py
+++ b/src/asap/auth/jti_replay_cache.py
@@ -40,6 +40,13 @@ class RedisJtiReplayCache:
     Uses ``SET key 1 NX EX ttl`` for atomic first-use recording and ``EXISTS``
     for read-only replay checks (Host JWT polling routes).
 
+    ``partition_key`` and ``jti`` are assumed URL-safe (no ``:``); keys are
+    ``{prefix}:{partition_key}:{jti}``.
+
+    Redis connection errors propagate to callers (same pattern as
+    :mod:`asap.transport.rate_limit`); wrap with health checks or retries
+    if you need graceful degradation.
+
     Example:
         >>> cache = RedisJtiReplayCache.from_url("redis://localhost:6379/0")
         >>> cache.check_and_record("host-thumbprint", "jwt_abc")
@@ -97,5 +104,6 @@ class RedisJtiReplayCache:
         if _jti_blank(jti):
             return False
         key = _redis_key(self._key_prefix, partition_key, jti)
+        # Floor fractional seconds to whole-second Redis EX (in-memory keeps float TTL).
         ttl_int = max(1, int(self._ttl))
         return bool(self._client.set(key, "1", nx=True, ex=ttl_int))

--- a/src/asap/mcp/auth/config.py
+++ b/src/asap/mcp/auth/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
-from asap.auth.agent_jwt import JtiReplayCache
+from asap.auth.jti_replay_cache import JtiReplayCacheProtocol
 from asap.auth.capabilities import CapabilityRegistry
 from asap.auth.identity import AgentStore, HostStore
 from asap.mcp.auth.jwt_extractor import default_jwt_extractor
@@ -45,7 +45,7 @@ class MCPAuthConfig:
     validate_tools_at_startup: bool = False
     jwt_extractor: Callable[[CallToolRequestParams], str | None] | None = None
     allow_env_jwt_fallback: bool = False
-    jti_replay_cache: JtiReplayCache | None = None
+    jti_replay_cache: JtiReplayCacheProtocol | None = None
     expected_audience: str | list[str] | None = None
     manifest_url: str | None = None
 

--- a/src/asap/transport/_auth_helpers.py
+++ b/src/asap/transport/_auth_helpers.py
@@ -9,11 +9,11 @@ from fastapi.responses import JSONResponse
 
 from asap.auth.agent_jwt import (
     HOST_REVOKED_ERROR,
-    JtiReplayCache,
     JwtVerifyResult,
     verify_host_jwt,
 )
 from asap.auth.identity import HostStore
+from asap.auth.jti_replay_cache import JtiReplayCacheProtocol
 
 # ``identity_host_store`` and ``identity_jwt_audience`` are attached to
 # ``app.state`` by :func:`asap.transport.server.create_app`; read at call time
@@ -33,7 +33,7 @@ def bearer_token_from_request(request: Request) -> str | None:
 async def verify_host_bearer(
     request: Request,
     *,
-    jti_replay_cache: JtiReplayCache | None,
+    jti_replay_cache: JtiReplayCacheProtocol | None,
     require_active_host: bool = True,
     record_jti: bool = True,
 ) -> tuple[JwtVerifyResult | None, JSONResponse | None]:

--- a/src/asap/transport/agent_routes.py
+++ b/src/asap/transport/agent_routes.py
@@ -19,9 +19,9 @@ from pydantic import Field
 from asap.auth.agent_jwt import (
     AGENT_PUBLIC_KEY_CLAIM,
     HOST_PUBLIC_KEY_CLAIM,
-    JtiReplayCache,
     JwtVerifyResult,
 )
+from asap.auth.jti_replay_cache import JtiReplayCacheProtocol
 from asap.auth.approval import (
     A2HApprovalChannel,
     ApprovalMethod,
@@ -281,7 +281,7 @@ async def _handle_agent_register(
     background_tasks: BackgroundTasks,
 ) -> JSONResponse:
     """Create or return an agent session from a verified Host JWT."""
-    jti_cache: JtiReplayCache = request.app.state.identity_jti_cache
+    jti_cache: JtiReplayCacheProtocol = request.app.state.identity_jti_cache
     result, err = await verify_host_bearer(request, jti_replay_cache=jti_cache)
     if err is not None:
         return err
@@ -503,7 +503,7 @@ async def _handle_agent_register(
 
 async def _handle_agent_status(request: Request, agent_id: str) -> JSONResponse:
     """Return agent session status and lifecycle for the authenticated host."""
-    jti_cache: JtiReplayCache = request.app.state.identity_jti_cache
+    jti_cache: JtiReplayCacheProtocol = request.app.state.identity_jti_cache
     # Status polling may legitimately reuse the same Host JWT, but issue #249
     # still requires rejecting tokens already consumed on recording routes.
     result, err = await verify_host_bearer(
@@ -624,7 +624,7 @@ async def _handle_agent_status(request: Request, agent_id: str) -> JSONResponse:
 
 async def _handle_agent_revoke(request: Request, body: AgentRevokeBody) -> JSONResponse:
     """Permanently revoke an agent session for the authenticated host."""
-    jti_cache: JtiReplayCache = request.app.state.identity_jti_cache
+    jti_cache: JtiReplayCacheProtocol = request.app.state.identity_jti_cache
     result, err = await verify_host_bearer(request, jti_replay_cache=jti_cache)
     if err is not None:
         return err
@@ -657,7 +657,7 @@ async def _handle_agent_revoke(request: Request, body: AgentRevokeBody) -> JSONR
 
 async def _handle_agent_rotate_key(request: Request, body: AgentRotateKeyBody) -> JSONResponse:
     """Replace the agent session's Ed25519 public JWK (old JWTs no longer verify)."""
-    jti_cache: JtiReplayCache = request.app.state.identity_jti_cache
+    jti_cache: JtiReplayCacheProtocol = request.app.state.identity_jti_cache
     result, err = await verify_host_bearer(request, jti_replay_cache=jti_cache)
     if err is not None:
         return err

--- a/src/asap/transport/capability_routes.py
+++ b/src/asap/transport/capability_routes.py
@@ -10,10 +10,10 @@ from fastapi.responses import JSONResponse
 
 from asap.auth.agent_jwt import (
     HOST_REVOKED_ERROR,
-    JtiReplayCache,
     JwtVerifyResult,
     verify_agent_jwt,
 )
+from asap.auth.jti_replay_cache import JtiReplayCacheProtocol
 from pydantic import ValidationError
 
 from asap.auth.capabilities import CapabilityGrant, CapabilityRegistry
@@ -61,7 +61,7 @@ class AgentReactivateBody(ASAPBaseModel):
 async def verify_agent_bearer(
     request: Request,
     *,
-    jti_replay_cache: JtiReplayCache | None = None,
+    jti_replay_cache: JtiReplayCacheProtocol | None = None,
 ) -> tuple[JwtVerifyResult | None, JSONResponse | None]:
     """Verify an Agent JWT Bearer token."""
     token = bearer_token_from_request(request)
@@ -251,7 +251,7 @@ async def _handle_capability_execute(request: Request) -> JSONResponse:
 
 async def _handle_agent_reactivate(request: Request) -> JSONResponse:
     """Reactivate an expired agent (Host JWT required)."""
-    jti_cache: JtiReplayCache = request.app.state.identity_jti_cache
+    jti_cache: JtiReplayCacheProtocol = request.app.state.identity_jti_cache
     result, err = await verify_host_bearer(request, jti_replay_cache=jti_cache)
     if err is not None:
         return err

--- a/src/asap/transport/server.py
+++ b/src/asap/transport/server.py
@@ -72,6 +72,7 @@ from asap.observability.tracing import configure_tracing
 from asap.auth import JWKSValidator, OAuth2Config, OAuth2Middleware
 from asap.auth.middleware import OPERATOR_API_PATH_PREFIXES
 from asap.auth.agent_jwt import JtiReplayCache
+from asap.auth.jti_replay_cache import JtiReplayCacheProtocol
 from asap.auth.approval import A2HApprovalChannel, ApprovalStore, InMemoryApprovalStore
 from asap.auth.self_auth import (
     FreshSessionConfig,
@@ -286,7 +287,7 @@ class ServerComponents:
     nonce_store: NonceStore | None
     identity_host_store: HostStore
     identity_agent_store: AgentStore
-    identity_jti_cache: JtiReplayCache
+    identity_jti_cache: JtiReplayCacheProtocol
     identity_jwt_audience: str | list[str]
     identity_approval_store: ApprovalStore
     snapshot_store: SnapshotStore
@@ -306,7 +307,7 @@ def _build_server_components(
     metering_storage: object | None,
     identity_host_store: HostStore | None,
     identity_agent_store: AgentStore | None,
-    identity_jti_cache: JtiReplayCache | None,
+    identity_jti_cache: JtiReplayCacheProtocol | None,
     identity_jwt_audience: str | list[str] | None,
     identity_approval_store: ApprovalStore | None,
 ) -> ServerComponents:
@@ -782,7 +783,7 @@ def create_app(
     audit_store: AuditStore | None = None,
     identity_host_store: HostStore | None = None,
     identity_agent_store: AgentStore | None = None,
-    identity_jti_cache: JtiReplayCache | None = None,
+    identity_jti_cache: JtiReplayCacheProtocol | None = None,
     identity_jwt_audience: str | list[str] | None = None,
     identity_rate_limit: str | None = None,
     identity_approval_store: ApprovalStore | None = None,
@@ -863,11 +864,14 @@ def create_app(
             message processing events.
         identity_host_store: Optional HostStore; default in-memory when both stores omitted.
         identity_agent_store: Optional AgentStore; must be set with identity_host_store or both omitted.
-        identity_jti_cache: Optional ``jti`` replay cache for Host JWT on agent routes.
+        identity_jti_cache: Optional ``jti`` replay cache for Host/Agent JWT routes.
             Mutating routes record ``jti`` values; ``GET /asap/agent/status`` uses
             the same cache in read-only mode so polling can reuse a token while
             still rejecting Host JWTs already consumed elsewhere. Defaults to a
-            new in-memory cache per app.
+            new in-memory :class:`~asap.auth.agent_jwt.JtiReplayCache` per app.
+            For multi-worker deployments, pass
+            :class:`~asap.auth.jti_replay_cache.RedisJtiReplayCache` (requires
+            the ``redis`` extra).
         identity_jwt_audience: Expected ``aud`` value(s) for Host JWT verification on
             ``/asap/agent/*``. Defaults to ``manifest.id`` so tokens are bound to this
             server instance. Set explicitly for multi-audience or migration scenarios.

--- a/tests/auth/test_jti_replay_cache_redis.py
+++ b/tests/auth/test_jti_replay_cache_redis.py
@@ -1,0 +1,92 @@
+"""Tests for Redis-backed JTI replay cache."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from typing import TYPE_CHECKING, Callable, Protocol
+
+import pytest
+
+from asap.auth.agent_jwt import JtiReplayCache
+from asap.auth.jti_replay_cache import JtiReplayCacheProtocol, RedisJtiReplayCache
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+class _ReplayCacheUnderTest(Protocol):
+    def contains(self, partition_key: str, jti: str) -> bool: ...
+
+    def check_and_record(self, partition_key: str, jti: str) -> bool: ...
+
+
+def _assert_shared_replay_semantics(
+    cache: _ReplayCacheUnderTest,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Exercise TTL, replay rejection, and blank-jti handling."""
+    t0 = 50_000.0
+    monkeypatch.setattr("asap.auth.agent_jwt.time.time", lambda: t0)
+    assert not cache.contains("part", "jti-1")
+    assert cache.check_and_record("part", "jti-1")
+    assert not cache.check_and_record("part", "jti-1")
+    assert cache.contains("part", "jti-1")
+    assert not cache.check_and_record("part", "")
+    assert not cache.check_and_record("part", "   ")
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(lambda: JtiReplayCache(ttl_seconds=1.0), id="memory"),
+    ],
+)
+def test_jti_replay_cache_shared_semantics(
+    factory: Callable[[], _ReplayCacheUnderTest],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In-memory cache satisfies the shared replay contract."""
+    _assert_shared_replay_semantics(factory(), monkeypatch)
+
+
+def test_redis_jti_replay_cache_from_url_raises_when_redis_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``from_url`` surfaces the optional ``redis`` extra requirement."""
+    monkeypatch.setitem(sys.modules, "redis", None)
+    with pytest.raises(ImportError, match="asap-protocol\\[redis\\]"):
+        RedisJtiReplayCache.from_url("redis://localhost:6379/0")
+
+
+def _fakeredis_cache() -> RedisJtiReplayCache | None:
+    if importlib.util.find_spec("redis") is None:
+        return None
+    if importlib.util.find_spec("fakeredis") is None:
+        return None
+    import fakeredis
+
+    client = fakeredis.FakeStrictRedis(decode_responses=False)
+    return RedisJtiReplayCache(client, ttl_seconds=1.0)
+
+
+@pytest.mark.skipif(_fakeredis_cache() is None, reason="redis/fakeredis not installed")
+def test_redis_jti_replay_cache_shared_semantics(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redis cache matches in-memory replay semantics."""
+    cache = _fakeredis_cache()
+    assert cache is not None
+    _assert_shared_replay_semantics(cache, monkeypatch)
+
+
+def test_jti_replay_cache_protocol_accepts_memory() -> None:
+    """Structural protocol typing covers the default in-memory backend."""
+    memory: JtiReplayCacheProtocol = JtiReplayCache()
+    assert isinstance(memory, JtiReplayCacheProtocol)
+
+
+@pytest.mark.skipif(_fakeredis_cache() is None, reason="redis/fakeredis not installed")
+def test_jti_replay_cache_protocol_accepts_redis() -> None:
+    """Structural protocol typing covers the Redis backend."""
+    cache = _fakeredis_cache()
+    assert cache is not None
+    assert isinstance(cache, JtiReplayCacheProtocol)

--- a/uv.lock
+++ b/uv.lock
@@ -270,6 +270,7 @@ crewai = [
 dev = [
     { name = "asgi-lifespan" },
     { name = "brotli" },
+    { name = "fakeredis" },
     { name = "mypy" },
     { name = "pip-audit" },
     { name = "pytest" },
@@ -344,6 +345,7 @@ requires-dist = [
     { name = "brotli", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.80" },
     { name = "cryptography", specifier = ">=48.0.1,<49" },
+    { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.26.0" },
     { name = "fastapi", specifier = ">=0.136.1" },
     { name = "ghp-import", marker = "extra == 'docs'", specifier = ">=2.1.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
@@ -387,7 +389,7 @@ requires-dist = [
     { name = "types-jsonschema", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "uvicorn", specifier = ">=0.34" },
     { name = "watchfiles", specifier = ">=0.21.0" },
-    { name = "webauthn", marker = "extra == 'webauthn'", specifier = ">=2.6,<3" },
+    { name = "webauthn", marker = "extra == 'webauthn'", specifier = ">=2.6,<4" },
     { name = "websockets", specifier = ">=12.0" },
     { name = "zeroconf", marker = "extra == 'dns-sd'", specifier = ">=0.149.5" },
 ]
@@ -1300,6 +1302,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/ed/86ed74d8829c3bc565025c1c9efaf8518c9165fbf8c9cc2c026c8ed21bd9/fakeredis-2.36.2.tar.gz", hash = "sha256:c37a0b307fae3f27ec7c19e59519e57b8c52782e00303df9075361b5ba441be6", size = 213336, upload-time = "2026-06-17T13:25:38.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/4d/e6e40f93031adbf654d34e542bd396e9f3bc1c6209b40c920d58c9e1317a/fakeredis-2.36.2-py3-none-any.whl", hash = "sha256:84cbb9c74ca8946c0d2499daadf3a5d0bfe3cfbac71e3398316d1a1eab3421c4", size = 141039, upload-time = "2026-06-17T13:25:36.638Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `JtiReplayCacheProtocol` and `RedisJtiReplayCache` (`SET NX EX` / `EXISTS`) as distributed alternative to in-memory default
- No breaking change: `JtiReplayCache` in-memory remains default per `create_app()`
- Wired via existing `identity_jti_cache` / `MCPAuthConfig.jti_replay_cache` injection
- Requires `asap-protocol[redis]` extra for Redis backend
- Docs: `CHANGELOG.md`, `docs/migration.md`

## Merge order (issue #209 train)

**Merge 3 of 4** — after #277 and forbid PR. Independent of `apps/web` PR; rebase on `main` if needed.

## Test plan

- [x] `uv run pytest tests/auth/ -q -k "jti or replay"` (12 passed, 2 skipped without fakeredis)
- [x] `uv run ruff check` + `uv run mypy` on changed auth files

Refs: #209