### PR TITLE
feat(web): optional distributed rate limits via Upstash Redis (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `asap.schemas`, `asap.cli.repl`). The `_compat` shim is removed in v2.6.0
   ([#275](https://github.com/adriannoes/asap-protocol/issues/275)).
   See [migration guide](docs/migration.md#upgrading-from-v251).
+- **Web app (`apps/web`)**: Optional distributed rate limits via Upstash Redis
+  or Vercel KV when `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` (or
+  `KV_REST_API_URL` + `KV_REST_API_TOKEN`) are set; local dev without Redis
+  keeps the existing in-memory per-instance limiter
+  ([#209](https://github.com/adriannoes/asap-protocol/issues/209)).
 
 ### Fixed
 
@@ -44,7 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Follow-up (not in v2.5.1)
 
 - **Adapter Lab II** — new framework adapters (separate PRD: [prd-v2.5.1-adapter-lab-ii.md](product/prd/prd-v2.5.1-adapter-lab-ii.md)).
-- Distributed Next.js rate limits (Upstash Redis).
 - `@asap-protocol/mcp-auth` HTTP/SSE middleware (deferred from v2.5.0 — see [2.5.0] TypeScript note and [typescript-mcp-auth-spike.md](engineering/tasks/v2.5.0/typescript-mcp-auth-spike.md)).
 - Collapse the dual `UsageMetrics`/`InMemoryMeteringStore` pair retained in S1 for API stability.
 - Reduce the `asap.transport.client` package aggregate LOC below the S2 target.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -51,6 +51,18 @@ TELEMETRY_SITE_METRICS_JSON=
 # Enable fixture routes (e.g. test-login, mock registry) for E2E/Playwright
 ENABLE_FIXTURE_ROUTES=
 
+# -----------------------------------------------------------------------------
+# Optional distributed rate limits (production multi-instance)
+# -----------------------------------------------------------------------------
+# When set, dashboard and proxy rate limits are shared across serverless instances
+# via Upstash Redis REST API. Omit for local dev (in-memory fallback per instance).
+# Upstash: https://upstash.com/docs/redis/overall/getstarted
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+# Vercel KV uses the same REST client (auto-injected on Vercel when KV is linked):
+# KV_REST_API_URL=
+# KV_REST_API_TOKEN=
+
 # Playwright: custom browser path (if "Executable doesn't exist" in sandbox)
 # See apps/web/docs/playwright-e2e.md for details.
 # macOS: /Users/yourname/Library/Caches/ms-playwright

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -20,6 +20,8 @@
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.14.5",
         "@types/three": "^0.185.0",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.38.0",
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
         "class-variance-authority": "^0.7.1",
@@ -1510,9 +1512,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1528,9 +1527,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1548,9 +1544,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1566,9 +1559,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1586,9 +1576,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1604,9 +1591,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1624,9 +1608,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1643,9 +1624,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1661,9 +1639,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1687,9 +1662,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1711,9 +1683,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1737,9 +1706,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1761,9 +1727,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1787,9 +1750,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1812,9 +1772,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1836,9 +1793,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2229,9 +2183,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2247,9 +2198,6 @@
       "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2267,9 +2215,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2285,9 +2230,6 @@
       "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4827,9 +4769,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4847,9 +4786,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4867,9 +4803,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4887,9 +4820,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5932,6 +5862,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vercel/analytics": {
       "version": "1.6.1",
@@ -8878,6 +8841,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14624,6 +14588,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.24.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,8 @@
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.14.5",
     "@types/three": "^0.185.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/api/health-check/route.ssrf.integration.test.ts
+++ b/apps/web/src/app/api/health-check/route.ssrf.integration.test.ts
@@ -14,7 +14,7 @@ function createRequest(url: string): NextRequest {
 
 describe('GET /api/health-check', () => {
   beforeEach(() => {
-    vi.mocked(checkProxyRateLimit).mockReturnValue({ allowed: true });
+    vi.mocked(checkProxyRateLimit).mockResolvedValue({ allowed: true });
   });
 
   it('returns 400 for loopback URL 127.0.0.2', async () => {

--- a/apps/web/src/app/api/health-check/route.test.ts
+++ b/apps/web/src/app/api/health-check/route.test.ts
@@ -21,7 +21,7 @@ function createRequest(url?: string, headers?: Record<string, string>): NextRequ
 describe('GET /api/health-check', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(checkProxyRateLimit).mockReturnValue({ allowed: true });
+    vi.mocked(checkProxyRateLimit).mockResolvedValue({ allowed: true });
     vi.mocked(isAllowedExternalUrl).mockResolvedValue({ valid: true });
   });
 
@@ -37,7 +37,7 @@ describe('GET /api/health-check', () => {
   });
 
   it('returns 429 and Retry-After when rate limit blocks request', async () => {
-    vi.mocked(checkProxyRateLimit).mockReturnValue({ allowed: false, retryAfter: 12 });
+    vi.mocked(checkProxyRateLimit).mockResolvedValue({ allowed: false, retryAfter: 12 });
     const res = await GET(createRequest('https://example.com/health', { 'x-forwarded-for': '203.0.113.10, 198.51.100.1' }));
     expect(res.status).toBe(429);
     expect(res.headers.get('Retry-After')).toBe('12');

--- a/apps/web/src/app/api/health-check/route.ts
+++ b/apps/web/src/app/api/health-check/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
     const { url } = parsed.data;
 
     const ip = getClientIp(request);
-    const rateCheck = checkProxyRateLimit(ip);
+    const rateCheck = await checkProxyRateLimit(ip);
     if (!rateCheck.allowed) {
         return NextResponse.json(
             { error: 'Too many requests', retryAfter: rateCheck.retryAfter },

--- a/apps/web/src/app/api/proxy/check/__tests__/route.test.ts
+++ b/apps/web/src/app/api/proxy/check/__tests__/route.test.ts
@@ -19,7 +19,7 @@ function createRequest(targetUrl: string, headers?: Record<string, string>): Nex
 describe('GET /api/proxy/check', () => {
     beforeEach(() => {
         vi.mocked(isAllowedProxyUrlAsync).mockResolvedValue({ valid: true });
-        vi.mocked(checkProxyRateLimit).mockReturnValue({ allowed: true });
+        vi.mocked(checkProxyRateLimit).mockResolvedValue({ allowed: true });
     });
 
     it('returns 400 when url parameter is missing', async () => {
@@ -31,7 +31,7 @@ describe('GET /api/proxy/check', () => {
     });
 
     it('returns 429 and Retry-After when rate limit blocks request', async () => {
-        vi.mocked(checkProxyRateLimit).mockReturnValue({ allowed: false, retryAfter: 9 });
+        vi.mocked(checkProxyRateLimit).mockResolvedValue({ allowed: false, retryAfter: 9 });
         const req = createRequest('https://example.com/health', { 'x-forwarded-for': '198.51.100.20' });
         const res = await GET(req);
         expect(res.status).toBe(429);
@@ -41,7 +41,7 @@ describe('GET /api/proxy/check', () => {
     });
 
     it('uses x-real-ip when x-forwarded-for is absent', async () => {
-        vi.mocked(checkProxyRateLimit).mockReturnValue({ allowed: true });
+        vi.mocked(checkProxyRateLimit).mockResolvedValue({ allowed: true });
         const req = createRequest('https://example.com/health', { 'x-real-ip': '203.0.113.5' });
         await GET(req);
         expect(checkProxyRateLimit).toHaveBeenCalledWith('203.0.113.5');

--- a/apps/web/src/app/api/proxy/check/route.ts
+++ b/apps/web/src/app/api/proxy/check/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
     const { url } = parsed.data;
 
     const ip = getClientIp(request);
-    const rateCheck = checkProxyRateLimit(ip);
+    const rateCheck = await checkProxyRateLimit(ip);
     if (!rateCheck.allowed) {
         return NextResponse.json(
             { error: 'Too many requests', retryAfter: rateCheck.retryAfter },

--- a/apps/web/src/app/dashboard/__tests__/dashboard-actions.test.ts
+++ b/apps/web/src/app/dashboard/__tests__/dashboard-actions.test.ts
@@ -10,7 +10,7 @@ vi.mock('@/auth', () => ({
     auth: vi.fn(),
 }));
 vi.mock('@/lib/rate-limit', () => ({
-    checkRateLimit: vi.fn(() => true),
+    checkRateLimit: vi.fn(() => Promise.resolve(true)),
 }));
 
 vi.mock('next/cache', () => ({
@@ -40,7 +40,7 @@ describe('fetchUserRegistrationIssues', () => {
             accessToken: 'ghp_fake_token',
         } as never);
 
-        checkRateLimit.mockReturnValue(true);
+        checkRateLimit.mockResolvedValue(true);
     });
 
     it('returns error when not authenticated', async () => {
@@ -51,7 +51,7 @@ describe('fetchUserRegistrationIssues', () => {
     });
 
     it('returns error when rate limit exceeded', async () => {
-        checkRateLimit.mockReturnValue(false);
+        checkRateLimit.mockResolvedValue(false);
         const result = await fetchUserRegistrationIssues();
         expect(result.success).toBe(false);
         if (!result.success) expect(result.error).toContain('Too many requests');

--- a/apps/web/src/app/dashboard/actions.ts
+++ b/apps/web/src/app/dashboard/actions.ts
@@ -64,7 +64,7 @@ export async function fetchUserRegistrationIssues() {
 
         const userId =
             (session.user as { id?: string }).id ?? session.user.username ?? 'anonymous';
-        if (!checkRateLimit(userId, 30, 60_000)) {
+        if (!(await checkRateLimit(userId, 30, 60_000))) {
             return { success: false, error: 'Too many requests. Please try again in a minute.' };
         }
 

--- a/apps/web/src/app/dashboard/register/__tests__/register-actions.test.ts
+++ b/apps/web/src/app/dashboard/register/__tests__/register-actions.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/lib/url-validator', () => ({
     isAllowedExternalUrl: vi.fn(),
 }));
 vi.mock('@/lib/rate-limit', () => ({
-    checkRateLimit: vi.fn(() => true),
+    checkRateLimit: vi.fn(() => Promise.resolve(true)),
 }));
 
 const auth = vi.mocked(authModule.auth);
@@ -38,7 +38,7 @@ describe('submitAgentRegistration', () => {
             user: { id: 'u1', username: 'testuser', name: 'Test' },
         } as never);
         isAllowedExternalUrl.mockResolvedValue({ valid: true });
-        checkRateLimit.mockReturnValue(true);
+        checkRateLimit.mockResolvedValue(true);
     });
 
     it('returns error when not authenticated', async () => {
@@ -56,7 +56,7 @@ describe('submitAgentRegistration', () => {
     });
 
     it('returns error when rate limit exceeded', async () => {
-        checkRateLimit.mockReturnValue(false);
+        checkRateLimit.mockResolvedValue(false);
         const result = await submitAgentRegistration(validForm);
         expect(result.success).toBe(false);
         expect(result.error).toContain('Too many registration attempts');

--- a/apps/web/src/app/dashboard/register/actions.ts
+++ b/apps/web/src/app/dashboard/register/actions.ts
@@ -24,7 +24,7 @@ export async function submitAgentRegistration(values: unknown) {
         }
 
         const isE2E = process.env.ENABLE_FIXTURE_ROUTES === 'true' && username === 'e2e-tester';
-        if (!isE2E && !checkRateLimit(userId, 5, 60_000)) {
+        if (!isE2E && !(await checkRateLimit(userId, 5, 60_000))) {
             return { success: false, error: 'Too many registration attempts. Please try again in a minute.' };
         }
 

--- a/apps/web/src/app/dashboard/verify/actions.ts
+++ b/apps/web/src/app/dashboard/verify/actions.ts
@@ -18,7 +18,7 @@ export async function submitVerificationRequest(
     const userId = (session.user as { id?: string }).id ?? 'anonymous';
     const username = (session.user as { username?: string }).username || session.user.name;
     const isE2E = process.env.ENABLE_FIXTURE_ROUTES === 'true' && username === 'e2e-tester';
-    if (!isE2E && !checkRateLimit(userId, 5, 60_000)) {
+    if (!isE2E && !(await checkRateLimit(userId, 5, 60_000))) {
         return { success: false, error: 'Too many verification attempts. Please try again in a minute.' };
     }
 

--- a/apps/web/src/lib/rate-limit.redis.test.ts
+++ b/apps/web/src/lib/rate-limit.redis.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockLimit } = vi.hoisted(() => ({
+    mockLimit: vi.fn(),
+}));
+
+vi.mock('@upstash/redis', () => ({
+    Redis: class MockRedis {},
+}));
+
+vi.mock('@upstash/ratelimit', () => {
+    class MockRatelimit {
+        limit = mockLimit;
+        static fixedWindow = vi.fn(() => 'fixed-window');
+        static slidingWindow = vi.fn(() => 'sliding-window');
+    }
+    return { Ratelimit: MockRatelimit };
+});
+
+describe('rate-limit Redis backend', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        mockLimit.mockReset();
+        delete process.env.KV_REST_API_URL;
+        delete process.env.KV_REST_API_TOKEN;
+        delete process.env.UPSTASH_REDIS_REST_URL;
+        delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    });
+
+    afterEach(() => {
+        delete process.env.KV_REST_API_URL;
+        delete process.env.KV_REST_API_TOKEN;
+        delete process.env.UPSTASH_REDIS_REST_URL;
+        delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    });
+
+    it('allows when Upstash limiter succeeds', async () => {
+        process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
+        process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+        mockLimit.mockResolvedValue({ success: true, reset: Date.now() + 60_000 });
+
+        const { checkRateLimit } = await import('./rate-limit');
+        await expect(checkRateLimit('redis-user-key', 3, 10_000)).resolves.toBe(true);
+        expect(mockLimit).toHaveBeenCalledWith('redis-user-key');
+    });
+
+    it('blocks proxy traffic when limiter returns failure with retryAfter', async () => {
+        process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
+        process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+        const resetAt = Date.now() + 45_000;
+        mockLimit.mockResolvedValue({ success: false, reset: resetAt });
+
+        const { checkProxyRateLimit } = await import('./rate-limit');
+        const result = await checkProxyRateLimit('203.0.113.1');
+        expect(result.allowed).toBe(false);
+        expect(result.retryAfter).toBeGreaterThan(0);
+    });
+
+    it('falls back to in-memory limits when Redis throws', async () => {
+        process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
+        process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+        mockLimit.mockRejectedValue(new Error('redis unavailable'));
+
+        const { checkRateLimit } = await import('./rate-limit');
+        const key = `fallback-${Date.now()}`;
+        await expect(checkRateLimit(key, 1, 60_000)).resolves.toBe(true);
+        await expect(checkRateLimit(key, 1, 60_000)).resolves.toBe(false);
+    });
+
+    it('ignores mixed Upstash URL with KV token', async () => {
+        process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
+        process.env.KV_REST_API_TOKEN = 'kv-only-token';
+
+        const { checkRateLimit } = await import('./rate-limit');
+        const key = `misconfig-${Date.now()}`;
+        await expect(checkRateLimit(key, 2, 10_000)).resolves.toBe(true);
+        expect(mockLimit).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/lib/rate-limit.test.ts
+++ b/apps/web/src/lib/rate-limit.test.ts
@@ -10,39 +10,39 @@ describe('checkProxyRateLimit', () => {
         vi.useRealTimers();
     });
 
-    it('allows the first request for a new IP', () => {
+    it('allows the first request for a new IP', async () => {
         const ip = `proxy-first-${Date.now()}-${Math.random()}`;
-        expect(checkProxyRateLimit(ip)).toEqual({ allowed: true });
+        await expect(checkProxyRateLimit(ip)).resolves.toEqual({ allowed: true });
     });
 
-    it('blocks the 31st request within the same window', () => {
+    it('blocks the 31st request within the same window', async () => {
         const ip = `proxy-block-${Date.now()}-${Math.random()}`;
         for (let i = 0; i < 30; i++) {
-            expect(checkProxyRateLimit(ip).allowed).toBe(true);
+            await expect(checkProxyRateLimit(ip)).resolves.toMatchObject({ allowed: true });
         }
-        const blocked = checkProxyRateLimit(ip);
+        const blocked = await checkProxyRateLimit(ip);
         expect(blocked.allowed).toBe(false);
         expect(blocked.retryAfter).toBeGreaterThan(0);
     });
 
-    it('resets the counter after the window expires', () => {
+    it('resets the counter after the window expires', async () => {
         const ip = `proxy-reset-${Date.now()}-${Math.random()}`;
         for (let i = 0; i < 30; i++) {
-            checkProxyRateLimit(ip);
+            await checkProxyRateLimit(ip);
         }
-        expect(checkProxyRateLimit(ip).allowed).toBe(false);
+        await expect(checkProxyRateLimit(ip)).resolves.toMatchObject({ allowed: false });
         vi.advanceTimersByTime(60_001);
-        expect(checkProxyRateLimit(ip).allowed).toBe(true);
+        await expect(checkProxyRateLimit(ip)).resolves.toMatchObject({ allowed: true });
     });
 
-    it('isolates limits per IP', () => {
+    it('isolates limits per IP', async () => {
         const ipA = `proxy-a-${Date.now()}-${Math.random()}`;
         const ipB = `proxy-b-${Date.now()}-${Math.random()}`;
         for (let i = 0; i < 30; i++) {
-            checkProxyRateLimit(ipA);
+            await checkProxyRateLimit(ipA);
         }
-        expect(checkProxyRateLimit(ipA).allowed).toBe(false);
-        expect(checkProxyRateLimit(ipB).allowed).toBe(true);
+        await expect(checkProxyRateLimit(ipA)).resolves.toMatchObject({ allowed: false });
+        await expect(checkProxyRateLimit(ipB)).resolves.toMatchObject({ allowed: true });
     });
 });
 
@@ -55,19 +55,19 @@ describe('checkRateLimit', () => {
         vi.useRealTimers();
     });
 
-    it('allows requests up to maxRequests', () => {
+    it('allows requests up to maxRequests', async () => {
         const key = `user-${Date.now()}-${Math.random()}`;
-        expect(checkRateLimit(key, 3, 10_000)).toBe(true);
-        expect(checkRateLimit(key, 3, 10_000)).toBe(true);
-        expect(checkRateLimit(key, 3, 10_000)).toBe(true);
-        expect(checkRateLimit(key, 3, 10_000)).toBe(false);
+        await expect(checkRateLimit(key, 3, 10_000)).resolves.toBe(true);
+        await expect(checkRateLimit(key, 3, 10_000)).resolves.toBe(true);
+        await expect(checkRateLimit(key, 3, 10_000)).resolves.toBe(true);
+        await expect(checkRateLimit(key, 3, 10_000)).resolves.toBe(false);
     });
 
-    it('resets after windowMs', () => {
+    it('resets after windowMs', async () => {
         const key = `user-reset-${Date.now()}-${Math.random()}`;
-        expect(checkRateLimit(key, 1, 5_000)).toBe(true);
-        expect(checkRateLimit(key, 1, 5_000)).toBe(false);
+        await expect(checkRateLimit(key, 1, 5_000)).resolves.toBe(true);
+        await expect(checkRateLimit(key, 1, 5_000)).resolves.toBe(false);
         vi.advanceTimersByTime(5_001);
-        expect(checkRateLimit(key, 1, 5_000)).toBe(true);
+        await expect(checkRateLimit(key, 1, 5_000)).resolves.toBe(true);
     });
 });

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -3,7 +3,7 @@
  * Uses Upstash Redis / Vercel KV when configured; otherwise in-memory per instance.
  */
 
-import { Ratelimit } from '@upstash/ratelimit';
+import { Ratelimit, type Duration } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 
 interface Entry {
@@ -88,9 +88,9 @@ function getRedisClient(): Redis | null {
 const userLimiterCache = new Map<string, Ratelimit>();
 let proxyLimiter: Ratelimit | null = null;
 
-function windowLabel(windowMs: number): string {
+function windowLabel(windowMs: number): Duration {
     const seconds = Math.max(1, Math.ceil(windowMs / 1000));
-    return `${seconds} s`;
+    return `${seconds} s` as Duration;
 }
 
 function getUserLimiter(maxRequests: number, windowMs: number): Ratelimit {

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -30,21 +30,58 @@ const proxyStore = createStore();
 const PROXY_WINDOW_MS = 60_000;
 const PROXY_MAX_PER_WINDOW = 30;
 
+type RedisCredentials = { url: string; token: string };
+
 let redisClient: Redis | null | undefined;
+
+function resolveRedisCredentials(): RedisCredentials | null {
+    const upstashUrl = process.env.UPSTASH_REDIS_REST_URL?.trim();
+    const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN?.trim();
+    const kvUrl = process.env.KV_REST_API_URL?.trim();
+    const kvToken = process.env.KV_REST_API_TOKEN?.trim();
+
+    const upstashCount = Number(Boolean(upstashUrl)) + Number(Boolean(upstashToken));
+    const kvCount = Number(Boolean(kvUrl)) + Number(Boolean(kvToken));
+
+    if (upstashCount === 2) {
+        if (kvCount > 0) {
+            console.warn(
+                JSON.stringify({
+                    event: 'rate_limit.redis_env_ignored',
+                    message: 'KV_* vars ignored because UPSTASH_REDIS_* pair is complete',
+                })
+            );
+        }
+        return { url: upstashUrl!, token: upstashToken! };
+    }
+
+    if (kvCount === 2) {
+        return { url: kvUrl!, token: kvToken! };
+    }
+
+    if (upstashCount > 0 || kvCount > 0) {
+        console.error(
+            JSON.stringify({
+                event: 'rate_limit.redis_misconfigured',
+                message:
+                    'Set both UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN, or both KV_REST_API_URL and KV_REST_API_TOKEN (same provider family)',
+            })
+        );
+    }
+
+    return null;
+}
 
 function getRedisClient(): Redis | null {
     if (redisClient !== undefined) return redisClient;
 
-    const url = process.env.UPSTASH_REDIS_REST_URL ?? process.env.KV_REST_API_URL;
-    const token =
-        process.env.UPSTASH_REDIS_REST_TOKEN ?? process.env.KV_REST_API_TOKEN;
-
-    if (!url || !token) {
+    const credentials = resolveRedisCredentials();
+    if (!credentials) {
         redisClient = null;
         return null;
     }
 
-    redisClient = new Redis({ url, token });
+    redisClient = new Redis({ url: credentials.url, token: credentials.token });
     return redisClient;
 }
 
@@ -68,7 +105,7 @@ function getUserLimiter(maxRequests: number, windowMs: number): Ratelimit {
 
     const limiter = new Ratelimit({
         redis,
-        limiter: Ratelimit.slidingWindow(maxRequests, windowLabel(windowMs)),
+        limiter: Ratelimit.fixedWindow(maxRequests, windowLabel(windowMs)),
         prefix: 'asap:web:rl:user',
     });
     userLimiterCache.set(cacheKey, limiter);
@@ -84,7 +121,7 @@ function getProxyLimiter(): Ratelimit {
     if (!proxyLimiter) {
         proxyLimiter = new Ratelimit({
             redis,
-            limiter: Ratelimit.slidingWindow(
+            limiter: Ratelimit.fixedWindow(
                 PROXY_MAX_PER_WINDOW,
                 windowLabel(PROXY_WINDOW_MS)
             ),
@@ -163,6 +200,7 @@ export async function checkRateLimit(
         const result = await limiter.limit(key);
         return result.success;
     } catch (error) {
+        // Fail-soft to per-instance memory (see docs/migration.md#web-app-distributed-rate-limits-209).
         console.error(
             JSON.stringify({
                 event: 'rate_limit.redis_fallback',
@@ -196,6 +234,7 @@ export async function checkProxyRateLimit(
                 : undefined;
         return { allowed: false, retryAfter };
     } catch (error) {
+        // Fail-soft to per-instance memory (see docs/migration.md#web-app-distributed-rate-limits-209).
         console.error(
             JSON.stringify({
                 event: 'rate_limit.redis_fallback',

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -1,6 +1,10 @@
 /**
- * In-memory rate limiters. Per-instance (serverless) so not distributed across replicas.
+ * Rate limiters for dashboard actions and proxy endpoints.
+ * Uses Upstash Redis / Vercel KV when configured; otherwise in-memory per instance.
  */
+
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
 
 interface Entry {
     count: number;
@@ -21,12 +25,76 @@ function createStore() {
 }
 
 const userStore = createStore();
+const proxyStore = createStore();
 
-/**
- * Generic rate limit for user actions (dashboard, register, verify).
- * Returns true if allowed, false if rate limited.
- */
-export function checkRateLimit(
+const PROXY_WINDOW_MS = 60_000;
+const PROXY_MAX_PER_WINDOW = 30;
+
+let redisClient: Redis | null | undefined;
+
+function getRedisClient(): Redis | null {
+    if (redisClient !== undefined) return redisClient;
+
+    const url = process.env.UPSTASH_REDIS_REST_URL ?? process.env.KV_REST_API_URL;
+    const token =
+        process.env.UPSTASH_REDIS_REST_TOKEN ?? process.env.KV_REST_API_TOKEN;
+
+    if (!url || !token) {
+        redisClient = null;
+        return null;
+    }
+
+    redisClient = new Redis({ url, token });
+    return redisClient;
+}
+
+const userLimiterCache = new Map<string, Ratelimit>();
+let proxyLimiter: Ratelimit | null = null;
+
+function windowLabel(windowMs: number): string {
+    const seconds = Math.max(1, Math.ceil(windowMs / 1000));
+    return `${seconds} s`;
+}
+
+function getUserLimiter(maxRequests: number, windowMs: number): Ratelimit {
+    const redis = getRedisClient();
+    if (!redis) {
+        throw new Error('Redis client is not configured');
+    }
+
+    const cacheKey = `${maxRequests}:${windowMs}`;
+    const cached = userLimiterCache.get(cacheKey);
+    if (cached) return cached;
+
+    const limiter = new Ratelimit({
+        redis,
+        limiter: Ratelimit.slidingWindow(maxRequests, windowLabel(windowMs)),
+        prefix: 'asap:web:rl:user',
+    });
+    userLimiterCache.set(cacheKey, limiter);
+    return limiter;
+}
+
+function getProxyLimiter(): Ratelimit {
+    const redis = getRedisClient();
+    if (!redis) {
+        throw new Error('Redis client is not configured');
+    }
+
+    if (!proxyLimiter) {
+        proxyLimiter = new Ratelimit({
+            redis,
+            limiter: Ratelimit.slidingWindow(
+                PROXY_MAX_PER_WINDOW,
+                windowLabel(PROXY_WINDOW_MS)
+            ),
+            prefix: 'asap:web:rl:proxy',
+        });
+    }
+    return proxyLimiter;
+}
+
+function checkRateLimitInMemory(
     key: string,
     maxRequests: number,
     windowMs: number
@@ -49,16 +117,10 @@ export function checkRateLimit(
     return entry.count <= maxRequests;
 }
 
-const PROXY_WINDOW_MS = 60_000;
-const PROXY_MAX_PER_WINDOW = 30;
-const proxyStore = createStore();
-
-/**
- * IP-based rate limiter for proxy/check endpoint. Prevents abuse.
- */
-export function checkProxyRateLimit(
-    ip: string
-): { allowed: boolean; retryAfter?: number } {
+function checkProxyRateLimitInMemory(ip: string): {
+    allowed: boolean;
+    retryAfter?: number;
+} {
     proxyStore.prune();
     const now = Date.now();
     const entry = proxyStore.store.get(ip);
@@ -81,4 +143,66 @@ export function checkProxyRateLimit(
         };
     }
     return { allowed: true };
+}
+
+/**
+ * Generic rate limit for user actions (dashboard, register, verify).
+ * Returns true if allowed, false if rate limited.
+ */
+export async function checkRateLimit(
+    key: string,
+    maxRequests: number,
+    windowMs: number
+): Promise<boolean> {
+    if (!getRedisClient()) {
+        return checkRateLimitInMemory(key, maxRequests, windowMs);
+    }
+
+    try {
+        const limiter = getUserLimiter(maxRequests, windowMs);
+        const result = await limiter.limit(key);
+        return result.success;
+    } catch (error) {
+        console.error(
+            JSON.stringify({
+                event: 'rate_limit.redis_fallback',
+                scope: 'user',
+                error: error instanceof Error ? error.message : String(error),
+            })
+        );
+        return checkRateLimitInMemory(key, maxRequests, windowMs);
+    }
+}
+
+/**
+ * IP-based rate limiter for proxy/check endpoint. Prevents abuse.
+ */
+export async function checkProxyRateLimit(
+    ip: string
+): Promise<{ allowed: boolean; retryAfter?: number }> {
+    if (!getRedisClient()) {
+        return checkProxyRateLimitInMemory(ip);
+    }
+
+    try {
+        const limiter = getProxyLimiter();
+        const result = await limiter.limit(ip);
+        if (result.success) {
+            return { allowed: true };
+        }
+        const retryAfter =
+            result.reset > 0
+                ? Math.max(1, Math.ceil((result.reset - Date.now()) / 1000))
+                : undefined;
+        return { allowed: false, retryAfter };
+    } catch (error) {
+        console.error(
+            JSON.stringify({
+                event: 'rate_limit.redis_fallback',
+                scope: 'proxy',
+                error: error instanceof Error ? error.message : String(error),
+            })
+        );
+        return checkProxyRateLimitInMemory(ip);
+    }
 }

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -952,6 +952,30 @@ app = create_app(manifest, identity_jti_cache=jti_cache, ...)
 MCP Auth Bridge deployments can pass the same instance through
 ``MCPAuthConfig(jti_replay_cache=jti_cache)``.
 
+#### Web app distributed rate limits (#209)
+
+Self-hosted or multi-instance `apps/web` deployments can share dashboard and
+proxy rate-limit counters across replicas by configuring Upstash Redis REST
+credentials (or Vercel KV, which uses the same client):
+
+```bash
+# Upstash Redis
+UPSTASH_REDIS_REST_URL=https://....upstash.io
+UPSTASH_REDIS_REST_TOKEN=...
+
+# Vercel KV (when linked to the project)
+# KV_REST_API_URL=...
+# KV_REST_API_TOKEN=...
+```
+
+When these variables are unset, behavior is unchanged from v2.5.1: per-instance
+in-memory limits in `apps/web/src/lib/rate-limit.ts`. No code changes are
+required for local development.
+
+The Redis backend uses a **fixed window** aligned with the in-memory fallback.
+If Redis is unreachable, the app falls back to per-instance in-memory limits
+(weaker on multi-instance deploys); set both URL and token from the same
+provider family (Upstash **or** Vercel KV) to avoid misconfiguration.
 
 ---
 


### PR DESCRIPTION
## Summary

- Optional distributed rate limits in `apps/web` when `UPSTASH_REDIS_REST_*` or `KV_REST_API_*` env vars are set
- In-memory per-instance fallback unchanged when Redis/KV is not configured (local dev)
- `checkRateLimit` / `checkProxyRateLimit` are now **async**; call sites updated with `await`
- Adds `@upstash/ratelimit` + `@upstash/redis`; `apps/web/.env.example` updated
- Docs: `CHANGELOG.md`, `docs/migration.md`

## Merge order (issue #209 train)

**Merge 4 of 4** — last in train. Can merge in parallel with Redis PR (#3) after forbid PR if no conflicts; rebase on `main` before merge.

## Test plan

- [x] `cd apps/web && npm test` (179 passed)

Refs: #209