### PR TITLE
feat(v2.5.3): Adapter Lab II S0+S1 workflow connector

### DIFF
--- a/docs/integrations/workflow-connectors.md
+++ b/docs/integrations/workflow-connectors.md
@@ -1,0 +1,145 @@
+# Workflow connectors (OpenAPI → ASAP)
+
+Map **n8n / Activepieces-style workflow HTTP APIs** into ASAP **capabilities** by reusing the existing Python **OpenAPI adapter** (`asap.adapters.openapi`). Each OpenAPI `operationId` becomes a manifest **skill id**; invocations proxy to the upstream workflow host.
+
+**Stack:** OpenAPI 3.0/3.1 fragment or full spec → `create_from_openapi` → `create_app` (same pattern as the PetStore demo). **No dedicated workflow adapter package.**
+
+!!! note "Site navigation (Sprint S3)"
+
+    This guide ships with Adapter Lab II (v2.5.3). **MkDocs nav** and the **`docs/index.md` CTA** are finished in **Sprint S3** (docs-review checklist). Until then, discover the page via the repo path `docs/integrations/workflow-connectors.md` or the runnable example below.
+
+## Purpose
+
+Workflow platforms expose REST (or webhook) surfaces such as “list workflows”, “get one”, and “trigger a run”. ASAP agents need those actions as **discoverable skills** with JSON Schema inputs/outputs and a standard `task.request` path.
+
+This integration:
+
+1. Takes a curated OpenAPI document that describes the workflow HTTP API.
+2. Maps selected operations to ASAP skills (`operationId` → skill id).
+3. Serves a normal ASAP agent (`/.well-known/asap/manifest.json` + JSON-RPC `/asap`).
+4. Proxies each skill invocation to the upstream workflow base URL.
+
+**Contrast with Lab I framework adapters:** [Mastra](./mastra.md) and [OpenAI Agents](./openai-agents.md) wrap ASAP capabilities **as tools inside** a TypeScript agent runtime. Workflow connectors do the opposite direction: they turn an **external HTTP workflow API** into ASAP capabilities via OpenAPI, without a new adapter package.
+
+## Requirements
+
+| Runtime / tool | Version / note |
+|----------------|----------------|
+| Python | **3.13+** |
+| `asap-protocol[openapi]` | OpenAPI extra (`openapi-pydantic`, shared `httpx` client) |
+| Upstream | Mock `httpx` transport for CI / happy path, or a live workflow HTTP base URL |
+
+## Capability mapping
+
+The OpenAPI mapper uses each operation’s **`operationId`** as the ASAP **skill id** when present. The Lab II prototype fragment maps three workflow actions:
+
+| Workflow action | HTTP | OpenAPI `operationId` / skill id |
+|-----------------|------|----------------------------------|
+| List workflows | `GET /workflows` | `listWorkflows` |
+| Get one workflow | `GET /workflows/{workflowId}` | `getWorkflow` |
+| Trigger / execute a run | `POST /workflows/{workflowId}/trigger` | `triggerWorkflow` |
+
+Path and body parameters become the skill **input schema**; successful `200`/`201` `application/json` responses become the **output schema**. Details: [OpenAPI adapter](../adapters/openapi.md) (`map_openapi_to_capabilities`).
+
+### Missing `operationId`
+
+If an operation omits `operationId`, the mapper falls back to a synthetic name derived from method + path (for example `get_workflows_workflowId`). Prefer stable, explicit `operationId` values so remote agents and approval maps stay readable.
+
+## Discovery (well-known / manifest)
+
+After `create_from_openapi` + `create_app`, the ASAP host advertises skills on the standard discovery endpoint:
+
+```http
+GET /.well-known/asap/manifest.json HTTP/1.1
+Host: your-asap-host.example
+```
+
+A remote agent:
+
+1. Fetches the manifest and reads `skills` (ids such as `listWorkflows`, `getWorkflow`, `triggerWorkflow`).
+2. Invokes a skill with JSON-RPC `asap.send` / `task.request` and the chosen `skill_id`, same as any other ASAP capability.
+3. The OpenAPI-backed handler proxies the call to the upstream workflow API.
+
+The prototype uses manifest id `urn:asap:agent:openapi-workflow-connector-example`. See [Transport — discovery](../transport.md) for the well-known contract.
+
+## Quick start (runnable example)
+
+From the repository root:
+
+```bash
+uv sync --extra openapi
+uv run python examples/workflow_asap_connector/main.py
+```
+
+Runs Compliance Harness v2 (expects score **1.0**), then invokes `listWorkflows` against a **mocked** upstream (no SaaS credentials). Spike notes and skill table: [`examples/workflow_asap_connector/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/workflow_asap_connector).
+
+Optional live upstream (HTTPS recommended; keep secrets in env only):
+
+```bash
+uv run python examples/workflow_asap_connector/main.py --live-base-url https://your-host.example/api/v1
+```
+
+Equivalent: `ASAP_WORKFLOW_BASE_URL`. Placeholders live in `.env.example` — never commit real tokens.
+
+Minimal wiring — keep the shared `httpx` client open for the full proxy lifetime
+(building the bundle **and** serving/invoking the app). The full runnable path is
+`examples/workflow_asap_connector/main.py`.
+
+```python
+import asyncio
+from pathlib import Path
+
+import httpx
+
+from asap.adapters.openapi import create_from_openapi
+from asap.transport.server import create_app
+
+
+async def build_workflow_asap_app(fragment: Path) -> None:
+    """Keep the shared httpx client open for the full proxy lifetime."""
+    async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as http:
+        bundle = await create_from_openapi(
+            spec_path=fragment,
+            http_client=http,
+            default_capabilities="all",
+            manifest_id="urn:asap:agent:openapi-workflow-connector-example",
+            asap_endpoint="https://your-asap-host.example/asap",
+            # upstream_base_url="https://your-workflow-host.example/api/v1",
+        )
+        app = create_app(bundle.manifest, bundle.registry)
+        # Serve / invoke `app` here while `http` remains open.
+        _ = app  # placeholder in docs; see examples/workflow_asap_connector/main.py
+
+
+# asyncio.run(build_workflow_asap_app(Path("openapi-fragment.json")))
+```
+
+## Failure modes
+
+| Condition | What happens | Guidance |
+|-----------|--------------|----------|
+| Upstream **4xx** | OpenAPI handler raises **`FatalError`** (`asap:adapters/openapi/upstream_client_error`) | Fix caller args / auth; do not retry blindly |
+| Upstream **5xx** or connection failure | **`RecoverableError`** (`upstream_server_error` / `upstream_connection`) | Retry with backoff; check workflow host health |
+| Missing / empty **`operationId`** | Skill id becomes method+path fallback | Add stable `operationId`s before publishing the manifest |
+| Unknown skill id on invoke | **`UnknownOpenAPICapabilityError`** (fatal) | Align client `skill_id` with advertised manifest skills |
+| **Mock vs live** | Default example uses `httpx.MockTransport`; `--live-base-url` / `ASAP_WORKFLOW_BASE_URL` hits a real host | Keep CI on mock; use live only for manual exploration |
+| Upstream auth | Adapter does **not** auto-apply OpenAPI `securitySchemes` | Pass **`resolve_headers`** (Bearer / API key from env) — see [OpenAPI adapter](../adapters/openapi.md) |
+
+Identity / approval for production: configure `FreshSessionConfig` and optional `approval_strength` as in the OpenAPI guide. The workflow example intentionally skips WebAuthn wiring for the offline happy path.
+
+## Troubleshooting
+
+| Symptom | What to verify |
+|---------|----------------|
+| Empty or unexpected skill list | Fragment paths included; `default_capabilities` not filtering them out |
+| Relative `servers[0].url` with local spec | Pass **`upstream_base_url`** (absolute origin) |
+| Live call returns 401/403 | `resolve_headers` / env token; HTTPS endpoint |
+| Compliance score ≠ 1.0 | Same agent shape as PetStore: `create_app` + skills + `task.request` handler |
+
+## Related
+
+- [OpenAPI adapter](../adapters/openapi.md) — mapper, upstream proxy, approval / headers
+- [Mastra integration](./mastra.md) — Lab I: ASAP capabilities → framework tools
+- [OpenAI Agents SDK integration](./openai-agents.md) — Lab I: ASAP capabilities → Agents SDK tools
+- Runnable example: [`examples/workflow_asap_connector/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/workflow_asap_connector)
+- Error codes: [Error handling](../error-handling.md)

--- a/engineering/tasks/v2.5.3/demand-sheet.md
+++ b/engineering/tasks/v2.5.3/demand-sheet.md
@@ -1,0 +1,101 @@
+# Demand sheet — Adapter Lab II (v2.5.3) S0
+
+**Date**: 2026-07-13  
+**Author context**: S0 Candidate lock kickoff (maintainer LGTM decisions applied)  
+**Repo**: [adriannoes/asap-protocol](https://github.com/adriannoes/asap-protocol)  
+**PRD**: [prd-v2.5.3-adapter-lab-ii.md](../../../product/prd/prd-v2.5.3-adapter-lab-ii.md)  
+**Sprint**: [sprint-S0-candidate-lock.md](./sprint-S0-candidate-lock.md)  
+**Branch**: `feat/v2.5.3-s0-s1-workflow` → `release/2.5.3` (exists on origin; not recreated)
+
+---
+
+## Method
+
+1. Listed repo labels (`gh label list --repo adriannoes/asap-protocol --limit 100`).
+2. Confirmed **no `adapter-request` label** (and no equivalent adapter-demand label).
+3. Searched issues with keywords (`gh issue list --state all --limit 50 --search …`) for each Lab II candidate and a combined OR query.
+4. Treated partner / Discord / email demand as **in-repo maintainer-logged only** (no private CRM dump in this sheet).
+
+**Combined search (2026-07-13):**
+
+```text
+n8n OR activepieces OR haystack OR letta OR semantic-kernel OR 'semantic kernel'
+OR nemo OR nvidia-nat OR zapier OR make.com
+```
+
+Result: **0 issues**.
+
+Per-keyword searches for the same terms also returned **0** matching issues. A search for `adapter-request` / `adapter request` only hit Lab I promotion-gate reviews (#158 Mastra, #159 OpenAI Agents) — **not** demand for Lab II candidates; those are excluded from the counts table below.
+
+---
+
+## Counts (GitHub issues)
+
+| Candidate | Open | Closed | Notes |
+|-----------|------|--------|-------|
+| Semantic Kernel / Microsoft Agent Framework | 0 | 0 | No keyword hits; no `adapter-request` label |
+| Haystack | 0 | 0 | Honest zero |
+| Letta | 0 | 0 | Honest zero |
+| n8n / Activepieces | 0 | 0 | Honest zero (primary still locked by PRD D1 default) |
+| Zapier / Make | 0 | 0 | Honest zero |
+| NeMo Agent Toolkit / nvidia-nat | 0 | 0 | Honest zero; D7 go is maintainer default, not issue volume |
+
+**Labels snapshot:** `bug`, `documentation`, `enhancement`, `good first issue`, `frontend`, `question`, `backend`, `dependencies`, `security`, `refactor`, `test`, `resolved`, `deferred` — **no `adapter-request`**.
+
+---
+
+## Discord / email / partner asks (since Lab I, 2026-05-21)
+
+No maintainer-logged partner asks recorded in-repo for Semantic Kernel / MAF, Haystack, Letta, n8n/Activepieces, Zapier/Make, or NeMo Agent Toolkit since Lab I. **Treat as zero unless override.**
+
+---
+
+## Primary decision (D1)
+
+**Confirmed (DEFAULT, no swap):** n8n / Activepieces-style **workflow → ASAP capabilities**.
+
+- Meets LAB2-002 (workflow/API → capabilities).
+- Issue volume does not favor another candidate; PRD default stands.
+- **Reuse path:** prefer existing **OpenAPI adapter** over a new package or thin custom wire format.
+- PRD changelog: **not updated** (primary did not swap).
+
+---
+
+## S1b go/no-go (D2) — Semantic Kernel
+
+**Decision: no-go** → skip [sprint-S1b-semantic-kernel.md](./sprint-S1b-semantic-kernel.md).
+
+**Rationale:** Gate requires ≥1 credible Azure/.NET partner ask, ≥3 `adapter-request` issues for SK/MAF, or maintainer override. There is no `adapter-request` label; keyword search found **0** SK/MAF issues; no in-repo partner asks. Maintainer LGTM: **no-go**.
+
+**Not this release:** Semantic Kernel / Microsoft Agent Framework will not receive an Adapter Lab II spike or public interop guide in v2.5.3. Revisit only if credible Azure/.NET demand appears (issues, partner ask, or explicit maintainer override) in a later lab cycle.
+
+---
+
+## S1c go/no-go (D7) — NeMo Agent Toolkit
+
+**Decision: go (DEFAULT)** → schedule [sprint-S1c-nemo-agent-toolkit.md](./sprint-S1c-nemo-agent-toolkit.md).
+
+- Research map present: [research-nemo-agent-toolkit.md](./research-nemo-agent-toolkit.md).
+- Issue volume is zero; go is **maintainer/PRD default**, not demand-driven.
+- **Path intent:** prefer Path A (thin demo) when capacity allows; otherwise guide-only. **Refine Path A vs guide-only in S1c §2c.2** at spike start. Path C (third-party NAT plugin) remains deferred post–v2.5.3.
+
+---
+
+## P1 / P2 parking
+
+**Haystack / Letta (P1):** recipe-only for v2.5.3 unless promoted under PRD §6 (credible demand + capacity). Do not schedule dedicated sprints.
+
+**Zapier / Make (P2):** research-only. No prototype or first-class guide in this release.
+
+---
+
+## Acceptance checklist (S0)
+
+| Criterion | Status |
+|-----------|--------|
+| Counts + method documented | Done |
+| Primary (D1) locked, no swap | Done |
+| S1b (D2) no-go + “not this release” note | Done |
+| S1c (D7) go + research map + Path intent | Done |
+| P1/P2 parking recorded | Done |
+| `release/2.5.3` on origin | Confirmed (`261e53b…`) |

--- a/engineering/tasks/v2.5.3/sprint-S0-candidate-lock.md
+++ b/engineering/tasks/v2.5.3/sprint-S0-candidate-lock.md
@@ -1,8 +1,9 @@
 # Sprint S0: Candidate lock & demand check (v2.5.3)
 
 **PRD**: [prd-v2.5.3-adapter-lab-ii.md](../../../product/prd/prd-v2.5.3-adapter-lab-ii.md) §2 D1–D7, §6  
-**Branch**: `feat/v2.5.3-s0-candidate-lock` → **`release/2.5.3`**  
-**Depends on**: v2.5.2 shipped
+**Branch**: `feat/v2.5.3-s0-s1-workflow` → **`release/2.5.3`** (exists on origin; not recreated)  
+**Depends on**: v2.5.2 shipped  
+**Status**: Done (2026-07-13)
 
 **Trigger:** Maintainer kickoff of Adapter Lab II.  
 **Enables:** S1 primary prototype; optional S1b; planned S1c.  
@@ -18,46 +19,53 @@ Confirm the **default primary** (workflow connector) or document an explicit swa
 
 ## Tasks
 
-- [ ] **1.1 Create integration branch**
-  - [ ] `git checkout main && git pull`
-  - [ ] `git checkout -b release/2.5.3 && git push -u origin release/2.5.3`
-  - [ ] Point this folder’s status to ACTIVE in [tasks-v2.5.3-roadmap.md](./tasks-v2.5.3-roadmap.md) when started
+- [x] **1.1 Create integration branch**
+  - [x] `release/2.5.3` already on origin — do **not** recreate
+  - [x] Working branch for this combined initiative: `feat/v2.5.3-s0-s1-workflow` → `release/2.5.3`
+  - [x] Point this folder’s status to ACTIVE in [tasks-v2.5.3-roadmap.md](./tasks-v2.5.3-roadmap.md) when started
 
-- [ ] **1.2 Demand sheet**
-  - [ ] Count open/closed issues with `adapter-request` (or equivalent) for: Semantic Kernel / Microsoft Agent Framework, Haystack, Letta, n8n/Activepieces, Zapier/Make, **NeMo Agent Toolkit / nvidia-nat**
-  - [ ] Note Discord / email / partner asks since Lab I (2026-05-21)
-  - [ ] Write results into `engineering/tasks/v2.5.3/demand-sheet.md` (can stay local if sensitive)
+- [x] **1.2 Demand sheet**
+  - [x] Count open/closed issues with `adapter-request` (or equivalent) for: Semantic Kernel / Microsoft Agent Framework, Haystack, Letta, n8n/Activepieces, Zapier/Make, **NeMo Agent Toolkit / nvidia-nat**
+  - [x] Note Discord / email / partner asks since Lab I (2026-05-21)
+  - [x] Write results into `engineering/tasks/v2.5.3/demand-sheet.md` (can stay local if sensitive)
 
-- [ ] **1.3 Lock primary (D1)**
-  - [ ] Default: **n8n / Activepieces-style workflow → ASAP capabilities**
-  - [ ] If demand strongly favors another candidate that still meets LAB2-002 (workflow/API → capabilities), document the swap in the demand sheet and update PRD changelog
-  - [ ] Confirm reuse path: OpenAPI adapter vs thin custom example (prefer OpenAPI)
+- [x] **1.3 Lock primary (D1)**
+  - [x] Default: **n8n / Activepieces-style workflow → ASAP capabilities**
+  - [x] If demand strongly favors another candidate that still meets LAB2-002 (workflow/API → capabilities), document the swap in the demand sheet and update PRD changelog
+  - [x] Confirm reuse path: OpenAPI adapter vs thin custom example (prefer OpenAPI)
 
-- [ ] **1.4 D2 gate (Semantic Kernel)**
-  - [ ] **Go** if ≥1 credible Azure/.NET partner ask **or** ≥3 `adapter-request` for SK/MAF **or** maintainer override
-  - [ ] **No-go** otherwise → skip [sprint-S1b-semantic-kernel.md](./sprint-S1b-semantic-kernel.md); leave a one-paragraph “not this release” note in demand sheet
+- [x] **1.4 D2 gate (Semantic Kernel)**
+  - [x] **Go** if ≥1 credible Azure/.NET partner ask **or** ≥3 `adapter-request` for SK/MAF **or** maintainer override
+  - [x] **No-go** otherwise → skip [sprint-S1b-semantic-kernel.md](./sprint-S1b-semantic-kernel.md); leave a one-paragraph “not this release” note in demand sheet
 
-- [ ] **1.5 D7 gate (NeMo Agent Toolkit)**
-  - [ ] **Default: go** → schedule [sprint-S1c-nemo-agent-toolkit.md](./sprint-S1c-nemo-agent-toolkit.md)
-  - [ ] Confirm research map present: [research-nemo-agent-toolkit.md](./research-nemo-agent-toolkit.md)
-  - [ ] **No-go** only with explicit maintainer note (capacity); do not silently drop
-  - [ ] Record intended Path A vs guide-only based on capacity (can refine in S1c §2c.2)
+- [x] **1.5 D7 gate (NeMo Agent Toolkit)**
+  - [x] **Default: go** → schedule [sprint-S1c-nemo-agent-toolkit.md](./sprint-S1c-nemo-agent-toolkit.md)
+  - [x] Confirm research map present: [research-nemo-agent-toolkit.md](./research-nemo-agent-toolkit.md)
+  - [x] **No-go** only with explicit maintainer note (capacity); do not silently drop
+  - [x] Record intended Path A vs guide-only based on capacity (can refine in S1c §2c.2)
 
-- [ ] **1.6 P1/P2 parking**
-  - [ ] Haystack / Letta: recipe-only unless promoted under PRD §6
-  - [ ] Zapier / Make: research-only
+- [x] **1.6 P1/P2 parking**
+  - [x] Haystack / Letta: recipe-only unless promoted under PRD §6
+  - [x] Zapier / Make: research-only
 
 ---
 
 ## Acceptance criteria
 
-- [ ] `release/2.5.3` exists on origin
-- [ ] Demand sheet exists with counts + primary decision + S1b go/no-go + **S1c go/no-go (default go)**
-- [ ] Roadmap sprint table updated (S0 → In progress / Done; S1b/S1c status set)
+- [x] `release/2.5.3` exists on origin
+- [x] Demand sheet exists with counts + primary decision + S1b go/no-go + **S1c go/no-go (default go)**
+- [x] Roadmap sprint table updated (S0 → In progress / Done; S1b/S1c status set)
+
+## Reviews
+
+| Date | Tier | Verdict | Report |
+|------|------|---------|--------|
+| 2026-07-13 | T2 | Approved with caveats | [review-v2.5.3-S0-S1-workflow-20260713-r2.md](../../../code-review/private/review-v2.5.3-S0-S1-workflow-20260713-r2.md) |
+| 2026-07-13 | T2 | Rejected | [review-v2.5.3-S0-S1-workflow-20260713.md](../../../code-review/private/review-v2.5.3-S0-S1-workflow-20260713.md) |
 
 ## Relevant files
 
-- `engineering/tasks/v2.5.3/demand-sheet.md` (new)
+- `engineering/tasks/v2.5.3/demand-sheet.md` (created 2026-07-13)
 - `engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md`
 - `engineering/tasks/v2.5.3/research-nemo-agent-toolkit.md`
-- `product/prd/prd-v2.5.3-adapter-lab-ii.md` (changelog only if primary swaps)
+- `product/prd/prd-v2.5.3-adapter-lab-ii.md` (changelog only if primary swaps — **not edited**)

--- a/engineering/tasks/v2.5.3/sprint-S0-candidate-lock.md
+++ b/engineering/tasks/v2.5.3/sprint-S0-candidate-lock.md
@@ -60,8 +60,8 @@ Confirm the **default primary** (workflow connector) or document an explicit swa
 
 | Date | Tier | Verdict | Report |
 |------|------|---------|--------|
-| 2026-07-13 | T2 | Approved with caveats | [review-v2.5.3-S0-S1-workflow-20260713-r2.md](../../../code-review/private/review-v2.5.3-S0-S1-workflow-20260713-r2.md) |
-| 2026-07-13 | T2 | Rejected | [review-v2.5.3-S0-S1-workflow-20260713.md](../../../code-review/private/review-v2.5.3-S0-S1-workflow-20260713.md) |
+| 2026-07-13 | T2 | Approved with caveats | [review-v2.5.3-S0-S1-workflow-20260713-r2.md](../../code-review/private/review-v2.5.3-S0-S1-workflow-20260713-r2.md) |
+| 2026-07-13 | T2 | Rejected | [review-v2.5.3-S0-S1-workflow-20260713.md](../../code-review/private/review-v2.5.3-S0-S1-workflow-20260713.md) |
 
 ## Relevant files
 

--- a/engineering/tasks/v2.5.3/sprint-S1-workflow-prototype.md
+++ b/engineering/tasks/v2.5.3/sprint-S1-workflow-prototype.md
@@ -1,8 +1,9 @@
 # Sprint S1: Workflow → ASAP prototype (v2.5.3)
 
 **PRD**: LAB2-001, LAB2-002  
-**Branch**: `feat/v2.5.3-s1-workflow` → **`release/2.5.3`**  
-**Depends on**: [S0](./sprint-S0-candidate-lock.md) primary = workflow (default)
+**Branch**: `feat/v2.5.3-s0-s1-workflow` → **`release/2.5.3`**  
+**Depends on**: [S0](./sprint-S0-candidate-lock.md) primary = workflow (default)  
+**Status**: Done (2026-07-13)
 
 **Trigger:** S0 locks workflow connector as primary.  
 **Enables:** S2 security guide; S3 site links.  
@@ -27,46 +28,59 @@ Ship **one** runnable prototype that turns workflow/automation (or a stand-in wo
 
 ## Tasks
 
-- [ ] **2.1 Spike shape (≤0.5 day)**
-  - [ ] Choose concrete target: n8n webhook/API **or** Activepieces-style HTTP workflow **or** local mock workflow OpenAPI that mimics either
-  - [ ] Map 2–3 workflow actions → capability IDs / skills
-  - [ ] Write spike notes in PR description or `examples/.../DESIGN.md`
+- [x] **2.1 Spike shape (≤0.5 day)**
+  - [x] Choose concrete target: n8n webhook/API **or** Activepieces-style HTTP workflow **or** local mock workflow OpenAPI that mimics either
+  - [x] Map 2–3 workflow actions → capability IDs / skills
+  - [x] Write spike notes in PR description or `examples/.../DESIGN.md`
 
-- [ ] **2.2 Runnable example**
-  - [ ] Create `examples/workflow_asap_connector/` (name may be `n8n_asap_connector` if n8n-specific)
-  - [ ] Include `README.md` with install, run, and “what a remote agent sees”
-  - [ ] Include minimal OpenAPI (or reuse petstore pattern) if that is the bridge
-  - [ ] Happy path: list capabilities / invoke one skill without real SaaS credentials (mock server OK)
+- [x] **2.2 Runnable example**
+  - [x] Create `examples/workflow_asap_connector/` (name may be `n8n_asap_connector` if n8n-specific)
+  - [x] Include `README.md` with install, run, and “what a remote agent sees”
+  - [x] Include minimal OpenAPI (or reuse petstore pattern) if that is the bridge
+  - [x] Happy path: list capabilities / invoke one skill without real SaaS credentials (mock server OK)
 
-- [ ] **2.3 Integration guide**
-  - [ ] Add `docs/integrations/workflow-connectors.md` (or `n8n.md`)
-  - [ ] Cover: capability mapping, discovery (well-known / manifest), failure modes
-  - [ ] Link OpenAPI adapter docs and Lab I adapters for contrast (framework vs workflow)
-  - [ ] Leave MkDocs nav + `docs/index.md` wiring to **S3** ([docs-review-checklist.md](./docs-review-checklist.md))
+- [x] **2.3 Integration guide**
+  - [x] Add `docs/integrations/workflow-connectors.md` (or `n8n.md`)
+  - [x] Cover: capability mapping, discovery (well-known / manifest), failure modes
+  - [x] Link OpenAPI adapter docs and Lab I adapters for contrast (framework vs workflow)
+  - [x] Leave MkDocs nav + `docs/index.md` wiring to **S3** ([docs-review-checklist.md](./docs-review-checklist.md))
 
-- [ ] **2.4 Tests / smoke**
-  - [ ] Unit or smoke tests for any new Python helpers (≥ existing project standards)
-  - [ ] Document manual smoke: command + expected output in example README
-  - [ ] `uv run ruff check` / targeted pytest green on the PR
+- [x] **2.4 Tests / smoke**
+  - [x] Unit or smoke tests for any new Python helpers (≥ existing project standards)
+  - [x] Document manual smoke: command + expected output in example README
+  - [x] `uv run ruff check` / targeted pytest green on the PR
 
-- [ ] **2.5 Compliance where shape permits**
-  - [ ] If the example agent shape fits, note which Compliance Harness checks apply (SHOULD, not ship-blocker)
+- [x] **2.5 Compliance where shape permits**
+  - [x] If the example agent shape fits, note which Compliance Harness checks apply (SHOULD, not ship-blocker)
 
 ---
 
 ## Acceptance criteria
 
-- [ ] LAB2-002 met: ≥1 enterprise/workflow example converting workflow/API → ASAP capabilities
-- [ ] LAB2-001 met: reuses existing interfaces; no protocol fork
-- [ ] Guide linked from docs index (final index + MkDocs nav wiring finishes in **S3**)
-- [ ] Transport growth lint clean for the PR
+- [x] LAB2-002 met: ≥1 enterprise/workflow example converting workflow/API → ASAP capabilities
+- [x] LAB2-001 met: reuses existing interfaces; no protocol fork
+- [x] Guide published under `docs/integrations/` (MkDocs nav + `docs/index.md` wiring deferred to **S3**)
+- [x] Transport growth lint clean for the PR
+
+## Reviews
+
+| Date | Tier | Verdict | Report |
+|------|------|---------|--------|
+| 2026-07-13 | T2 | Approved with caveats | [review-v2.5.3-S0-S1-workflow-20260713-r2.md](../../../code-review/private/review-v2.5.3-S0-S1-workflow-20260713-r2.md) |
+| 2026-07-13 | T2 | Rejected | [review-v2.5.3-S0-S1-workflow-20260713.md](../../../code-review/private/review-v2.5.3-S0-S1-workflow-20260713.md) |
 
 ## Relevant files
 
 ### New
 
-- `examples/workflow_asap_connector/` (or renamed)
-- `docs/integrations/workflow-connectors.md`
+- `examples/workflow_asap_connector/DESIGN.md`
+- `examples/workflow_asap_connector/README.md`
+- `examples/workflow_asap_connector/openapi-fragment.json`
+- `examples/workflow_asap_connector/main.py`
+- `examples/workflow_asap_connector/mock_upstream.py`
+- `examples/workflow_asap_connector/.env.example`
+- `tests/examples/test_workflow_asap_connector.py`
+- `docs/integrations/workflow-connectors.md` (Wave 3 / task 2.3)
 
 ### Reference
 

--- a/engineering/tasks/v2.5.3/sprint-S1-workflow-prototype.md
+++ b/engineering/tasks/v2.5.3/sprint-S1-workflow-prototype.md
@@ -66,8 +66,8 @@ Ship **one** runnable prototype that turns workflow/automation (or a stand-in wo
 
 | Date | Tier | Verdict | Report |
 |------|------|---------|--------|
-| 2026-07-13 | T2 | Approved with caveats | [review-v2.5.3-S0-S1-workflow-20260713-r2.md](../../../code-review/private/review-v2.5.3-S0-S1-workflow-20260713-r2.md) |
-| 2026-07-13 | T2 | Rejected | [review-v2.5.3-S0-S1-workflow-20260713.md](../../../code-review/private/review-v2.5.3-S0-S1-workflow-20260713.md) |
+| 2026-07-13 | T2 | Approved with caveats | [review-v2.5.3-S0-S1-workflow-20260713-r2.md](../../code-review/private/review-v2.5.3-S0-S1-workflow-20260713-r2.md) |
+| 2026-07-13 | T2 | Rejected | [review-v2.5.3-S0-S1-workflow-20260713.md](../../code-review/private/review-v2.5.3-S0-S1-workflow-20260713.md) |
 
 ## Relevant files
 

--- a/engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md
+++ b/engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md
@@ -1,6 +1,6 @@
 # Tasks: v2.5.3 Adapter Lab II — Sprint Index
 
-**Status: PLANNED (READY FOR KICKOFF)** — create `release/2.5.3` at S0 start.
+**Status: ACTIVE (kickoff started 2026-07-13)** — `release/2.5.3` on origin; working branch `feat/v2.5.3-s0-s1-workflow`. Demand sheet: [demand-sheet.md](./demand-sheet.md).
 
 Based on [PRD v2.5.3 Adapter Lab II](../../../product/prd/prd-v2.5.3-adapter-lab-ii.md). Each sprint merges into **`release/2.5.3`** (see [BRANCHING.md](./BRANCHING.md)); merge to `main` only after S4.
 
@@ -10,16 +10,16 @@ Based on [PRD v2.5.3 Adapter Lab II](../../../product/prd/prd-v2.5.3-adapter-lab
 - [x] v2.5.0 MCP Auth Bridge in tree (`asap.adapters.mcp.protect_server`)
 - [x] v2.3.0 OpenAPI adapter + v2.3.1 Mastra / OpenAI Agents adapters shipped
 - [x] `scripts/lint_no_transport_growth.py` CI-enforced (Lab I D4)
-- [ ] Maintainer opens kickoff (this folder + `release/2.5.3` branch)
+- [x] Maintainer opens kickoff (this folder + `release/2.5.3` branch)
 
 ## Sprint plan
 
 | Sprint | Focus | PRD | Priority | Status |
 |--------|-------|-----|----------|--------|
-| **S0** | [Candidate lock & demand check](./sprint-S0-candidate-lock.md) | D1–D7, §6 gates | P0 | Planned |
-| **S1** | [Workflow prototype (primary)](./sprint-S1-workflow-prototype.md) | LAB2-001, LAB2-002 | P0 | Planned |
-| **S1b** | [Conditional SK / .NET spike](./sprint-S1b-semantic-kernel.md) | D2 | P0 if gate | Optional |
-| **S1c** | [NeMo Agent Toolkit spike](./sprint-S1c-nemo-agent-toolkit.md) | D7 | P0 planned | Optional (non-blocking) |
+| **S0** | [Candidate lock & demand check](./sprint-S0-candidate-lock.md) | D1–D7, §6 gates | P0 | Done |
+| **S1** | [Workflow prototype (primary)](./sprint-S1-workflow-prototype.md) | LAB2-001, LAB2-002 | P0 | Done |
+| **S1b** | [Conditional SK / .NET spike](./sprint-S1b-semantic-kernel.md) | D2 | P0 if gate | Skipped (D2 no-go) |
+| **S1c** | [NeMo Agent Toolkit spike](./sprint-S1c-nemo-agent-toolkit.md) | D7 | P0 planned | Planned (D7 go) |
 | **S2** | [Security guide & MCP patterns](./sprint-S2-security-docs.md) | LAB2-003, LAB2-006 | P0 | Planned |
 | **S3** | [Docs review, site routing & learnings](./sprint-S3-docs-review.md) | LAB2-004, LAB2-005 + docs surface | P0 | Planned |
 | **S4** | [Release v2.5.3](./sprint-S4-release.md) | DoD, metrics | P0 | Planned |
@@ -44,26 +44,26 @@ S1b / S1c never block S1/S2/S3/S4. If D2 fails, skip S1b. S1c defaults to **go**
 
 ## Parent tasks (high-level)
 
-- [ ] **1.0 Candidate lock (S0)**
+- [x] **1.0 Candidate lock (S0)**
   - **Trigger:** Maintainer kickoff after v2.5.2.
   - **Enables:** S1 primary path; optional S1b; planned S1c.
   - **Depends on:** PRD D1–D7; GitHub `adapter-request` label / issues.
   - **Acceptance criteria:**
-    - [ ] Demand sheet filled (SK / Haystack / Letta / n8n / NeMo Agent Toolkit counts)
-    - [ ] Primary confirmed: workflow connector **or** explicit swap documented
-    - [ ] S1b go/no-go recorded
-    - [ ] S1c go/no-go recorded (**default go** per D7)
-    - [ ] `release/2.5.3` branch exists
+    - [x] Demand sheet filled (SK / Haystack / Letta / n8n / NeMo Agent Toolkit counts)
+    - [x] Primary confirmed: workflow connector **or** explicit swap documented
+    - [x] S1b go/no-go recorded
+    - [x] S1c go/no-go recorded (**default go** per D7)
+    - [x] `release/2.5.3` branch exists
 
-- [ ] **2.0 Workflow prototype (S1)**
+- [x] **2.0 Workflow prototype (S1)**
   - **Trigger:** S0 primary = workflow (default).
   - **Enables:** S2 security guide against a real example; S3 site links.
   - **Depends on:** Task 1.0; OpenAPI adapter and/or capability grant APIs in tree.
   - **Acceptance criteria:**
-    - [ ] Runnable example under `examples/` (or `apps/`) maps workflow/API actions → ASAP capabilities
-    - [ ] Guide under `docs/integrations/` (or `docs/adapters/`)
-    - [ ] No protocol fork; transport lint clean
-    - [ ] LAB2-001 / LAB2-002 satisfied for the primary
+    - [x] Runnable example under `examples/` (or `apps/`) maps workflow/API actions → ASAP capabilities
+    - [x] Guide under `docs/integrations/` (or `docs/adapters/`)
+    - [x] No protocol fork; transport lint clean
+    - [x] LAB2-001 / LAB2-002 satisfied for the primary
 
 - [ ] **2b.0 Conditional Semantic Kernel spike (S1b)**
   - **Trigger:** S0 D2 gate pass.
@@ -168,3 +168,5 @@ S1b / S1c never block S1/S2/S3/S4. If D2 fails, skip S1b. S1c defaults to **go**
 | 2026-07-11 | Initial sprint index from revised PRD (D1–D6); S0–S4 + optional S1b |
 | 2026-07-11 | **D7 / S1c**: NeMo Agent Toolkit spike + [research-nemo-agent-toolkit.md](./research-nemo-agent-toolkit.md) |
 | 2026-07-12 | **S3 docs review**: [sprint-S3-docs-review.md](./sprint-S3-docs-review.md) + [docs-review-checklist.md](./docs-review-checklist.md); replaces S3 site-learnings-only |
+| 2026-07-13 | **S0 Done**: [demand-sheet.md](./demand-sheet.md); D1 workflow primary (no swap); D2 S1b skipped; D7 S1c planned; kickoff ACTIVE |
+| 2026-07-13 | **S1 Done**: workflow example + [workflow-connectors.md](../../../docs/integrations/workflow-connectors.md); MkDocs nav deferred to S3 |

--- a/examples/workflow_asap_connector/.env.example
+++ b/examples/workflow_asap_connector/.env.example
@@ -1,0 +1,6 @@
+# Optional: live workflow HTTP API base URL (no secrets required for happy path)
+# ASAP_WORKFLOW_BASE_URL=https://your-host.example/api/v1
+
+# Illustrative only — this demo does not read ASAP_WORKFLOW_BEARER_TOKEN.
+# Intended for a future resolve_headers / S2 security guide when wiring live auth.
+# ASAP_WORKFLOW_BEARER_TOKEN=

--- a/examples/workflow_asap_connector/DESIGN.md
+++ b/examples/workflow_asap_connector/DESIGN.md
@@ -1,0 +1,39 @@
+# Workflow → ASAP connector spike notes (S1 / LAB2-001)
+
+## Target
+
+**Local mock workflow OpenAPI** that mimics an n8n / Activepieces-style HTTP
+workflow webhook/API — **not** a live n8n Cloud or Activepieces SaaS instance.
+
+Happy path uses `httpx.MockTransport` against `servers[0].url`
+(`http://workflow.mock/api/v1`). Optional `--live-base-url` /
+`ASAP_WORKFLOW_BASE_URL` can point at a real host later; credentials stay out of
+the example (placeholders only in `.env.example`).
+
+## Skill mapping (OpenAPI `operationId` → ASAP skill id)
+
+| Workflow action | HTTP | `operationId` / skill id |
+|-----------------|------|--------------------------|
+| List workflows | `GET /workflows` | `listWorkflows` |
+| Get one workflow | `GET /workflows/{workflowId}` | `getWorkflow` |
+| Trigger / execute a run | `POST /workflows/{workflowId}/trigger` | `triggerWorkflow` |
+
+The OpenAPI adapter maps each `operationId` to a manifest skill id unchanged
+(see `map_openapi_to_capabilities` in `asap.adapters.openapi`).
+
+## Why OpenAPI reuse satisfies LAB2-001
+
+- **No new adapter package** under `src/asap/adapters/`.
+- Compose existing `create_from_openapi` + `create_app` + Compliance Harness v2,
+  same pattern as `examples/openapi_petstore/`.
+- No public methods added to `transport/server.py` or `transport/client.py`.
+- Workflow HTTP APIs that already expose (or can expose) OpenAPI become ASAP
+  capabilities without a protocol fork.
+
+## What a remote agent sees
+
+After `create_from_openapi`, the ASAP manifest advertises skills
+`listWorkflows`, `getWorkflow`, and `triggerWorkflow`. A remote agent discovers
+them via `/.well-known/asap/manifest.json` and invokes them with
+`task.request` / `skill_id` like any other ASAP capability; the handler proxies
+to the upstream workflow HTTP API.

--- a/examples/workflow_asap_connector/README.md
+++ b/examples/workflow_asap_connector/README.md
@@ -55,6 +55,10 @@ uv run python examples/workflow_asap_connector/main.py --live-base-url https://y
 
 Equivalent: `ASAP_WORKFLOW_BASE_URL=https://your-host.example/api/v1`.
 
+`.env.example` may show `ASAP_WORKFLOW_BEARER_TOKEN` as an **illustrative** placeholder only —
+this demo does **not** read it. Live auth via `resolve_headers` is deferred to the S2
+security guide; setting the env var alone will not avoid upstream 401s.
+
 ## What a remote agent sees
 
 | Skill id | Upstream |

--- a/examples/workflow_asap_connector/README.md
+++ b/examples/workflow_asap_connector/README.md
@@ -1,0 +1,79 @@
+# Workflow → ASAP connector (OpenAPI reuse)
+
+Runnable demo: builds an ASAP app from a **workflow-shaped** OpenAPI fragment
+(`openapi-fragment.json`) that mimics an n8n/Activepieces-style HTTP workflow
+API, runs **Compliance Harness v2** (expects score **1.0**), and invokes
+`listWorkflows` in-process. By default the upstream API is **mocked** (offline,
+no SaaS credentials).
+
+Spike notes: [DESIGN.md](./DESIGN.md).
+
+## Prerequisites
+
+- Python 3.13+
+- `uv`
+
+Install the OpenAPI extra:
+
+```bash
+uv sync --extra openapi
+```
+
+Installs optional OpenAPI adapter dependencies used by this example.
+
+## Run (default: bundled fragment + mock upstream)
+
+From the repository root:
+
+```bash
+uv run python examples/workflow_asap_connector/main.py
+```
+
+Runs Compliance Harness v2 then invokes `listWorkflows` against the mock upstream.
+
+### Manual smoke — expected output
+
+You should see lines similar to:
+
+```text
+skills: ['getWorkflow', 'listWorkflows', 'triggerWorkflow']
+Compliance Harness v2: ...
+listWorkflows: 1 workflow(s) via 'workflows'
+```
+
+Exact harness summary text may vary; score must be **1.0** (non-zero exit if not).
+
+## Optional live upstream
+
+Point the fragment’s operations at a real workflow HTTP base URL (requires
+connectivity; auth is your responsibility — use env placeholders, never commit
+secrets):
+
+```bash
+uv run python examples/workflow_asap_connector/main.py --live-base-url https://your-host.example/api/v1
+```
+
+Equivalent: `ASAP_WORKFLOW_BASE_URL=https://your-host.example/api/v1`.
+
+## What a remote agent sees
+
+| Skill id | Upstream |
+|----------|----------|
+| `listWorkflows` | `GET /workflows` |
+| `getWorkflow` | `GET /workflows/{workflowId}` |
+| `triggerWorkflow` | `POST /workflows/{workflowId}/trigger` |
+
+Manifest id: `urn:asap:agent:openapi-workflow-connector-example`. Discovery:
+`/.well-known/asap/manifest.json` on the ASAP host.
+
+## Compliance (2.5)
+
+This example agent shape matches the PetStore OpenAPI demo: `create_app` +
+manifest skills + `task.request` handler. **Compliance Harness v2** is invoked
+in `main.py` and must score **1.0** on the happy path.
+
+## Notes
+
+- Reuses `asap.adapters.openapi` only (LAB2-001); no dedicated workflow adapter package.
+- Identity / approval: this example does not configure `FreshSessionConfig`; see
+  `docs/adapters/openapi.md` and `src/asap/adapters/openapi/approval.py` for production wiring.

--- a/examples/workflow_asap_connector/main.py
+++ b/examples/workflow_asap_connector/main.py
@@ -1,0 +1,158 @@
+"""Workflow OpenAPI → ASAP adapter demo (Compliance Harness v2 + listWorkflows).
+
+Maps a local mock n8n/Activepieces-style workflow HTTP API into ASAP skills via
+``asap.adapters.openapi.create_from_openapi`` (LAB2-001 reuse; no new adapter package).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from asap.adapters.openapi import OpenAPIAdapterBundle, create_from_openapi
+from asap.economics.audit import InMemoryAuditStore
+from asap.models.enums import TaskStatus
+from asap.models.envelope import Envelope
+from asap.models.payloads import TaskRequest, TaskResponse
+from asap.testing.compliance import run_compliance_harness_v2
+from asap.transport.client import ASAPClient
+from asap.transport.rate_limit import create_test_limiter
+from asap.transport.server import create_app
+
+from mock_upstream import mock_workflow_upstream
+
+_FRAGMENT = Path(__file__).resolve().parent / "openapi-fragment.json"
+_MANIFEST_ID = "urn:asap:agent:openapi-workflow-connector-example"
+
+
+def _workflows_preview(result: dict[str, Any] | None) -> str:
+    """Return a short human-readable summary of a listWorkflows result."""
+    if result is None:
+        return "(no result)"
+    for key in ("workflows", "value", "data", "body", "items", "_json"):
+        value = result.get(key)
+        if isinstance(value, list):
+            return f"{len(value)} workflow(s) via {key!r}"
+    for _key, value in result.items():
+        if isinstance(value, list):
+            return f"{len(value)} workflow(s) in list field"
+    return str(result)[:200]
+
+
+async def _build_bundle(
+    http: httpx.AsyncClient,
+    *,
+    upstream_base_url: str | None = None,
+) -> OpenAPIAdapterBundle:
+    """Build the OpenAPI→ASAP bundle with a shared open httpx client."""
+    if upstream_base_url is not None:
+        return await create_from_openapi(
+            spec_path=_FRAGMENT,
+            http_client=http,
+            upstream_base_url=upstream_base_url.rstrip("/"),
+            default_capabilities="all",
+            manifest_id=_MANIFEST_ID,
+            asap_endpoint="http://127.0.0.1:8000/asap",
+        )
+    return await create_from_openapi(
+        spec_path=_FRAGMENT,
+        http_client=http,
+        default_capabilities="all",
+        manifest_id=_MANIFEST_ID,
+        asap_endpoint="http://127.0.0.1:8000/asap",
+    )
+
+
+async def _run(*, live_base_url: str | None) -> None:
+    """Build the OpenAPI→ASAP bundle and run harness + listWorkflows."""
+    timeout = 60.0
+    if live_base_url:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as http:
+            bundle = await _build_bundle(http, upstream_base_url=live_base_url)
+            await _harness_and_call(bundle)
+        return
+
+    transport = httpx.MockTransport(mock_workflow_upstream)
+    async with httpx.AsyncClient(transport=transport, timeout=timeout) as http:
+        bundle = await _build_bundle(http)
+        await _harness_and_call(bundle)
+
+
+async def _harness_and_call(bundle: OpenAPIAdapterBundle) -> None:
+    """Run Compliance Harness v2 then invoke ``listWorkflows`` in-process."""
+    skill_ids = sorted(skill.id for skill in bundle.manifest.capabilities.skills)
+    print(f"skills: {skill_ids}")
+
+    audit = InMemoryAuditStore()
+    app = create_app(
+        bundle.manifest,
+        bundle.registry,
+        audit_store=audit,
+        rate_limit="999999/minute",
+    )
+    app.state.limiter = create_test_limiter()
+
+    report = await run_compliance_harness_v2(app)
+    print(report.summary)
+    if report.score < 1.0:
+        failed = [check for check in report.checks if not check.passed]
+        detail = [(check.name, check.message) for check in failed]
+        msg = f"Compliance Harness v2 score {report.score}: {detail}"
+        raise SystemExit(msg)
+
+    await _invoke_list_workflows(bundle, app)
+
+
+async def _invoke_list_workflows(
+    bundle: OpenAPIAdapterBundle,
+    app: FastAPI,
+) -> None:
+    """Send an in-process ``listWorkflows`` task.request and print a preview."""
+    inproc = ASGITransport(app=app)
+    envelope = Envelope(
+        asap_version="0.1",
+        sender="urn:asap:agent:workflow-example-client",
+        recipient=bundle.manifest.id,
+        payload_type="task.request",
+        payload=TaskRequest(
+            conversation_id="conv-workflow-example",
+            skill_id="listWorkflows",
+            input={},
+        ).model_dump(),
+    )
+    async with ASAPClient(
+        "http://testserver",
+        transport=inproc,
+        require_https=False,
+    ) as client:
+        response = await client.send(envelope)
+
+    if response.payload_type != "task.response":
+        raise SystemExit(f"unexpected payload_type: {response.payload_type!r}")
+    task_response = TaskResponse.model_validate(response.payload_dict)
+    if task_response.status != TaskStatus.COMPLETED:
+        raise SystemExit(f"task not completed: {task_response.status}")
+    print("listWorkflows:", _workflows_preview(task_response.result))
+
+
+def main() -> None:
+    """CLI entrypoint for the workflow → ASAP connector demo."""
+    parser = argparse.ArgumentParser(description="Workflow OpenAPI → ASAP demo")
+    parser.add_argument(
+        "--live-base-url",
+        default=os.environ.get("ASAP_WORKFLOW_BASE_URL"),
+        help="Optional live workflow API base URL (overrides mock upstream)",
+    )
+    args = parser.parse_args()
+    asyncio.run(_run(live_base_url=args.live_base_url or None))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/workflow_asap_connector/main.py
+++ b/examples/workflow_asap_connector/main.py
@@ -52,22 +52,16 @@ async def _build_bundle(
     upstream_base_url: str | None = None,
 ) -> OpenAPIAdapterBundle:
     """Build the OpenAPI→ASAP bundle with a shared open httpx client."""
+    kwargs: dict[str, Any] = {
+        "spec_path": _FRAGMENT,
+        "http_client": http,
+        "default_capabilities": "all",
+        "manifest_id": _MANIFEST_ID,
+        "asap_endpoint": "http://127.0.0.1:8000/asap",
+    }
     if upstream_base_url is not None:
-        return await create_from_openapi(
-            spec_path=_FRAGMENT,
-            http_client=http,
-            upstream_base_url=upstream_base_url.rstrip("/"),
-            default_capabilities="all",
-            manifest_id=_MANIFEST_ID,
-            asap_endpoint="http://127.0.0.1:8000/asap",
-        )
-    return await create_from_openapi(
-        spec_path=_FRAGMENT,
-        http_client=http,
-        default_capabilities="all",
-        manifest_id=_MANIFEST_ID,
-        asap_endpoint="http://127.0.0.1:8000/asap",
-    )
+        kwargs["upstream_base_url"] = upstream_base_url.rstrip("/")
+    return await create_from_openapi(**kwargs)
 
 
 async def _run(*, live_base_url: str | None) -> None:

--- a/examples/workflow_asap_connector/mock_upstream.py
+++ b/examples/workflow_asap_connector/mock_upstream.py
@@ -1,0 +1,38 @@
+"""Mock n8n/Activepieces-style workflow HTTP API for the offline demo and tests."""
+
+from __future__ import annotations
+
+import httpx
+
+
+def mock_workflow_upstream(request: httpx.Request) -> httpx.Response:
+    """Respond to workflow mock paths without contacting a live SaaS.
+
+    Example::
+
+        transport = httpx.MockTransport(mock_workflow_upstream)
+        async with httpx.AsyncClient(transport=transport) as http:
+            ...
+    """
+    path = request.url.path
+    if request.method == "GET" and path.rstrip("/").endswith("/workflows"):
+        return httpx.Response(
+            200,
+            json={
+                "workflows": [
+                    {"id": "wf-demo", "name": "Demo Workflow", "active": True},
+                ],
+            },
+        )
+    if request.method == "GET" and "/workflows/" in path:
+        workflow_id = path.rstrip("/").rsplit("/", 1)[-1]
+        return httpx.Response(
+            200,
+            json={"id": workflow_id, "name": "Demo Workflow", "active": True},
+        )
+    if request.method == "POST" and path.rstrip("/").endswith("/trigger"):
+        return httpx.Response(
+            200,
+            json={"executionId": "exec-1", "status": "running"},
+        )
+    return httpx.Response(404, text=f"unexpected request: {request.method} {request.url}")

--- a/examples/workflow_asap_connector/mock_upstream.py
+++ b/examples/workflow_asap_connector/mock_upstream.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import re
+
 import httpx
+
+# Exact one-segment workflow id (excludes /workflows/{id}/trigger).
+_GET_WORKFLOW_BY_ID = re.compile(r"^/api/v1/workflows/[^/]+$")
 
 
 def mock_workflow_upstream(request: httpx.Request) -> httpx.Response:
@@ -14,8 +19,8 @@ def mock_workflow_upstream(request: httpx.Request) -> httpx.Response:
         async with httpx.AsyncClient(transport=transport) as http:
             ...
     """
-    path = request.url.path
-    if request.method == "GET" and path.rstrip("/").endswith("/workflows"):
+    path = request.url.path.rstrip("/") or "/"
+    if request.method == "GET" and path.endswith("/workflows"):
         return httpx.Response(
             200,
             json={
@@ -24,13 +29,13 @@ def mock_workflow_upstream(request: httpx.Request) -> httpx.Response:
                 ],
             },
         )
-    if request.method == "GET" and "/workflows/" in path:
-        workflow_id = path.rstrip("/").rsplit("/", 1)[-1]
+    if request.method == "GET" and _GET_WORKFLOW_BY_ID.match(path):
+        workflow_id = path.rsplit("/", 1)[-1]
         return httpx.Response(
             200,
             json={"id": workflow_id, "name": "Demo Workflow", "active": True},
         )
-    if request.method == "POST" and path.rstrip("/").endswith("/trigger"):
+    if request.method == "POST" and path.endswith("/trigger"):
         return httpx.Response(
             200,
             json={"executionId": "exec-1", "status": "running"},

--- a/examples/workflow_asap_connector/openapi-fragment.json
+++ b/examples/workflow_asap_connector/openapi-fragment.json
@@ -1,0 +1,138 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Workflow connector fragment (n8n/Activepieces-style mock)",
+    "version": "1.0.0",
+    "description": "Minimal OpenAPI for LAB2 workflow → ASAP capability demo. Not a live SaaS."
+  },
+  "servers": [
+    {
+      "url": "http://workflow.mock/api/v1"
+    }
+  ],
+  "paths": {
+    "/workflows": {
+      "get": {
+        "operationId": "listWorkflows",
+        "summary": "List workflows",
+        "responses": {
+          "200": {
+            "description": "Workflow list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "workflows": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/WorkflowSummary"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{workflowId}": {
+      "get": {
+        "operationId": "getWorkflow",
+        "summary": "Get one workflow by id",
+        "parameters": [
+          {
+            "name": "workflowId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Workflow detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowSummary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{workflowId}/trigger": {
+      "post": {
+        "operationId": "triggerWorkflow",
+        "summary": "Trigger / execute a workflow run",
+        "parameters": [
+          {
+            "name": "workflowId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Optional webhook-style input payload"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Execution accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowExecution"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "WorkflowSummary": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "active": { "type": "boolean" }
+        }
+      },
+      "WorkflowExecution": {
+        "type": "object",
+        "required": ["executionId", "status"],
+        "properties": {
+          "executionId": { "type": "string" },
+          "status": {
+            "type": "string",
+            "enum": ["running", "queued", "completed", "failed"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/examples/test_workflow_asap_connector.py
+++ b/tests/examples/test_workflow_asap_connector.py
@@ -12,8 +12,9 @@ from typing import Any
 import httpx
 import pytest
 from _pytest.capture import CaptureFixture
+from fastapi import FastAPI
 
-from asap.adapters.openapi import create_from_openapi
+from asap.adapters.openapi import OpenAPIAdapterBundle, create_from_openapi
 from asap.economics.audit import InMemoryAuditStore
 from asap.models.enums import TaskStatus
 from asap.models.envelope import Envelope
@@ -69,19 +70,63 @@ def _workflows_from_task_result(result: dict[str, Any] | None) -> list[Any]:
     )
 
 
-def _list_workflows_envelope(recipient: str) -> Envelope:
-    """Build a task.request envelope for the listWorkflows skill."""
+def _skill_envelope(
+    recipient: str,
+    *,
+    skill_id: str,
+    skill_input: dict[str, Any],
+    conversation_id: str,
+) -> Envelope:
+    """Build a task.request envelope for a workflow skill."""
     return Envelope(
         asap_version="0.1",
         sender="urn:asap:agent:workflow-test-client",
         recipient=recipient,
         payload_type="task.request",
         payload=TaskRequest(
-            conversation_id="conv-workflow-e2e",
-            skill_id="listWorkflows",
-            input={},
+            conversation_id=conversation_id,
+            skill_id=skill_id,
+            input=skill_input,
         ).model_dump(),
     )
+
+
+async def _build_e2e_app(
+    http: httpx.AsyncClient,
+) -> tuple[OpenAPIAdapterBundle, FastAPI]:
+    """Create OpenAPI bundle + ASAP app with test rate limiter."""
+    built = await create_from_openapi(
+        spec_path=_FRAGMENT,
+        http_client=http,
+        default_capabilities="all",
+        manifest_id="urn:asap:agent:workflow-connector-e2e",
+        asap_endpoint="http://test/asap",
+    )
+    app = create_app(
+        built.manifest,
+        built.registry,
+        audit_store=InMemoryAuditStore(),
+        rate_limit="999999/minute",
+    )
+    app.state.limiter = create_test_limiter()
+    return built, app
+
+
+async def _invoke_skill(
+    app: FastAPI,
+    envelope: Envelope,
+) -> TaskResponse:
+    """Send one skill envelope through ASAPClient over ASGITransport."""
+    async with ASAPClient(
+        "http://testserver",
+        transport=httpx.ASGITransport(app=app),
+        require_https=False,
+    ) as client:
+        response = await client.send(envelope)
+    assert response.payload_type == "task.response"
+    task_response = TaskResponse.model_validate(response.payload_dict)
+    assert task_response.status == TaskStatus.COMPLETED
+    return task_response
 
 
 class TestWorkflowAsapConnectorExample(NoRateLimitTestBase):
@@ -89,7 +134,7 @@ class TestWorkflowAsapConnectorExample(NoRateLimitTestBase):
 
     @pytest.mark.asyncio
     async def test_fragment_maps_expected_skill_ids(self) -> None:
-        """create_from_openapi exposes listWorkflows, getWorkflow, triggerWorkflow."""
+        """create_from_openapi exposes exactly the three fragment operationIds."""
         assert _FRAGMENT.is_file(), f"missing fixture: {_FRAGMENT}"
         mock_fn = _mock_workflow_upstream()
         transport = httpx.MockTransport(mock_fn)
@@ -103,9 +148,9 @@ class TestWorkflowAsapConnectorExample(NoRateLimitTestBase):
             )
 
         skill_ids = {skill.id for skill in bundle.manifest.capabilities.skills}
-        assert skill_ids >= _EXPECTED_SKILL_IDS
+        assert skill_ids == _EXPECTED_SKILL_IDS
         mapped_ids = {cap.skill.id for cap in bundle.capabilities}
-        assert mapped_ids >= _EXPECTED_SKILL_IDS
+        assert mapped_ids == _EXPECTED_SKILL_IDS
 
     @pytest.mark.asyncio
     async def test_list_workflows_skill_via_asap_app(self) -> None:
@@ -114,34 +159,68 @@ class TestWorkflowAsapConnectorExample(NoRateLimitTestBase):
         mock_fn = _mock_workflow_upstream()
         transport = httpx.MockTransport(mock_fn)
         async with httpx.AsyncClient(transport=transport, timeout=30.0) as http:
-            built = await create_from_openapi(
-                spec_path=_FRAGMENT,
-                http_client=http,
-                default_capabilities="all",
-                manifest_id="urn:asap:agent:workflow-connector-e2e",
-                asap_endpoint="http://test/asap",
+            built, app = await _build_e2e_app(http)
+            task_response = await _invoke_skill(
+                app,
+                _skill_envelope(
+                    built.manifest.id,
+                    skill_id="listWorkflows",
+                    skill_input={},
+                    conversation_id="conv-workflow-list",
+                ),
             )
-            app = create_app(
-                built.manifest,
-                built.registry,
-                audit_store=InMemoryAuditStore(),
-                rate_limit="999999/minute",
-            )
-            app.state.limiter = create_test_limiter()
-            async with ASAPClient(
-                "http://testserver",
-                transport=httpx.ASGITransport(app=app),
-                require_https=False,
-            ) as client:
-                response = await client.send(_list_workflows_envelope(built.manifest.id))
 
-        assert response.payload_type == "task.response"
-        task_response = TaskResponse.model_validate(response.payload_dict)
-        assert task_response.status == TaskStatus.COMPLETED
         workflows = _workflows_from_task_result(task_response.result)
         assert len(workflows) >= 1
         assert isinstance(workflows[0], dict)
         assert workflows[0].get("id") == "wf-demo"
+
+    @pytest.mark.asyncio
+    async def test_get_workflow_skill_via_asap_app(self) -> None:
+        """Invoke getWorkflow with workflowId path param against the mock."""
+        assert _FRAGMENT.is_file(), f"missing fixture: {_FRAGMENT}"
+        mock_fn = _mock_workflow_upstream()
+        transport = httpx.MockTransport(mock_fn)
+        async with httpx.AsyncClient(transport=transport, timeout=30.0) as http:
+            built, app = await _build_e2e_app(http)
+            task_response = await _invoke_skill(
+                app,
+                _skill_envelope(
+                    built.manifest.id,
+                    skill_id="getWorkflow",
+                    skill_input={"workflowId": "wf-demo"},
+                    conversation_id="conv-workflow-get",
+                ),
+            )
+
+        assert task_response.result is not None
+        assert task_response.result.get("id") == "wf-demo"
+        assert task_response.result.get("name") == "Demo Workflow"
+
+    @pytest.mark.asyncio
+    async def test_trigger_workflow_skill_via_asap_app(self) -> None:
+        """Invoke triggerWorkflow (POST + path param + optional body) against mock."""
+        assert _FRAGMENT.is_file(), f"missing fixture: {_FRAGMENT}"
+        mock_fn = _mock_workflow_upstream()
+        transport = httpx.MockTransport(mock_fn)
+        async with httpx.AsyncClient(transport=transport, timeout=30.0) as http:
+            built, app = await _build_e2e_app(http)
+            task_response = await _invoke_skill(
+                app,
+                _skill_envelope(
+                    built.manifest.id,
+                    skill_id="triggerWorkflow",
+                    skill_input={
+                        "workflowId": "wf-demo",
+                        "payload": {"source": "asap-e2e"},
+                    },
+                    conversation_id="conv-workflow-trigger",
+                ),
+            )
+
+        assert task_response.result is not None
+        assert task_response.result.get("executionId") == "exec-1"
+        assert task_response.result.get("status") == "running"
 
     def test_example_main_is_importable(self) -> None:
         """examples/workflow_asap_connector/main.py must import without side effects."""
@@ -155,7 +234,7 @@ class TestWorkflowAsapConnectorExample(NoRateLimitTestBase):
         self,
         capsys: CaptureFixture[str],
     ) -> None:
-        """Await main._run(live_base_url=None) and confirm skills + completion."""
+        """Await main._run(live_base_url=None) and confirm skills + harness."""
         assert _MAIN_PATH.is_file(), f"missing example entrypoint: {_MAIN_PATH}"
         module = _load_example_module("workflow_asap_connector_main_run", _MAIN_PATH)
         await module._run(live_base_url=None)
@@ -163,3 +242,4 @@ class TestWorkflowAsapConnectorExample(NoRateLimitTestBase):
         assert "listWorkflows" in captured.out
         assert "skills:" in captured.out
         assert "listWorkflows:" in captured.out
+        assert "12/12" in captured.out or "100%" in captured.out

--- a/tests/examples/test_workflow_asap_connector.py
+++ b/tests/examples/test_workflow_asap_connector.py
@@ -1,0 +1,165 @@
+"""Smoke/E2E: workflow OpenAPI fragment → ASAP skills (mocked upstream)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import httpx
+import pytest
+from _pytest.capture import CaptureFixture
+
+from asap.adapters.openapi import create_from_openapi
+from asap.economics.audit import InMemoryAuditStore
+from asap.models.enums import TaskStatus
+from asap.models.envelope import Envelope
+from asap.models.payloads import TaskRequest, TaskResponse
+from asap.transport.client import ASAPClient
+from asap.transport.rate_limit import create_test_limiter
+from asap.transport.server import create_app
+
+from tests.transport.conftest import NoRateLimitTestBase
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLE_DIR = _REPO_ROOT / "examples" / "workflow_asap_connector"
+_FRAGMENT = _EXAMPLE_DIR / "openapi-fragment.json"
+_MAIN_PATH = _EXAMPLE_DIR / "main.py"
+_MOCK_PATH = _EXAMPLE_DIR / "mock_upstream.py"
+
+_EXPECTED_SKILL_IDS = frozenset({"listWorkflows", "getWorkflow", "triggerWorkflow"})
+
+
+def _load_example_module(module_name: str, path: Path) -> ModuleType:
+    """Import an example module from its file path (mcp_auth_bridge pattern)."""
+    example_dir = str(path.parent)
+    if example_dir not in sys.path:
+        sys.path.insert(0, example_dir)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _mock_workflow_upstream() -> Callable[[httpx.Request], httpx.Response]:
+    """Load the shared example mock helper."""
+    module = _load_example_module("workflow_asap_connector_mock", _MOCK_PATH)
+    mock_fn = getattr(module, "mock_workflow_upstream", None)
+    assert callable(mock_fn), "mock_upstream.py must export mock_workflow_upstream"
+    return mock_fn
+
+
+def _workflows_from_task_result(result: dict[str, Any] | None) -> list[Any]:
+    """Extract a workflow list from an OpenAPI-proxied TaskResponse.result."""
+    assert result is not None, "TaskResponse.result must be present for listWorkflows"
+    for key in ("value", "data", "body", "items", "workflows", "response", "json", "_json"):
+        payload = result.get(key)
+        if isinstance(payload, list):
+            return payload
+    for _nested_key, val in result.items():
+        if isinstance(val, list):
+            return val
+    raise AssertionError(
+        f"Expected a list of workflows in TaskResponse.result, got keys {sorted(result.keys())}",
+    )
+
+
+def _list_workflows_envelope(recipient: str) -> Envelope:
+    """Build a task.request envelope for the listWorkflows skill."""
+    return Envelope(
+        asap_version="0.1",
+        sender="urn:asap:agent:workflow-test-client",
+        recipient=recipient,
+        payload_type="task.request",
+        payload=TaskRequest(
+            conversation_id="conv-workflow-e2e",
+            skill_id="listWorkflows",
+            input={},
+        ).model_dump(),
+    )
+
+
+class TestWorkflowAsapConnectorExample(NoRateLimitTestBase):
+    """E2E coverage for examples/workflow_asap_connector OpenAPI → ASAP bridge."""
+
+    @pytest.mark.asyncio
+    async def test_fragment_maps_expected_skill_ids(self) -> None:
+        """create_from_openapi exposes listWorkflows, getWorkflow, triggerWorkflow."""
+        assert _FRAGMENT.is_file(), f"missing fixture: {_FRAGMENT}"
+        mock_fn = _mock_workflow_upstream()
+        transport = httpx.MockTransport(mock_fn)
+        async with httpx.AsyncClient(transport=transport, timeout=30.0) as http:
+            bundle = await create_from_openapi(
+                spec_path=_FRAGMENT,
+                http_client=http,
+                default_capabilities="all",
+                manifest_id="urn:asap:agent:workflow-connector-test",
+                asap_endpoint="http://test/asap",
+            )
+
+        skill_ids = {skill.id for skill in bundle.manifest.capabilities.skills}
+        assert skill_ids >= _EXPECTED_SKILL_IDS
+        mapped_ids = {cap.skill.id for cap in bundle.capabilities}
+        assert mapped_ids >= _EXPECTED_SKILL_IDS
+
+    @pytest.mark.asyncio
+    async def test_list_workflows_skill_via_asap_app(self) -> None:
+        """Invoke listWorkflows through create_app with mocked upstream."""
+        assert _FRAGMENT.is_file(), f"missing fixture: {_FRAGMENT}"
+        mock_fn = _mock_workflow_upstream()
+        transport = httpx.MockTransport(mock_fn)
+        async with httpx.AsyncClient(transport=transport, timeout=30.0) as http:
+            built = await create_from_openapi(
+                spec_path=_FRAGMENT,
+                http_client=http,
+                default_capabilities="all",
+                manifest_id="urn:asap:agent:workflow-connector-e2e",
+                asap_endpoint="http://test/asap",
+            )
+            app = create_app(
+                built.manifest,
+                built.registry,
+                audit_store=InMemoryAuditStore(),
+                rate_limit="999999/minute",
+            )
+            app.state.limiter = create_test_limiter()
+            async with ASAPClient(
+                "http://testserver",
+                transport=httpx.ASGITransport(app=app),
+                require_https=False,
+            ) as client:
+                response = await client.send(_list_workflows_envelope(built.manifest.id))
+
+        assert response.payload_type == "task.response"
+        task_response = TaskResponse.model_validate(response.payload_dict)
+        assert task_response.status == TaskStatus.COMPLETED
+        workflows = _workflows_from_task_result(task_response.result)
+        assert len(workflows) >= 1
+        assert isinstance(workflows[0], dict)
+        assert workflows[0].get("id") == "wf-demo"
+
+    def test_example_main_is_importable(self) -> None:
+        """examples/workflow_asap_connector/main.py must import without side effects."""
+        assert _MAIN_PATH.is_file(), f"missing example entrypoint: {_MAIN_PATH}"
+        module = _load_example_module("workflow_asap_connector_main", _MAIN_PATH)
+        assert callable(getattr(module, "main", None))
+        assert callable(getattr(module, "_run", None))
+
+    @pytest.mark.asyncio
+    async def test_example_run_prints_skills(
+        self,
+        capsys: CaptureFixture[str],
+    ) -> None:
+        """Await main._run(live_base_url=None) and confirm skills + completion."""
+        assert _MAIN_PATH.is_file(), f"missing example entrypoint: {_MAIN_PATH}"
+        module = _load_example_module("workflow_asap_connector_main_run", _MAIN_PATH)
+        await module._run(live_base_url=None)
+        captured = capsys.readouterr()
+        assert "listWorkflows" in captured.out
+        assert "skills:" in captured.out
+        assert "listWorkflows:" in captured.out


### PR DESCRIPTION
## Summary
- **S0:** Lock Lab II candidates — workflow primary (D1), Semantic Kernel no-go (D2), NeMo Agent Toolkit go (D7); demand sheet with honest zero GitHub signal.
- **S1:** Runnable `examples/workflow_asap_connector/` maps mock n8n/Activepieces-style OpenAPI → ASAP skills via existing `create_from_openapi` (LAB2-001/002).
- **Docs:** `docs/integrations/workflow-connectors.md` (MkDocs nav + `docs/index.md` deferred to S3).

## Test plan
- [ ] `uv run python examples/workflow_asap_connector/main.py` — skills + Compliance Harness 12/12 + `listWorkflows`
- [ ] `uv run pytest tests/examples/test_workflow_asap_connector.py -q`
- [ ] `uv run ruff check . && uv run ruff format --check . && uv run mypy src/ scripts/ tests/`
- [ ] `uv run pytest --tb=short --cov=asap --cov-report=xml --cov-fail-under=85`
- [ ] `uv run python scripts/lint_no_transport_growth.py`

## Review
T2 elevated review: **Approved with caveats** (guide wiring blocker fixed in r2; bearer/`resolve_headers` deferred to S2 security docs).