### PR TITLE
feat(v2.5.3): Adapter Lab II S1b+S1c MAF guide and NeMo Agent Toolkit spike

### DIFF
--- a/docs/integrations/microsoft-agent-framework.md
+++ b/docs/integrations/microsoft-agent-framework.md
@@ -1,0 +1,122 @@
+# Microsoft Agent Framework ↔ ASAP (interop)
+
+How [Microsoft Agent Framework (MAF)](https://learn.microsoft.com/en-us/agent-framework/overview/overview) tool surfaces (in-process **`AIFunction`** / **`AITool`**, MCP) sit beside ASAP **Host/Agent JWT** and **capability grants**. Naming and packages below are accurate as of **2026-07-13** (MAF **1.0** GA).
+
+!!! warning "Research / experimental — not maintained"
+
+    This page is **interop guidance** from Adapter Lab II (v2.5.3). It is **not** a first-class ASAP adapter like [Mastra](./mastra.md) or [OpenAI Agents](./openai-agents.md): there is **no** ASAP .NET SDK, **no** NuGet package, and **no** in-repo C# sample under `examples/`. Treat recommendations as research notes — they may change without a deprecation cycle.
+
+!!! note "Site navigation (Sprint S3)"
+
+    MkDocs nav and the **`docs/index.md`** CTA are finished in **Sprint S3**. Until then, discover this page via `docs/integrations/microsoft-agent-framework.md`.
+
+## Purpose
+
+Use this when a .NET (or Python MAF) agent already speaks MAF tools / MCP and you need ASAP identity and authorization to remain the source of truth for remote capability execution.
+
+This guide:
+
+1. Maps ASAP **Agent JWT** + **capability grants** to how MAF registers tools (`AIFunctionFactory` / MCP `AITool`s).
+2. States honest limits: conceptual interop only — you wire HTTP/JSON-RPC yourself (or via Python ASAP + MCP bridge).
+3. Points Semantic Kernel readers at Microsoft’s migration path (SK is legacy here).
+
+**Contrast with Lab I adapters:** Mastra and OpenAI Agents ship TypeScript packages that turn ASAP capabilities into framework tools. MAF has **no** equivalent ASAP package in this release.
+
+## Requirements (your stack — not ASAP packages)
+
+| Piece | Note |
+|-------|------|
+| MAF .NET | NuGet **`Microsoft.Agents.AI`** (and MEAI **`AIFunction`** / **`AITool`** types) |
+| MAF Python | PyPI **`agent-framework`** |
+| ASAP side | Python **`asap-protocol`** (identity, grants, transport) and/or TypeScript **`@asap-protocol/client`** — **not** a .NET SDK |
+| Docs | [aka.ms/AgentFramework/Docs](https://aka.ms/AgentFramework/Docs) · [microsoft/agent-framework](https://github.com/microsoft/agent-framework) |
+
+## Capability mapping
+
+ASAP authorizes **who** may invoke **which** skill under **which** constraints. MAF decides **how** a model-visible tool is registered and invoked inside the agent runtime. Keep those layers distinct.
+
+| ASAP concept | MAF-side analogue | Interop note |
+|--------------|-------------------|--------------|
+| Capability / skill id (URN or manifest skill) | Tool name on an **`AIFunction`** / MCP tool | Prefer stable ids that match the ASAP grant / manifest skill — do not invent a parallel naming scheme |
+| Capability **input/output** JSON Schema | Function parameters / MCP tool schema | Discover via ASAP `describeCapability` (or manifest); mirror into `AIFunctionFactory.Create` or MCP tool metadata |
+| **Agent JWT** (caller identity) | Not a MAF primitive | Attach on outbound ASAP HTTP (Bearer / client config) or, for MCP stdio tools, `_meta.asap_agent_jwt` when using [MCP Auth Bridge](../adapters/mcp-auth-bridge.md) |
+| **Capability grant** + constraints | Tool allowlist on the agent | Register only tools that correspond to **granted** capabilities; enforce again on the ASAP host (never trust MAF alone) |
+| Approval / escalation | MAF human-in-the-loop (optional) | ASAP [capability escalation](../capabilities/escalation.md) remains the protocol path for expanding grants |
+| Host identity / registration | Out of band | See [Security](../security.md) and [Migration — per-runtime agent identity](../migration.md#upgrading-from-v21x-to-v220) |
+
+### Pattern A — In-process `AIFunction` wrapping ASAP execute
+
+Register one MAF tool per granted ASAP capability. The tool body calls ASAP (`task.request` / capability execute) with the Agent JWT and capability URN.
+
+Conceptual shape (.NET naming as of MAF 1.0):
+
+```csharp
+// Pseudocode — no ASAP .NET SDK; use HttpClient / your JSON-RPC client.
+AIFunction asapEcho = AIFunctionFactory.Create(
+    async (string message, CancellationToken ct) =>
+    {
+        // POST ASAP provider: execute granted capability with Agent JWT.
+        // capability id must match the grant (e.g. urn:...:echo).
+        return await ExecuteAsapCapabilityAsync("urn:asap:cap:echo", new { message }, ct);
+    });
+
+AIAgent agent = chatClient.AsAIAgent(
+    instructions: "Use ASAP tools only when they match the user task.",
+    tools: [asapEcho]);
+```
+
+MAF docs: [Function tools](https://learn.microsoft.com/en-us/agent-framework/agents/tools/function-tools).
+
+### Pattern B — MCP tools as `AITool`s (ASAP behind MCP)
+
+MAF can list MCP server tools and pass them to the agent as **`AITool`** instances (MCP C# SDK → cast to `AITool`). If the MCP server is an ASAP-backed stdio process protected with **`protect_server`**, each protected `tools/call` must carry **`_meta.asap_agent_jwt`**; the bridge verifies JWT and grants.
+
+```text
+MAF agent  --MCP tools/call-->  MCP server (asap.adapters.mcp.protect_server)
+                                      |
+                                      +-- verify Agent JWT + capability grant
+                                      +-- invoke underlying tool / ASAP skill
+```
+
+- MAF MCP client: [Using MCP tools](https://learn.microsoft.com/en-us/agent-framework/agents/tools/local-mcp-tools)
+- ASAP enforcement: [MCP Auth Bridge](../adapters/mcp-auth-bridge.md), [MCP integration](../mcp-integration.md)
+
+Do **not** treat MCP tool discovery alone as authorization — grants still live on the ASAP host.
+
+## What ASAP still owns
+
+Regardless of MAF registration style:
+
+1. **Identity** — Host/Agent JWT lifecycle (register, revoke, rotate). See [Security](../security.md).
+2. **Authorization** — Capability grants, constraints, approval/escalation. See [Capabilities](../capabilities/index.md).
+3. **Wire contract** — Envelope + JSON-RPC over HTTP/WebSocket; no protocol fork for MAF.
+4. **MCP Mode A** — Opt-in JWT + grant checks on stdio `tools/call` via the Auth Bridge.
+
+MAF owns session memory, model routing, and local tool orchestration. ASAP owns remote trust.
+
+## Semantic Kernel (legacy / migration)
+
+**Semantic Kernel (SK)** is on a **maintenance** track. Prefer **MAF** (`Microsoft.Agents.AI` / `agent-framework`) for new work. If you still run SK plugins/kernel functions, treat them like Pattern A: thin wrappers that call ASAP with a valid Agent JWT — then plan migration to MAF tools.
+
+Microsoft migration: [From Semantic Kernel](https://learn.microsoft.com/en-us/agent-framework/migration-guide/from-semantic-kernel/). Background: [SK and Microsoft Agent Framework](https://devblogs.microsoft.com/agent-framework/semantic-kernel-and-microsoft-agent-framework/).
+
+## Limits and non-goals
+
+| Claim | Reality in v2.5.3 |
+|-------|-------------------|
+| First-class MAF adapter package | **No** — guide only |
+| ASAP .NET / NuGet SDK | **Does not exist** |
+| In-repo C# sample / `setup-dotnet` CI | **No** (see S1b 2b.3 — deferred) |
+| Protocol changes for MAF | **Out of scope** |
+| Parity with Mastra / OpenAI Agents | **Not claimed** |
+
+If you need a maintained TypeScript path today, use [Mastra](./mastra.md) or [OpenAI Agents](./openai-agents.md). For HTTP workflow hosts → ASAP skills, see [Workflow connectors](./workflow-connectors.md).
+
+## Related
+
+- Spike lock: [`engineering/tasks/v2.5.3/research-semantic-kernel.md`](../../engineering/tasks/v2.5.3/research-semantic-kernel.md)
+- [Security](../security.md) — Agent JWT / Host identity
+- [Capabilities](../capabilities/index.md) · [Escalation](../capabilities/escalation.md)
+- [MCP Auth Bridge](../adapters/mcp-auth-bridge.md) · [MCP integration](../mcp-integration.md)
+- [Mastra](./mastra.md) · [OpenAI Agents](./openai-agents.md) — maintained Lab I adapters
+- MAF overview: [learn.microsoft.com/agent-framework](https://learn.microsoft.com/en-us/agent-framework/overview/overview)

--- a/docs/integrations/nemo-agent-toolkit.md
+++ b/docs/integrations/nemo-agent-toolkit.md
@@ -4,7 +4,7 @@ How [NVIDIA NeMo Agent Toolkit (NAT)](https://docs.nvidia.com/nemo/agent-toolkit
 
 !!! warning "Experimental — Path A demo exists; not a maintained adapter"
 
-    This page is **interop guidance** from Adapter Lab II (v2.5.3). A reproducible **Path A** stdio demo lives under [`examples/nemo_agent_toolkit_asap/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/nemo_agent_toolkit_asap). It remains **experimental** until a maintained promotion decision — there is **no** first-class ASAP↔NAT adapter package, **no** published `nemo-agent-toolkit-asap` plugin, and **no** claim of native NAT↔ASAP protocol support. Treat recommendations as research notes — they may change without a deprecation cycle.
+    This page is **interop guidance** from Adapter Lab II (v2.5.3). A reproducible **Path A** stdio demo lives under [`examples/nemo_agent_toolkit_asap/`](../../examples/nemo_agent_toolkit_asap/). It remains **experimental** until a maintained promotion decision — there is **no** first-class ASAP↔NAT adapter package, **no** published `nemo-agent-toolkit-asap` plugin, and **no** claim of native NAT↔ASAP protocol support. Treat recommendations as research notes — they may change without a deprecation cycle.
 
 !!! note "Site navigation (Sprint S3)"
 
@@ -71,6 +71,10 @@ Identity in ASAP is URN-based (`urn:asap:agent:*`) with structured skill schemas
 
 These models are **complementary**, not interchangeable. Do not wire Keycloak as a stand-in for ASAP grants, and do not claim NAT `mcp_oauth2` talks to ASAP.
 
+!!! danger "Production hard-stop (env JWT fallback)"
+
+    Path A’s `ASAP_AGENT_JWT` env fallback is **dev-only** and **unsafe for multi-tenant production**. **Do not deploy** the Path A example unchanged, and **do not** use env JWT fallback as a production auth carriage. Prefer in-band `_meta.asap_agent_jwt` (or a future HTTP Auth Bridge) for real deployments. Same stance as [MCP Auth Bridge](../adapters/mcp-auth-bridge.md) and the example README.
+
 ## Transport honesty (Path A)
 
 | Transport | Path A for ASAP Auth Bridge? |
@@ -123,7 +127,7 @@ nat run --config_file examples/nemo_agent_toolkit_asap/configs/config-mcp-client
 
 Or: `./examples/nemo_agent_toolkit_asap/run_demo.sh nat` (exits with a clear skip if `nat` is missing — does not fail ASAP CI).
 
-Example README (same commands): [`examples/nemo_agent_toolkit_asap/README.md`](https://github.com/adriannoes/asap-protocol/tree/main/examples/nemo_agent_toolkit_asap).
+Example README (same commands): [`examples/nemo_agent_toolkit_asap/README.md`](../../examples/nemo_agent_toolkit_asap/README.md).
 
 ## Adjacent edge story (ShellClaw / CUDA)
 
@@ -142,7 +146,7 @@ NAT’s NIM / CUDA LLM path is **out of band** for this interop guide. For edge 
 ## Related
 
 - Spike map: [`engineering/tasks/v2.5.3/research-nemo-agent-toolkit.md`](../../engineering/tasks/v2.5.3/research-nemo-agent-toolkit.md)
-- Runnable Path A: [`examples/nemo_agent_toolkit_asap/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/nemo_agent_toolkit_asap)
+- Runnable Path A: [`examples/nemo_agent_toolkit_asap/`](../../examples/nemo_agent_toolkit_asap/)
 - [MCP Auth Bridge](../adapters/mcp-auth-bridge.md) · [MCP integration](../mcp-integration.md)
 - [Security](../security.md) — Agent JWT / Host identity
 - [Capabilities](../capabilities/index.md)

--- a/docs/integrations/nemo-agent-toolkit.md
+++ b/docs/integrations/nemo-agent-toolkit.md
@@ -1,0 +1,169 @@
+# NeMo Agent Toolkit ↔ ASAP (interop)
+
+How [NVIDIA NeMo Agent Toolkit (NAT)](https://docs.nvidia.com/nemo/agent-toolkit/latest/) workflows sit beside ASAP **Host/Agent JWT** and **capability grants**. Naming and pins below are accurate as of **2026-07-13** (`nvidia-nat` **1.8.0**).
+
+!!! warning "Experimental — Path A demo exists; not a maintained adapter"
+
+    This page is **interop guidance** from Adapter Lab II (v2.5.3). A reproducible **Path A** stdio demo lives under [`examples/nemo_agent_toolkit_asap/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/nemo_agent_toolkit_asap). It remains **experimental** until a maintained promotion decision — there is **no** first-class ASAP↔NAT adapter package, **no** published `nemo-agent-toolkit-asap` plugin, and **no** claim of native NAT↔ASAP protocol support. Treat recommendations as research notes — they may change without a deprecation cycle.
+
+!!! note "Site navigation (Sprint S3)"
+
+    MkDocs nav and the **`docs/index.md`** CTA are finished in **Sprint S3**. Until then, discover this page via `docs/integrations/nemo-agent-toolkit.md`.
+
+## Purpose
+
+Use this when a NAT workflow already speaks **MCP** and/or **A2A** and you need ASAP identity and authorization to remain the source of truth for remote capability execution.
+
+This guide:
+
+1. Positions ASAP as an **identity / capability complement** — not an A2A replacement inside NAT.
+2. Documents Path A (NAT `mcp_client` **stdio** → ASAP `protect_server`) and honest transport limits.
+3. Contrasts NAT OAuth2/Keycloak user JWTs with ASAP Host/Agent JWT + grants (no equivalence).
+4. Sketches Agent Card → Manifest mapping for later formal work (v2.5.5).
+
+**Contrast with Lab I adapters:** Mastra and OpenAI Agents ship TypeScript packages that turn ASAP capabilities into framework tools. NAT already has first-class MCP/A2A plugins; ASAP wires **policy** onto tools those plugins call — it does not replace NAT’s conductor.
+
+## What NAT is
+
+NeMo Agent Toolkit (formerly AgentIQ / AIQ) is a **framework-agnostic conductor**: YAML workflows, `nat` CLI, profiling/eval, plus **native MCP and A2A** plugins. It can wrap LangChain, LlamaIndex, CrewAI, Semantic Kernel, and others.
+
+| Layer | NAT today | ASAP today |
+|-------|-----------|------------|
+| Tool protocol | MCP client + MCP/FastMCP server | MCP Auth Bridge (`protect_server`) + envelope MCP payloads |
+| Agent protocol | A2A client + `nat a2a serve` | ASAP envelope / task FSM / well-known manifest |
+| Auth on protected examples | OAuth2 + Keycloak (user JWT, scopes, JWKS) | Host/Agent JWT + `CapabilityRegistry` grants |
+| Discovery | A2A Agent Card `/.well-known/agent-card.json` | ASAP manifest / Lite Registry / well-known |
+
+Upstream docs: [docs.nvidia.com/nemo/agent-toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest/). Spike map: [`research-nemo-agent-toolkit.md`](../../engineering/tasks/v2.5.3/research-nemo-agent-toolkit.md).
+
+## A2A vs MCP vs ASAP
+
+| Protocol | Role in a NAT deployment | Role of ASAP |
+|----------|--------------------------|--------------|
+| **A2A** | Agent-to-agent runtime NAT already speaks (`a2a-sdk`) | **Complement, not replacement** — ASAP does not displace NAT’s A2A stack in v2.5.3 |
+| **MCP** | Tool calling between NAT workflows and MCP servers | ASAP can **gate** MCP tools via Auth Bridge (Path A stdio) |
+| **ASAP** | Optional remote trust layer for identity, grants, discovery, metering | Owns who may invoke which skill under which constraints |
+
+Do **not** present ASAP as “A2A but better.” When NAT already uses A2A between agents, keep that path; use ASAP where you need Host/Agent identity, capability grants, compliance, or ASAP-native discovery.
+
+## Agent Card → Manifest (sketch)
+
+Path B for Lab II is **docs-only**. A light field sketch (feeds [v2.5.5 Formal Spec / A2A interop](../../product/prd/prd-v2.5.5-formal-spec-interop.md)); not a runtime bridge:
+
+| A2A Agent Card (typical) | ASAP Manifest |
+|--------------------------|---------------|
+| `name` / `description` | `name` / `description` |
+| `url` | `endpoints.asap` (+ optional `events`) |
+| Skill / capability list (often strings) | `capabilities.skills[]` with `id`, schemas |
+| `authentication` / `securitySchemes` | `auth.schemes` — **orthogonal** to Agent JWT grants |
+| Card URL `/.well-known/agent-card.json` | `/.well-known/asap/manifest.json` |
+
+Identity in ASAP is URN-based (`urn:asap:agent:*`) with structured skill schemas. Fuller mapping examples: [Migration — Agent Card to Manifest](../migration.md#agent-card-to-manifest).
+
+## Auth contrast (no equivalence)
+
+| Dimension | NAT protected MCP/A2A examples | ASAP MCP Auth Bridge |
+|-----------|-------------------------------|----------------------|
+| Actor | End **user** (OAuth2 Authorization Code / Keycloak) | **Agent** identity (Host JWT → Agent JWT) |
+| Token | OIDC/OAuth2 access JWT (JWKS, `iss` / `aud` / scopes) | ASAP Agent JWT (`verify_agent_jwt`) |
+| Carriage | HTTP `Authorization: Bearer` on **streamable-http** | MCP `_meta.asap_agent_jwt` per `tools/call` (stdio); optional **dev-only** `ASAP_AGENT_JWT` env |
+| Authorization | Scope + audience on the resource server | `CapabilityRegistry.check_grant` (+ constraints) |
+
+These models are **complementary**, not interchangeable. Do not wire Keycloak as a stand-in for ASAP grants, and do not claim NAT `mcp_oauth2` talks to ASAP.
+
+## Transport honesty (Path A)
+
+| Transport | Path A for ASAP Auth Bridge? |
+|-----------|------------------------------|
+| **stdio** | **Yes** — NAT `mcp_client` spawns ASAP `protect_server` child; demo uses server-side `ASAP_AGENT_JWT` env fallback because NAT does not pass `_meta.asap_agent_jwt` |
+| **streamable-http** / **SSE** | **Blocked** this release — ASAP has no shipped HTTP/SSE Auth Bridge |
+
+HTTP/SSE follow-up: [backlog-mcp-auth-typescript.md](../../engineering/tasks/v2.5.0/backlog-mcp-auth-typescript.md) (`@asap-protocol/mcp-auth`). Do not invent a Python HTTP protect path in Lab II.
+
+Full matrices: [research note §10](../../engineering/tasks/v2.5.3/research-nemo-agent-toolkit.md#10-spike-gap-analysis-2026-07-13).
+
+## Requirements
+
+| Piece | Note |
+|-------|------|
+| Python | **3.13** for joint examples (ASAP ∩ `nvidia-nat` 1.8.x) |
+| ASAP | `asap-protocol` in-repo (`uv sync`) — Auth Bridge via `asap.adapters.mcp` |
+| NAT (optional) | `nvidia-nat[mcp]==1.8.0` from `examples/nemo_agent_toolkit_asap/requirements.txt` — **not** a core ASAP dependency |
+| NIM | `NVIDIA_API_KEY` only if you run `nat run` with the sample `react_agent` YAML |
+
+## Quick start (commands)
+
+### ASAP-side smoke (CI / no NAT / no NIM)
+
+From the repository root:
+
+```bash
+uv run python examples/nemo_agent_toolkit_asap/smoke_asap_side.py
+uv run python examples/nemo_agent_toolkit_asap/smoke_asap_side.py --stdio
+uv run pytest tests/examples/test_nemo_agent_toolkit_asap.py -v
+```
+
+Or via the launcher:
+
+```bash
+./examples/nemo_agent_toolkit_asap/run_demo.sh smoke
+./examples/nemo_agent_toolkit_asap/run_demo.sh smoke-stdio
+```
+
+These paths exercise `protect_server` + env JWT fallback **without** installing `nvidia-nat`. Main CI stays green when NAT is absent — ASAP-side tests always run; the optional NAT import uses `pytest.importorskip("nat")`.
+
+### Optional full NAT workflow (maintainer / local)
+
+```bash
+uv pip install -r examples/nemo_agent_toolkit_asap/requirements.txt
+export NVIDIA_API_KEY='your-key'   # never commit; required for sample react_agent
+nat run --config_file examples/nemo_agent_toolkit_asap/configs/config-mcp-client-stdio.yml \
+  --input "Call echo with message hello, then secure_action with action demo"
+```
+
+Or: `./examples/nemo_agent_toolkit_asap/run_demo.sh nat` (exits with a clear skip if `nat` is missing — does not fail ASAP CI).
+
+Example README (same commands): [`examples/nemo_agent_toolkit_asap/README.md`](https://github.com/adriannoes/asap-protocol/tree/main/examples/nemo_agent_toolkit_asap).
+
+## Adjacent edge story (ShellClaw / CUDA)
+
+NAT’s NIM / CUDA LLM path is **out of band** for this interop guide. For edge hardware advertising and static registry listing, see the separate ShellClaw story: [ShellClaw registry guide](../guides/shellclaw-registry.md) and [registry-shellclaw example](../examples/registry-shellclaw.md). That does not imply NAT↔ASAP native support on device.
+
+## Limits and non-goals
+
+| Claim | Reality in v2.5.3 |
+|-------|-------------------|
+| Maintained ASAP↔NAT adapter package | **No** — experimental Path A demo + this guide |
+| Native NAT↔ASAP protocol / A2A replacement | **Not claimed** |
+| HTTP / streamable-http Auth Bridge | **Blocked** — see mcp-auth backlog |
+| Published `nemo-agent-toolkit-asap` / `nat.plugins.asap` | **Out of ship** (Path C feasibility only — appendix below) |
+| Protocol changes for NAT | **Out of scope** |
+
+## Related
+
+- Spike map: [`engineering/tasks/v2.5.3/research-nemo-agent-toolkit.md`](../../engineering/tasks/v2.5.3/research-nemo-agent-toolkit.md)
+- Runnable Path A: [`examples/nemo_agent_toolkit_asap/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/nemo_agent_toolkit_asap)
+- [MCP Auth Bridge](../adapters/mcp-auth-bridge.md) · [MCP integration](../mcp-integration.md)
+- [Security](../security.md) — Agent JWT / Host identity
+- [Capabilities](../capabilities/index.md)
+- [Workflow connectors](./workflow-connectors.md) · [Microsoft Agent Framework](./microsoft-agent-framework.md)
+- Upstream: [NeMo Agent Toolkit docs](https://docs.nvidia.com/nemo/agent-toolkit/latest/) · [NVIDIA/NeMo-Agent-Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit)
+
+---
+
+## Appendix: Path C third-party plugin (feasibility — out of ship)
+
+Upstream encourages provider-owned packages ([third-party plugins](https://docs.nvidia.com/nemo/agent-toolkit/latest/extend/third-party-plugins.html)):
+
+| Surface | Convention (sketch) |
+|---------|----------------------|
+| Import | `nat.plugins.asap` |
+| Dist name | `nemo-agent-toolkit-asap` |
+| Repo name | `NeMo-Agent-Toolkit-asap` (or live under ASAP monorepo `packages/`) |
+| Entry | `nat_asap` / function group e.g. `asap__discover`, `asap__task_request` |
+
+**Ownership options:** (1) ASAP-maintained package in this monorepo; (2) separate NVIDIA-style provider repo. Either needs a clear owner before publish.
+
+**CI matrix sketch (post–v2.5.3):** Python **3.11–3.13** × pinned `nvidia-nat==1.8.0` (joint Path A examples stay on **3.13** only). Optional extra — must not become a required ASAP core dep.
+
+**Explicit out of ship for v2.5.3:** do **not** publish `nemo-agent-toolkit-asap`, register `nat.plugins.asap`, or claim a Public Plugin API integration in this release. Path C remains a feasibility note until Path A is promoted and maintainership is decided. Checklist: [research note §6](../../engineering/tasks/v2.5.3/research-nemo-agent-toolkit.md#6-third-party-plugin-feasibility-checklist-spike).

--- a/engineering/tasks/v2.5.3/demand-sheet.md
+++ b/engineering/tasks/v2.5.3/demand-sheet.md
@@ -63,11 +63,15 @@ No maintainer-logged partner asks recorded in-repo for Semantic Kernel / MAF, Ha
 
 ## S1b go/no-go (D2) — Semantic Kernel
 
-**Decision: no-go** → skip [sprint-S1b-semantic-kernel.md](./sprint-S1b-semantic-kernel.md).
+**Original S0 decision (2026-07-13): no-go** — evidence below is unchanged.
 
-**Rationale:** Gate requires ≥1 credible Azure/.NET partner ask, ≥3 `adapter-request` issues for SK/MAF, or maintainer override. There is no `adapter-request` label; keyword search found **0** SK/MAF issues; no in-repo partner asks. Maintainer LGTM: **no-go**.
+**Rationale (S0):** Gate requires ≥1 credible Azure/.NET partner ask, ≥3 `adapter-request` issues for SK/MAF, or maintainer override. There is no `adapter-request` label; keyword search found **0** SK/MAF issues; no in-repo partner asks. Initial maintainer LGTM at S0: **no-go**.
 
-**Not this release:** Semantic Kernel / Microsoft Agent Framework will not receive an Adapter Lab II spike or public interop guide in v2.5.3. Revisit only if credible Azure/.NET demand appears (issues, partner ask, or explicit maintainer override) in a later lab cycle.
+**Maintainer override (2026-07-13): go** → run [sprint-S1b-semantic-kernel.md](./sprint-S1b-semantic-kernel.md) despite zero GitHub demand.
+
+**Override rationale:** Explicit LGTM to pursue a **research / experimental** interop guide in v2.5.3 as part of the combined Lab II **S1b + S1c** initiative on branch `feat/v2.5.3-s1b-s1c-spikes`. Demand evidence remains zero; this is not a promotion to a maintained .NET SDK or NuGet surface. Prefer **guide-only** (see [research-semantic-kernel.md](./research-semantic-kernel.md)).
+
+**In this release (override):** research/experimental Microsoft Agent Framework / Semantic Kernel interop guide only. No protocol fork; no NuGet publish.
 
 ---
 
@@ -95,7 +99,7 @@ No maintainer-logged partner asks recorded in-repo for Semantic Kernel / MAF, Ha
 |-----------|--------|
 | Counts + method documented | Done |
 | Primary (D1) locked, no swap | Done |
-| S1b (D2) no-go + “not this release” note | Done |
+| S1b (D2) no-go + “not this release” note | Superseded: original no-go kept; **override go** recorded 2026-07-13 |
 | S1c (D7) go + research map + Path intent | Done |
 | P1/P2 parking recorded | Done |
 | `release/2.5.3` on origin | Confirmed (`261e53b…`) |

--- a/engineering/tasks/v2.5.3/research-nemo-agent-toolkit.md
+++ b/engineering/tasks/v2.5.3/research-nemo-agent-toolkit.md
@@ -2,14 +2,16 @@
 
 > **Status**: Living technical map for Adapter Lab II S1c  
 > **Created**: 2026-07-11  
-> **Upstream pin**: [NVIDIA/NeMo-Agent-Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) @ tag **`v1.8.0`** (2026-06-16); default branch **`develop`** (last push observed 2026-07-10)  
-> **PyPI**: `nvidia-nat` **1.8.0** (`requires-python >=3.11,<3.14`)  
+> **Last refreshed**: 2026-07-13 (S1c 2c.4–2c.6 public guide + Path C out-of-ship)  
+> **Upstream pin**: [NVIDIA/NeMo-Agent-Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) @ tag **`v1.8.0`** (GitHub release published 2026-06-16; latest *release* unchanged); default branch **`develop`** HEAD `e8692d0050d03706bcd33d5b059937d59d4eed7d` (2026-07-10T05:21:32Z)  
+> **PyPI**: `nvidia-nat` **1.8.0** (`requires-python >=3.11,<3.14`) — confirmed latest on PyPI 2026-07-13; tags include `v1.9.0-dev` but no newer stable release  
+> **Install pin**: `nvidia-nat[mcp,a2a]==1.8.0`  
 > **License**: Apache-2.0  
 > **Docs**: https://docs.nvidia.com/nemo/agent-toolkit/latest/  
 > **PRD**: [prd-v2.5.3-adapter-lab-ii.md](../../../product/prd/prd-v2.5.3-adapter-lab-ii.md) D7  
 > **Sprint**: [sprint-S1c-nemo-agent-toolkit.md](./sprint-S1c-nemo-agent-toolkit.md)
 
-Re-verify tags/paths against `develop` before coding. This note is evidence from the public repo as of 2026-07-11, not a substitute for reading upstream CHANGELOG at spike start.
+Re-verify tags/paths against `develop` before coding. This note is evidence from the public repo; spike refresh 2026-07-13 confirmed pin and auth/transport facts below.
 
 ---
 
@@ -144,15 +146,19 @@ A future `nemo-agent-toolkit-asap` / `nat.plugins.asap` could register ASAP clie
 
 ## 6. Third-party plugin feasibility checklist (spike)
 
-From upstream `third-party-plugins.md`:
+From upstream `third-party-plugins.md`. **Public write-up:** [docs/integrations/nemo-agent-toolkit.md](../../../docs/integrations/nemo-agent-toolkit.md) appendix (Path C). **Explicit out of ship for v2.5.3** — do not publish the plugin in this release.
 
-- [ ] Confirm Public Plugin API stability for our target NAT minor (1.8.x)
-- [ ] Sketch `nat.plugins.asap` function group: e.g. `asap__discover`, `asap__task_request`
-- [ ] Decide ownership: live in ASAP repo vs separate `NeMo-Agent-Toolkit-asap`
-- [ ] CI matrix: Python 3.11–3.13 × `nvidia-nat==1.8.0`
-- [ ] Do **not** start the package until Path A demo works
+| Item | Status (2026-07-13) |
+|------|---------------------|
+| Public Plugin API stability for NAT 1.8.x | Documented as **unconfirmed until Path A promoted** — re-read upstream before any package start |
+| Sketch `nat.plugins.asap` / `asap__discover`, `asap__task_request` | **Sketched** in public guide appendix |
+| Naming: import `nat.plugins.asap`, dist `nemo-agent-toolkit-asap` | **Recorded** |
+| Ownership: ASAP monorepo vs `NeMo-Agent-Toolkit-asap` | **Options listed**; decision deferred |
+| CI matrix: Python 3.11–3.13 × `nvidia-nat==1.8.0` | **Sketched**; joint Path A examples stay on **3.13** only; NAT must remain optional |
+| Start the package | **Blocked** until Path A is promoted + ownership decided |
 
 ---
+
 
 ## 7. Version & environment constraints
 
@@ -189,8 +195,90 @@ Update this file’s pin line when the spike starts.
 
 ---
 
+## 10. Spike gap analysis (2026-07-13)
+
+Evidence sources for this section:
+
+| Source | What was checked |
+|--------|------------------|
+| PyPI `nvidia-nat` JSON | Latest version **1.8.0** |
+| `gh api …/releases/latest` | Tag **`v1.8.0`** (published 2026-06-16) |
+| `gh api …/commits/develop` | SHA `e8692d0…`, 2026-07-10 |
+| `gh api …/tags` | `v1.9.0-dev` present; latest stable release still **v1.8.0** |
+| `v1.8.0` READMEs | `examples/MCP/simple_calculator_mcp_protected/`, `examples/A2A/math_assistant_a2a_protected/` |
+| `v1.8.0` docs/code | `docs/source/build-workflows/mcp-client.md`, `docs/source/components/auth/mcp-auth/index.md`, `packages/nvidia_nat_mcp/.../client_config.py`, `client_base.py` |
+| `v1.8.0...develop` compare | Protected MCP/A2A example paths: only `uv.lock` churn — **no auth/transport semantic change** since the note was written |
+| ASAP | `docs/adapters/mcp-auth-bridge.md`, `examples/mcp_auth_bridge/`, [backlog-mcp-auth-typescript.md](../v2.5.0/backlog-mcp-auth-typescript.md) |
+
+### 10.1 Transport matrix — NAT MCP client vs ASAP Auth Bridge
+
+| Transport | NAT `mcp_client` / `per_user_mcp_client` | NAT OAuth / `auth_provider` | ASAP `protect_server` (v2.5.0) | Honest overlap for Path A? |
+|-----------|------------------------------------------|-----------------------------|--------------------------------|----------------------------|
+| **stdio** | Supported (`server.command` / `args` / `env`) | **Not supported** — config validator rejects `auth_provider` and `custom_headers` on stdio | **Supported** — Mode A is native stdio `MCPServer` + `_meta.asap_agent_jwt` (optional dev `ASAP_AGENT_JWT` env) | **Yes** — spawn ASAP example as stdio child; auth is *not* NAT OAuth |
+| **streamable-http** | Supported (default; `server.url`) | **Supported** — Bearer via `mcp_oauth2` / service-account; protected examples use this | **Not shipped** — no Python HTTP MCP Auth Bridge; TS `@asap-protocol/mcp-auth` deferred | **No** — NAT’s happy path ≠ ASAP’s shipped protect surface |
+| **SSE** | Supported (legacy) | **Explicitly unsupported** — upstream warns SSE has no authentication | **Not shipped** for Auth Bridge | **No** |
+
+Notes (do not invent compatibility):
+
+- NAT `session.call_tool(tool_name, tool_args)` does **not** pass MCP `_meta`. There is no first-class ASAP Agent JWT injection on NAT tool calls.
+- ASAP protected `tools/call` expects `_meta.asap_agent_jwt`, or — only when `allow_env_jwt_fallback=True` — `ASAP_AGENT_JWT` in the **server** process environment (dev-only; already enabled in `examples/mcp_auth_bridge/`).
+- ASAP also has registry/MCP serve helpers with `--transport` choices including `streamable-http` (`src/asap/mcp/serve.py`), but that path is **not** the Auth Bridge; `protect_server` remains the stdio Mode A adapter documented in [mcp-auth-bridge.md](../../../docs/adapters/mcp-auth-bridge.md).
+
+### 10.2 Auth matrix — NAT OAuth2 user JWT vs ASAP Host/Agent JWT + grants
+
+| Dimension | NAT protected MCP/A2A examples (`v1.8.0`) | ASAP MCP Auth Bridge (v2.5.0) |
+|-----------|------------------------------------------|-------------------------------|
+| Actor | End **user** (browser Authorization Code via Keycloak) | **Agent** identity (Host JWT → Agent JWT) |
+| Token | OIDC/OAuth2 access JWT (JWKS, `iss` / `aud` / scopes) | ASAP Agent JWT (`verify_agent_jwt`) |
+| Carriage | HTTP `Authorization: Bearer <jwt>` on streamable-http | MCP `_meta.asap_agent_jwt` per `tools/call` (stdio); optional env fallback |
+| Authorization | Scope + audience checks on the resource server | `CapabilityRegistry.check_grant` (+ constraints) |
+| Discovery | MCP OAuth discovery / A2A Agent Card `securitySchemes` | ASAP well-known manifest / skills (orthogonal) |
+| Equivalence | — | **None** — complementary policy layer, not a Keycloak drop-in |
+
+Upstream protected MCP README (`simple_calculator_mcp_protected`, tag `v1.8.0`): server at `http://localhost:9902`, client `per_user_mcp_client` + `mcp_oauth2`, Keycloak scopes such as `calculator_mcp_execute`. Protected A2A README mirrors the same OAuth2/Keycloak pattern over A2A JSON-RPC Bearer — irrelevant to ASAP Auth Bridge carriage, useful only for Path B discovery contrast.
+
+### 10.3 Path A demo shape decision
+
+**Recommendation: proceed Path A this sprint — YES (stdio).**
+
+| Option | Verdict | Why |
+|--------|---------|-----|
+| **A1 — NAT stdio → ASAP `protect_server` stdio** | **Choose for 2c.3** | Transport aligns. NAT already documents stdio clients (`simple_calculator_mcp` mixes stdio + streamable-http). Reuse `examples/mcp_auth_bridge/` patterns. |
+| A2 — NAT streamable-http → ASAP HTTP MCP auth | **Blocked this sprint** | ASAP has no Python HTTP/SSE Auth Bridge. Follow-up: [backlog-mcp-auth-typescript.md](../v2.5.0/backlog-mcp-auth-typescript.md) (HTTP/SSE middleware) and any future **Python** HTTP MCP auth work — do **not** invent a bridge in Lab II (PRD D5/D6). |
+| A3 — Pretend NAT OAuth ≡ ASAP grants | **Forbidden** | Dual auth models; docs must show side-by-side, not equivalence. |
+
+**Demo shape for 2c.3 (when implemented):**
+
+1. ASAP side: protected stdio server (reuse / thin wrap of `examples/mcp_auth_bridge/` — `echo` public, `secure_action` granted).
+2. NAT side: YAML `function_groups` with `_type: mcp_client`, `server.transport: stdio`, `command`/`args` pointing at that server (Python 3.13).
+3. Auth carriage honesty:
+   - NAT will **not** send `_meta.asap_agent_jwt`.
+   - Use the existing **dev-only** `allow_env_jwt_fallback` path so the ASAP child process authenticates protected calls without in-band `_meta` (e.g. mint demo JWT into the server process env at startup, or a documented mint → `server.env.ASAP_AGENT_JWT` flow with **deterministic demo keys** so parent and child share material).
+   - Label clearly: single-agent local demo; not multi-tenant; not production.
+4. Negative control: without grant / without JWT env → `asap:auth_required` or `asap:capability_denied` as applicable.
+5. Do **not** wire Keycloak or claim NAT `mcp_oauth2` talks to ASAP.
+
+**HTTP follow-up pointer (explicit blocker for streamable-http Path A):**
+
+- TypeScript: [engineering/tasks/v2.5.0/backlog-mcp-auth-typescript.md](../v2.5.0/backlog-mcp-auth-typescript.md) (`@asap-protocol/mcp-auth` HTTP/SSE).
+- Python: no shipped HTTP MCP Auth Bridge equivalent to `protect_server`; Lab II must not expand protocol or transport servers (`src/asap/transport/{server,client}.py` untouched).
+
+### 10.4 Upstream skim — auth/transport changes since 2026-07-11 note
+
+| Area | Finding (2026-07-13) |
+|------|----------------------|
+| Release pin | Still **v1.8.0** on GitHub + PyPI |
+| Protected MCP example | Still streamable-http + Keycloak OAuth2 + `per_user_mcp_client`; no stdio auth story |
+| Protected A2A example | Still Agent Card discovery + Bearer JWT; unchanged for ASAP Auth Bridge |
+| MCP client docs | Still three transports; auth **only** on streamable-http; stdio for local process spawn |
+| `develop` vs `v1.8.0` | No meaningful protected-example README/config auth changes (lockfile-only in compare filter) |
+
+---
+
 ## Change log
 
 | Date | Change |
 |------|--------|
+| 2026-07-13 | S1c 2c.4–2c.6: public guide `docs/integrations/nemo-agent-toolkit.md`; §6 Path C feasibility marked out-of-ship; commands + CI-optional NAT documented |
+| 2026-07-13 | S1c Wave 1–2: reconfirmed pin `nvidia-nat[mcp,a2a]==1.8.0`; skimmed protected MCP/A2A READMEs + MCP client/auth docs; appended §10 transport/auth gap analysis; Path A = YES stdio |
 | 2026-07-11 | Initial map from public GitHub + PyPI (v1.8.0 / develop) |

--- a/engineering/tasks/v2.5.3/research-semantic-kernel.md
+++ b/engineering/tasks/v2.5.3/research-semantic-kernel.md
@@ -1,0 +1,66 @@
+# Research note: Semantic Kernel / Microsoft Agent Framework ↔ ASAP
+
+> **Status**: Spike-time scope check for Adapter Lab II S1b (Wave 1 / 2b.1)  
+> **Spike date**: 2026-07-13  
+> **Sprint**: [sprint-S1b-semantic-kernel.md](./sprint-S1b-semantic-kernel.md)  
+> **Demand**: [demand-sheet.md](./demand-sheet.md) — S0 **no-go** on GitHub demand; **maintainer override (2026-07-13)** to ship a research/experimental interop guide  
+> **PRD**: [prd-v2.5.3-adapter-lab-ii.md](../../../product/prd/prd-v2.5.3-adapter-lab-ii.md) D2  
+> **ASAP guide status**: **research / experimental** — not a maintained adapter  
+> **Public guide (2b.2)**: [`docs/integrations/microsoft-agent-framework.md`](../../../docs/integrations/microsoft-agent-framework.md)
+
+This note locks naming and deliverable shape for 2b.2. The public guide is linked above.
+
+---
+
+## 1. Naming conclusion (as of 2026-07-13)
+
+| Name | Role today | Packages / docs |
+|------|------------|-----------------|
+| **Microsoft Agent Framework (MAF)** | **Current** Microsoft call-to-action for new agent apps; successor to Semantic Kernel + AutoGen | .NET: `Microsoft.Agents.AI` (NuGet); Python: `agent-framework` (PyPI); docs: aka.ms/AgentFramework/Docs; repo: [microsoft/agent-framework](https://github.com/microsoft/agent-framework) |
+| **Semantic Kernel (SK)** | **Maintenance / legacy** track — critical bugs + security; most new features go to MAF | `Microsoft.SemanticKernel` / SK Python; migration guides under Agent Framework docs |
+
+**Evidence (public Microsoft sources):**
+
+- Product FAQ: MAF is the successor to SK for building AI agents; SK remains supported at least one year after MAF leaves Preview / reaches GA ([Semantic Kernel and Microsoft Agent Framework](https://devblogs.microsoft.com/agent-framework/semantic-kernel-and-microsoft-agent-framework/), Oct 2025).
+- **MAF 1.0 GA**: announced early April 2026 for .NET and Python ([Microsoft Agent Framework Version 1.0](https://devblogs.microsoft.com/agent-framework/microsoft-agent-framework-version-1-0/); tags `dotnet-1.0.0` / `python-1.0.0` on `microsoft/agent-framework`, 2026-04-02).
+- Migration: [SK → Agent Framework](https://learn.microsoft.com/en-us/agent-framework/migration-guide/from-semantic-kernel/) (Learn / semantic-kernel-docs tree).
+
+**Guide title / path for 2b.2:** prefer `docs/integrations/microsoft-agent-framework.md`, with a short “Semantic Kernel (legacy)” section pointing at Microsoft’s migration docs. Keep sprint/folder name “semantic-kernel” for PRD continuity; do not brand the public page as SK-first.
+
+---
+
+## 2. Deliverable decision: **guide-only**
+
+| Option | Decision |
+|--------|----------|
+| Full .NET SDK / NuGet | **Out of scope** (PRD + maintainer) |
+| Guide + minimal C# sample under `examples/` | **No** for v2.5.3 Wave 1→2 |
+| **Guide-only** research/experimental interop doc | **Yes** |
+
+**Why guide-only:**
+
+1. **No in-repo .NET maintainer path** — CI has Mastra / OpenAI Agents / TypeScript workflows; **no** `setup-dotnet`, `.csproj`, or C# samples under `examples/`.
+2. Maintainer override explicitly prefers **guide-only** when a C# sample cannot run in CI or lacks a clear .NET path.
+3. Demand remains **zero** GitHub issues; override justifies an experimental doc, not CI matrix expansion.
+4. Interop story is conceptual: ASAP Host/Agent JWT + capability grants beside MAF tools / MCP / A2A — does not require a compiled sample to be useful.
+
+**2b.3:** leave unchecked; revisit a thin sample only if a maintainer later adds a documented “requires .NET SDK” path (still no NuGet / no protocol fork).
+
+---
+
+## 3. Guide shape (2b.2 — written)
+
+**Path:** [`docs/integrations/microsoft-agent-framework.md`](../../../docs/integrations/microsoft-agent-framework.md)
+
+- Status banner first: **research / experimental** (not maintained).
+- Map ASAP Agent JWT / capabilities ↔ MAF tool registration / MCP-style tool surfaces (honest limits).
+- Call out SK only as predecessor / migration audience.
+- MkDocs nav + `docs/index.md` deferred to **S3**.
+
+---
+
+## 4. Non-goals
+
+- Protocol fork or new transport methods
+- Publishing a NuGet package
+- Claiming parity with Lab I first-class adapters (Mastra / OpenAI Agents)

--- a/engineering/tasks/v2.5.3/sprint-S1b-semantic-kernel.md
+++ b/engineering/tasks/v2.5.3/sprint-S1b-semantic-kernel.md
@@ -13,7 +13,7 @@
 
 ## Goal
 
-Produce an **interop spike + .NET-oriented guide** showing how ASAP identity/capabilities sit beside Microsoft Agent Framework / Semantic Kernel. Prefer guide + thin sample over a full .NET SDK in this release.
+Ship a **research / experimental interop guide** (guide-only) showing how ASAP identity/capabilities sit beside **Microsoft Agent Framework**, with Semantic Kernel called out only as legacy/migration. No C# sample, no NuGet, and no full .NET SDK in this release.
 
 If the spike exceeds ~1 week or needs protocol changes: stop, publish research notes, mark **not maintained**.
 

--- a/engineering/tasks/v2.5.3/sprint-S1b-semantic-kernel.md
+++ b/engineering/tasks/v2.5.3/sprint-S1b-semantic-kernel.md
@@ -1,12 +1,13 @@
 # Sprint S1b: Semantic Kernel / Microsoft Agent Framework (conditional)
 
 **PRD**: D2, §6 promotion gates  
-**Branch**: `feat/v2.5.3-s1b-semantic-kernel` → **`release/2.5.3`**  
-**Depends on**: [S0](./sprint-S0-candidate-lock.md) **D2 = go**
+**Branch**: `feat/v2.5.3-s1b-s1c-spikes` → **`release/2.5.3`**  
+**Depends on**: [S0](./sprint-S0-candidate-lock.md); [demand-sheet.md](./demand-sheet.md) **maintainer override (2026-07-13)**  
+**Research**: [research-semantic-kernel.md](./research-semantic-kernel.md)
 
-**Trigger:** Azure/.NET demand gate passed in S0.  
+**Trigger:** S0 recorded D2 **no-go** on demand; maintainer override reopened S1b for a research/experimental guide (combined S1b+S1c initiative).  
 **Enables:** Optional second public surface; never blocks S4.  
-**Depends on:** S0 go decision.
+**Depends on:** Demand-sheet override + 2b.1 scope lock.
 
 ---
 
@@ -16,32 +17,52 @@ Produce an **interop spike + .NET-oriented guide** showing how ASAP identity/cap
 
 If the spike exceeds ~1 week or needs protocol changes: stop, publish research notes, mark **not maintained**.
 
+### 2b.1 decision (2026-07-13)
+
+See [research-semantic-kernel.md](./research-semantic-kernel.md).
+
+- **Target API surface:** **Microsoft Agent Framework (MAF)** is the primary public naming (GA 1.0, April 2026). Semantic Kernel is maintenance/legacy — mention for migration readers only.
+- **Deliverable:** **guide-only** → `docs/integrations/microsoft-agent-framework.md` (research/experimental). No C# sample under `examples/` in this release (no in-repo .NET CI / maintainer path).
+
 ---
 
 ## Tasks
 
-- [ ] **2b.1 Scope check**
-  - [ ] Confirm target API surface (SK vs Agent Framework naming as of spike date)
-  - [ ] Decide: guide-only vs guide + minimal C# sample repo path under `examples/`
+- [x] **2b.1 Scope check**
+  - [x] Confirm target API surface (SK vs Agent Framework naming as of spike date)
+  - [x] Decide: guide-only vs guide + minimal C# sample repo path under `examples/`
 
-- [ ] **2b.2 Guide**
-  - [ ] `docs/integrations/semantic-kernel.md` (or `microsoft-agent-framework.md`)
-  - [ ] Map: Agent JWT / capabilities ↔ how tools are registered on the MS side
-  - [ ] Explicit status banner: **research / experimental** vs **maintained**
-  - [ ] Leave MkDocs nav + home index to **S3**
+- [x] **2b.2 Guide**
+  - [x] `docs/integrations/microsoft-agent-framework.md` (SK called out as legacy / migration)
+  - [x] Map: Agent JWT / capabilities ↔ how tools are registered on the MS side
+  - [x] Explicit status banner: **research / experimental** vs **maintained**
+  - [x] Leave MkDocs nav + home index to **S3**
 
-- [ ] **2b.3 Optional sample**
-  - [ ] Minimal sample only if it runs in CI or has a clear “requires .NET SDK” maintainer path
-  - [ ] Do not block release on NuGet publish
+- [x] **2b.3 Optional sample** — **skipped / N/A (guide-only)**
+  - [x] No C# sample under `examples/` (2b.1 deliverable = guide-only; no in-repo .NET CI)
+  - [x] Do not block release on NuGet publish
 
 ---
 
 ## Acceptance criteria
 
-- [ ] Guide merged or explicitly deferred with reason in demand sheet
-- [ ] No protocol fork
-- [ ] Status (research vs maintained) is obvious in the first screen of the doc
+- [x] Guide exists at `docs/integrations/microsoft-agent-framework.md` (nav/index deferred to S3; 2b.3 N/A — guide-only)
+- [x] No protocol fork
+- [x] Status (research vs maintained) is obvious in the first screen of the doc
+
+## Relevant files
+
+| Path | Role |
+|------|------|
+| [`docs/integrations/microsoft-agent-framework.md`](../../../docs/integrations/microsoft-agent-framework.md) | Public interop guide (2b.2) |
+| [`research-semantic-kernel.md`](./research-semantic-kernel.md) | 2b.1 naming + deliverable lock |
 
 ## Skip condition
 
-If S0 records **no-go**, mark this sprint **SKIPPED** in the roadmap table and do not open a branch.
+If S0 records **no-go** *and* there is no maintainer override, mark this sprint **SKIPPED** in the roadmap table and do not open a branch. *(Override applied 2026-07-13 — sprint **Done** guide-only; 2b.3 skipped.)*
+
+## Reviews
+
+| Date | Tier | Verdict | Report |
+|------|------|---------|--------|
+| 2026-07-13 | T3 | Approved with caveats | [review-v2.5.3-S1b-S1c-spikes-20260713.md](../../code-review/private/review-v2.5.3-S1b-S1c-spikes-20260713.md) |

--- a/engineering/tasks/v2.5.3/sprint-S1c-nemo-agent-toolkit.md
+++ b/engineering/tasks/v2.5.3/sprint-S1c-nemo-agent-toolkit.md
@@ -1,7 +1,7 @@
 # Sprint S1c: NeMo Agent Toolkit ↔ ASAP (v2.5.3)
 
 **PRD**: D7, §3 (NeMo Agent Toolkit)  
-**Branch**: `feat/v2.5.3-s1c-nemo-agent-toolkit` → **`release/2.5.3`**  
+**Branch**: `feat/v2.5.3-s1b-s1c-spikes` → **`release/2.5.3`**  
 **Depends on**: [S0](./sprint-S0-candidate-lock.md) records S1c = **go** (default for Lab II)  
 **Research map**: [research-nemo-agent-toolkit.md](./research-nemo-agent-toolkit.md)
 
@@ -31,56 +31,67 @@ Prove a **careful, honest** integration story: NeMo Agent Toolkit already speaks
 
 ## Tasks
 
-- [ ] **2c.1 Refresh upstream pin**
-  - [ ] Run refresh commands in research note §9; update pin line if needed
-  - [ ] Skim protected MCP/A2A example READMEs for auth/transport changes
+- [x] **2c.1 Refresh upstream pin**
+  - [x] Run refresh commands in research note §9; update pin line if needed
+  - [x] Skim protected MCP/A2A example READMEs for auth/transport changes
 
-- [ ] **2c.2 Transport & auth gap analysis (write first)**
-  - [ ] Table: NAT MCP transports (stdio / streamable-http / SSE) vs ASAP Auth Bridge carriage
-  - [ ] Table: OAuth2 user JWT (NAT protected examples) vs Host/Agent JWT + capability grants
-  - [ ] Decide Path A demo shape: stdio bridge **or** document blocker + HTTP follow-up (mcp-auth backlog)
-  - [ ] Append conclusions to research note (do not invent compatibility)
+- [x] **2c.2 Transport & auth gap analysis (write first)**
+  - [x] Table: NAT MCP transports (stdio / streamable-http / SSE) vs ASAP Auth Bridge carriage
+  - [x] Table: OAuth2 user JWT (NAT protected examples) vs Host/Agent JWT + capability grants
+  - [x] Decide Path A demo shape: stdio bridge **or** document blocker + HTTP follow-up (mcp-auth backlog)
+  - [x] Append conclusions to research note (do not invent compatibility)
 
-- [ ] **2c.3 Path A spike (if transport allows)**
-  - [ ] ASAP side: minimal protected MCP server (reuse `examples/mcp_auth_bridge/` patterns)
-  - [ ] NAT side: workflow YAML using `nvidia-nat[mcp]` client against that server
-  - [ ] Example folder: `examples/nemo_agent_toolkit_asap/` with README, `.env.example`, pin versions
-  - [ ] Happy path without committing secrets; `NVIDIA_API_KEY` only if NIM is used (optional)
+- [x] **2c.3 Path A spike (if transport allows)**
+  - [x] ASAP side: minimal protected MCP server (reuse `examples/mcp_auth_bridge/` patterns)
+  - [x] NAT side: workflow YAML using `nvidia-nat[mcp]` client against that server
+  - [x] Example folder: `examples/nemo_agent_toolkit_asap/` with README, `.env.example`, pin versions
+  - [x] Happy path without committing secrets; `NVIDIA_API_KEY` only if NIM is used (optional)
 
-- [ ] **2c.4 Path B docs (always)**
-  - [ ] `docs/integrations/nemo-agent-toolkit.md`
-  - [ ] Sections: what NAT is; A2A vs MCP vs ASAP; Agent Card → Manifest sketch; auth contrast; link ShellClaw/CUDA only as adjacent edge story
-  - [ ] Status banner: **experimental** until Path A demo is green
-  - [ ] Leave MkDocs nav + home index to **S3**
+- [x] **2c.4 Path B docs (always)**
+  - [x] `docs/integrations/nemo-agent-toolkit.md`
+  - [x] Sections: what NAT is; A2A vs MCP vs ASAP; Agent Card → Manifest sketch; auth contrast; link ShellClaw/CUDA only as adjacent edge story
+  - [x] Status banner: **experimental** — Path A demo under `examples/nemo_agent_toolkit_asap/`; still experimental until maintained promotion
+  - [x] Leave MkDocs nav + home index to **S3**
 
-- [ ] **2c.5 Path C feasibility (optional, short)**
-  - [ ] One page in research note or guide appendix: third-party plugin naming (`nat.plugins.asap`), ownership, CI matrix
-  - [ ] Explicit **out of ship** for v2.5.3
+- [x] **2c.5 Path C feasibility (short)**
+  - [x] Appendix in public guide: third-party plugin naming (`nat.plugins.asap`, `nemo-agent-toolkit-asap`), ownership, CI matrix
+  - [x] Explicit **out of ship** for v2.5.3 (research note §6 updated)
 
-- [ ] **2c.6 Tests / smoke**
-  - [ ] Document exact commands; if demo exists, add smoke test or CI-skippable script with clear deps
-  - [ ] Do not fail main CI if `nvidia-nat` is optional extra — keep NAT as optional/dev path
+- [x] **2c.6 Tests / smoke**
+  - [x] Exact commands documented in public guide + example README
+  - [x] ASAP-side pytest always runs; optional NAT import skips when `nvidia-nat` absent (main CI does not require NAT)
+  - [x] Smoke: `smoke_asap_side.py` / `run_demo.sh`; NAT path optional via `run_demo.sh nat`
 
 ---
 
 ## Acceptance criteria
 
-- [ ] Research note updated with spike-time pin + gap tables
-- [ ] Public guide published (`docs/integrations/nemo-agent-toolkit.md`) with honest auth/transport limits
-- [ ] Either: Path A runnable example **or** written blocker + follow-up issue/backlog pointer (no fake “native support” claim)
-- [ ] Path C deferred explicitly
-- [ ] Does not block S4 if only the guide ships
+- [x] Research note updated with spike-time pin + gap tables
+- [x] Public guide published (`docs/integrations/nemo-agent-toolkit.md`) with honest auth/transport limits
+- [x] Either: Path A runnable example **or** written blocker + follow-up issue/backlog pointer (no fake “native support” claim)
+- [x] Path C deferred explicitly
+- [x] Does not block S4 if only the guide ships
 
 ## Relevant files
 
-### New
+### New / shipped
 
-- `docs/integrations/nemo-agent-toolkit.md`
-- `examples/nemo_agent_toolkit_asap/` (if Path A proceeds)
-- Updates to [research-nemo-agent-toolkit.md](./research-nemo-agent-toolkit.md)
+| Path | Role |
+|------|------|
+| [`docs/integrations/nemo-agent-toolkit.md`](../../../docs/integrations/nemo-agent-toolkit.md) | Public interop guide (2c.4) + Path C appendix (2c.5) |
+| [`examples/nemo_agent_toolkit_asap/`](../../../examples/nemo_agent_toolkit_asap/) | Path A stdio demo (2c.3) |
+| [`tests/examples/test_nemo_agent_toolkit_asap.py`](../../../tests/examples/test_nemo_agent_toolkit_asap.py) | ASAP-side smoke; NAT optional skip (2c.6) |
+| [research-nemo-agent-toolkit.md](./research-nemo-agent-toolkit.md) | Pin, §10 gap analysis, §6 Path C |
 
 ### Reference
 
 - `examples/mcp_auth_bridge/`
 - `docs/adapters/mcp-auth-bridge.md`
+- [backlog-mcp-auth-typescript.md](../v2.5.0/backlog-mcp-auth-typescript.md) — HTTP/streamable-http follow-up
 - Upstream: `examples/MCP/simple_calculator_mcp_protected/`, `examples/A2A/math_assistant_a2a_protected/`
+
+## Reviews
+
+| Date | Tier | Verdict | Report |
+|------|------|---------|--------|
+| 2026-07-13 | T3 | Approved with caveats | [review-v2.5.3-S1b-S1c-spikes-20260713.md](../../code-review/private/review-v2.5.3-S1b-S1c-spikes-20260713.md) |

--- a/engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md
+++ b/engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md
@@ -18,8 +18,8 @@ Based on [PRD v2.5.3 Adapter Lab II](../../../product/prd/prd-v2.5.3-adapter-lab
 |--------|-------|-----|----------|--------|
 | **S0** | [Candidate lock & demand check](./sprint-S0-candidate-lock.md) | D1–D7, §6 gates | P0 | Done |
 | **S1** | [Workflow prototype (primary)](./sprint-S1-workflow-prototype.md) | LAB2-001, LAB2-002 | P0 | Done |
-| **S1b** | [Conditional SK / .NET spike](./sprint-S1b-semantic-kernel.md) | D2 | P0 if gate | Skipped (D2 no-go) |
-| **S1c** | [NeMo Agent Toolkit spike](./sprint-S1c-nemo-agent-toolkit.md) | D7 | P0 planned | Planned (D7 go) |
+| **S1b** | [Conditional SK / .NET spike](./sprint-S1b-semantic-kernel.md) | D2 | P0 if gate | Done (guide-only; 2b.3 skipped) |
+| **S1c** | [NeMo Agent Toolkit spike](./sprint-S1c-nemo-agent-toolkit.md) | D7 | P0 planned | Done |
 | **S2** | [Security guide & MCP patterns](./sprint-S2-security-docs.md) | LAB2-003, LAB2-006 | P0 | Planned |
 | **S3** | [Docs review, site routing & learnings](./sprint-S3-docs-review.md) | LAB2-004, LAB2-005 + docs surface | P0 | Planned |
 | **S4** | [Release v2.5.3](./sprint-S4-release.md) | DoD, metrics | P0 | Planned |
@@ -40,7 +40,7 @@ S0 (candidate lock)
                                             S4 (release)
 ```
 
-S1b / S1c never block S1/S2/S3/S4. If D2 fails, skip S1b. S1c defaults to **go** (D7); skip only with explicit maintainer no-go in the demand sheet.
+S1b / S1c never block S1/S2/S3/S4. S0 D2 was **no-go** on demand; **maintainer override (2026-07-13)** reopened S1b (guide-only). S1c defaults to **go** (D7); skip only with explicit maintainer no-go in the demand sheet. Combined spike branch: `feat/v2.5.3-s1b-s1c-spikes`.
 
 ## Parent tasks (high-level)
 
@@ -65,23 +65,24 @@ S1b / S1c never block S1/S2/S3/S4. If D2 fails, skip S1b. S1c defaults to **go**
     - [x] No protocol fork; transport lint clean
     - [x] LAB2-001 / LAB2-002 satisfied for the primary
 
-- [ ] **2b.0 Conditional Semantic Kernel spike (S1b)**
-  - **Trigger:** S0 D2 gate pass.
+- [x] **2b.0 Conditional Semantic Kernel spike (S1b)**
+  - **Trigger:** S0 D2 was no-go on demand; **maintainer override (2026-07-13)** reopened S1b for a research/experimental guide.
   - **Enables:** Optional second public guide; does not block release if incomplete.
-  - **Depends on:** Task 1.0 go decision.
+  - **Depends on:** Task 1.0; [demand-sheet.md](./demand-sheet.md) override; [research-semantic-kernel.md](./research-semantic-kernel.md).
   - **Acceptance criteria:**
-    - [ ] Interop note + .NET/guide path documented
-    - [ ] Explicit “maintained vs research” status in the guide
+    - [x] Interop note + .NET/guide path documented (`docs/integrations/microsoft-agent-framework.md`)
+    - [x] Explicit “maintained vs research” status in the guide
+  - **Note:** 2b.3 C# sample **skipped / N/A** (guide-only per 2b.1). MkDocs nav/index deferred to S3.
 
-- [ ] **2c.0 NeMo Agent Toolkit spike (S1c)**
+- [x] **2c.0 NeMo Agent Toolkit spike (S1c)**
   - **Trigger:** S0 D7 default go (or explicit no-go skip).
   - **Enables:** NVIDIA-stack guide + optional MCP bridge demo; feeds v2.5.5 Agent Card mapping.
   - **Depends on:** Task 1.0; [research-nemo-agent-toolkit.md](./research-nemo-agent-toolkit.md).
   - **Acceptance criteria:**
-    - [ ] Research pin refreshed; auth/transport gap tables written
-    - [ ] `docs/integrations/nemo-agent-toolkit.md` published (honest limits)
-    - [ ] Path A demo **or** documented blocker + follow-up (no fake native claim)
-    - [ ] Third-party NAT plugin deferred (Path C)
+    - [x] Research pin refreshed; auth/transport gap tables written
+    - [x] `docs/integrations/nemo-agent-toolkit.md` published (honest limits)
+    - [x] Path A demo **or** documented blocker + follow-up (no fake native claim)
+    - [x] Third-party NAT plugin deferred (Path C)
 
 - [ ] **3.0 Security & MCP docs (S2)**
   - **Trigger:** S1 example shape known.
@@ -142,9 +143,10 @@ S1b / S1c never block S1/S2/S3/S4. If D2 fails, skip S1b. S1c defaults to **go**
 - `docs/guides/automation-connector-security.md` — LAB2-003
 - `engineering/tasks/v2.5.3/learnings-open-vs-hosted.md` — LAB2-005
 - [docs-review-checklist.md](./docs-review-checklist.md) — S3 nav/index/cross-link gate
-- Optional: `docs/integrations/semantic-kernel.md` — only if S1b runs
+- Optional: `docs/integrations/microsoft-agent-framework.md` — S1b (guide-only; see research note)
 - Optional: `docs/integrations/nemo-agent-toolkit.md` + `examples/nemo_agent_toolkit_asap/` — S1c
 - [research-nemo-agent-toolkit.md](./research-nemo-agent-toolkit.md) — upstream map for S1c
+- [research-semantic-kernel.md](./research-semantic-kernel.md) — S1b naming + guide-only lock
 
 ### Likely modify
 
@@ -170,3 +172,5 @@ S1b / S1c never block S1/S2/S3/S4. If D2 fails, skip S1b. S1c defaults to **go**
 | 2026-07-12 | **S3 docs review**: [sprint-S3-docs-review.md](./sprint-S3-docs-review.md) + [docs-review-checklist.md](./docs-review-checklist.md); replaces S3 site-learnings-only |
 | 2026-07-13 | **S0 Done**: [demand-sheet.md](./demand-sheet.md); D1 workflow primary (no swap); D2 S1b skipped; D7 S1c planned; kickoff ACTIVE |
 | 2026-07-13 | **S1 Done**: workflow example + [workflow-connectors.md](../../../docs/integrations/workflow-connectors.md); MkDocs nav deferred to S3 |
+| 2026-07-13 | **S1b Done**: MAF guide-only ([microsoft-agent-framework.md](../../../docs/integrations/microsoft-agent-framework.md)); 2b.3 C# sample skipped/N/A |
+| 2026-07-13 | **S1c Done**: Path A example + [nemo-agent-toolkit.md](../../../docs/integrations/nemo-agent-toolkit.md); Path C out of ship; NAT optional in CI |

--- a/engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md
+++ b/engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md
@@ -1,6 +1,6 @@
 # Tasks: v2.5.3 Adapter Lab II — Sprint Index
 
-**Status: ACTIVE (kickoff started 2026-07-13)** — `release/2.5.3` on origin; working branch `feat/v2.5.3-s0-s1-workflow`. Demand sheet: [demand-sheet.md](./demand-sheet.md).
+**Status: ACTIVE (kickoff started 2026-07-13)** — `release/2.5.3` on origin; current spike branch `feat/v2.5.3-s1b-s1c-spikes` (S0+S1 merged via `feat/v2.5.3-s0-s1-workflow`). Demand sheet: [demand-sheet.md](./demand-sheet.md).
 
 Based on [PRD v2.5.3 Adapter Lab II](../../../product/prd/prd-v2.5.3-adapter-lab-ii.md). Each sprint merges into **`release/2.5.3`** (see [BRANCHING.md](./BRANCHING.md)); merge to `main` only after S4.
 

--- a/examples/nemo_agent_toolkit_asap/.env.example
+++ b/examples/nemo_agent_toolkit_asap/.env.example
@@ -1,0 +1,7 @@
+# Optional — only for full `nat run` react_agent path (not required for ASAP-side smoke).
+# Copy to .env locally; never commit real secrets.
+#
+# NVIDIA_API_KEY=
+
+# Dev-only ASAP Agent JWT override (normally asap_mcp_server.py mints and injects this).
+# ASAP_AGENT_JWT=

--- a/examples/nemo_agent_toolkit_asap/README.md
+++ b/examples/nemo_agent_toolkit_asap/README.md
@@ -1,0 +1,133 @@
+# NeMo Agent Toolkit ↔ ASAP (Path A) — experimental local demo
+
+**Status:** experimental / maintainer-reproducible spike (ASAP v2.5.3 S1c Path A).  
+**Not** a production integration and **not** published as an NVIDIA NAT plugin.
+
+## What this proves
+
+| Layer | Behavior |
+|-------|----------|
+| Transport | NAT `mcp_client` **stdio** → ASAP `protect_server` stdio (`asap_mcp_server.py`) |
+| Tools | Public `echo`; protected `secure_action` (grant + Agent JWT) |
+| Auth carriage | NAT does **not** send `_meta.asap_agent_jwt`. The ASAP child **mints** a demo Agent JWT and sets `ASAP_AGENT_JWT` (`allow_env_jwt_fallback=True`, same idea as `examples/mcp_auth_bridge/`) |
+
+## Honest auth note
+
+- **Dev-only env JWT fallback.** Suitable for a single-agent local demo.
+- **Not** production Host/Agent JWT minting or multi-tenant isolation.
+- **NAT OAuth2 / Keycloak / `mcp_oauth2` ≠ ASAP Agent JWT + capability grants.** Do not wire Keycloak for this example.
+- Streamable-http / HTTP MCP Auth Bridge is **out of scope** here — see [backlog-mcp-auth-typescript.md](../../engineering/tasks/v2.5.0/backlog-mcp-auth-typescript.md).
+- `asap_mcp_server.py` routes ASAP structlog to **stderr** before `run_stdio`. With `ASAP_AGENT_JWT` set, auth log lines would otherwise land on **stdout** and corrupt MCP JSON-RPC (breaks NAT `mcp_client` / ASAP `MCPClient`).
+
+Research decision: [research-nemo-agent-toolkit.md](../../engineering/tasks/v2.5.3/research-nemo-agent-toolkit.md) §10.3.
+
+## Prerequisites
+
+- **Python 3.13** only for the joint example (ASAP ∩ `nvidia-nat` 1.8.x)
+- [uv](https://github.com/astral-sh/uv)
+- ASAP repo checkout with dependencies:
+
+```bash
+uv sync
+```
+
+Optional (full NAT workflow only):
+
+```bash
+uv pip install -r examples/nemo_agent_toolkit_asap/requirements.txt
+```
+
+Pin: **`nvidia-nat[mcp]==1.8.0`** (optional path; **not** a required ASAP core dep). The `a2a` extra is not required for Path A.
+
+**NIM / `NVIDIA_API_KEY`:** only needed for `nat run` with the sample `react_agent` YAML. Prefer the **ASAP-side smoke** below (no LLM).
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `asap_mcp_server.py` | Stdio MCP server; reuses `examples/mcp_auth_bridge/`; injects `ASAP_AGENT_JWT` |
+| `smoke_asap_side.py` | Headless ASAP proof (no `nvidia-nat`) |
+| `configs/config-mcp-client-stdio.yml` | NAT `mcp_client` stdio → ASAP server |
+| `requirements.txt` | Optional NAT pin |
+| `.env.example` | Placeholders only |
+| `run_demo.sh` | Launcher: ASAP smoke, optional `nat run` |
+
+## Commands
+
+### 1. ASAP-side smoke (recommended happy path — no NAT, no NIM)
+
+From the repository root:
+
+```bash
+uv run python examples/nemo_agent_toolkit_asap/smoke_asap_side.py
+```
+
+Includes stdio subprocess (server injects JWT; client calls without `_meta`):
+
+```bash
+uv run python examples/nemo_agent_toolkit_asap/smoke_asap_side.py --stdio
+```
+
+Or:
+
+```bash
+./examples/nemo_agent_toolkit_asap/run_demo.sh smoke
+./examples/nemo_agent_toolkit_asap/run_demo.sh smoke-stdio
+```
+
+Pytest (always runs ASAP side; does not require `nvidia-nat`):
+
+```bash
+uv run pytest tests/examples/test_nemo_agent_toolkit_asap.py -v
+```
+
+### 2. Run the ASAP stdio server alone
+
+```bash
+uv run python examples/nemo_agent_toolkit_asap/asap_mcp_server.py
+```
+
+Negative control (no env JWT injection — protected calls need `_meta` or a pre-set env):
+
+```bash
+uv run python examples/nemo_agent_toolkit_asap/asap_mcp_server.py --no-env-jwt
+```
+
+### 3. Full NAT path (optional — requires NIM)
+
+Install NAT, set `NVIDIA_API_KEY`, run from **repo root** so `uv run python examples/...` resolves:
+
+```bash
+uv pip install -r examples/nemo_agent_toolkit_asap/requirements.txt
+export NVIDIA_API_KEY='your-key'   # never commit
+nat run --config_file examples/nemo_agent_toolkit_asap/configs/config-mcp-client-stdio.yml \
+  --input "Call echo with message hello, then secure_action with action demo"
+```
+
+Or:
+
+```bash
+./examples/nemo_agent_toolkit_asap/run_demo.sh nat
+```
+
+If `nat` is missing, the script exits with a clear skip message (does not fail ASAP CI).
+
+## Negative path
+
+| Condition | Expected |
+|-----------|----------|
+| `secure_action` without JWT (no env, no `_meta`) | `asap:auth_required` |
+| Valid JWT but no grant / wrong capability | `asap:capability_denied` (see mcp_auth_bridge docs) |
+
+Smoke covers the auth_required case. Grant denial semantics: [docs/adapters/mcp-auth-bridge.md](../../docs/adapters/mcp-auth-bridge.md).
+
+## HTTP / streamable-http gap
+
+ASAP `protect_server` is **stdio Mode A**. NAT OAuth examples use **streamable-http**. Bridging those without inventing a protocol fork is deferred — pointer: [engineering/tasks/v2.5.0/backlog-mcp-auth-typescript.md](../../engineering/tasks/v2.5.0/backlog-mcp-auth-typescript.md).
+
+## Related
+
+- Public interop guide: [`docs/integrations/nemo-agent-toolkit.md`](../../docs/integrations/nemo-agent-toolkit.md)
+- Reference server/client: [`examples/mcp_auth_bridge/`](../mcp_auth_bridge/)
+- Adapter guide: [`docs/adapters/mcp-auth-bridge.md`](../../docs/adapters/mcp-auth-bridge.md)
+- Sprint: [`engineering/tasks/v2.5.3/sprint-S1c-nemo-agent-toolkit.md`](../../engineering/tasks/v2.5.3/sprint-S1c-nemo-agent-toolkit.md)

--- a/examples/nemo_agent_toolkit_asap/asap_mcp_server.py
+++ b/examples/nemo_agent_toolkit_asap/asap_mcp_server.py
@@ -1,0 +1,164 @@
+"""ASAP protected MCP stdio server for NeMo Agent Toolkit Path A (v2.5.3 S1c).
+
+Reuses ``examples/mcp_auth_bridge/server.py`` (echo + secure_action + protect_server)
+and injects the minted demo Agent JWT into ``ASAP_AGENT_JWT`` so NAT ``mcp_client``
+(stdio) can call protected tools without ``_meta.asap_agent_jwt``.
+
+NAT will not send ASAP ``_meta``; this is a **dev-only** env fallback
+(``allow_env_jwt_fallback=True``). Do not deploy unchanged.
+
+Run (from repo root)::
+
+    uv run python examples/nemo_agent_toolkit_asap/asap_mcp_server.py
+
+Negative path (no env JWT)::
+
+    uv run python examples/nemo_agent_toolkit_asap/asap_mcp_server.py --no-env-jwt
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import logging
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from asap.observability.logging import configure_logging
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MCP_AUTH_BRIDGE_SERVER = _REPO_ROOT / "examples" / "mcp_auth_bridge" / "server.py"
+_ENV_JWT_KEY = "ASAP_AGENT_JWT"
+
+
+def route_observability_logs_to_stderr() -> None:
+    """Send ASAP structlog to stderr so MCP stdout stays JSON-RPC-only.
+
+    Provenance (S1c Path A): with ``ASAP_AGENT_JWT`` set, ``ProtectedMCPServer``
+    emits ``mcp.tool.public_jwt_ignored`` / ``mcp.tool.authorized`` via the default
+    ``StreamHandler(sys.stdout)``. Those lines break NAT ``mcp_client`` and ASAP
+    ``MCPClient`` parsers on the next ``tools/call``.
+
+    Example:
+        route_observability_logs_to_stderr()
+        await server.run_stdio()
+    """
+    configure_logging(force=True)
+    root = logging.getLogger()
+    formatter = root.handlers[0].formatter if root.handlers else None
+    root.handlers.clear()
+    handler = logging.StreamHandler(sys.stderr)
+    if formatter is not None:
+        handler.setFormatter(formatter)
+    root.addHandler(handler)
+
+
+def _load_mcp_auth_bridge_server() -> ModuleType:
+    """Import the mcp_auth_bridge example server module by file path.
+
+    Example:
+        module = _load_mcp_auth_bridge_server()
+        server, identity = await module.build_protected_server()
+    """
+    if not _MCP_AUTH_BRIDGE_SERVER.is_file():
+        raise FileNotFoundError(
+            f"mcp_auth_bridge server missing: expected {_MCP_AUTH_BRIDGE_SERVER}, "
+            "got missing file (run from ASAP repo checkout)",
+        )
+    spec = importlib.util.spec_from_file_location(
+        "mcp_auth_bridge_server_for_nat",
+        _MCP_AUTH_BRIDGE_SERVER,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(
+            f"cannot load mcp_auth_bridge server from {_MCP_AUTH_BRIDGE_SERVER!s}",
+        )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def inject_demo_jwt_env(demo_jwt: str) -> None:
+    """Put the minted demo JWT into the process env for ``allow_env_jwt_fallback``.
+
+    Args:
+        demo_jwt: Agent JWT string minted by the mcp_auth_bridge demo.
+
+    Example:
+        inject_demo_jwt_env(identity.demo_jwt)
+    """
+    if not demo_jwt or not isinstance(demo_jwt, str):
+        raise ValueError(
+            f"demo_jwt must be a non-empty str, got {type(demo_jwt).__name__}: {demo_jwt!r}",
+        )
+    os.environ[_ENV_JWT_KEY] = demo_jwt
+
+
+async def build_and_prepare_server(
+    *,
+    inject_env_jwt: bool = True,
+) -> tuple[Any, Any]:
+    """Build the protected MCP server and optionally inject ``ASAP_AGENT_JWT``.
+
+    Args:
+        inject_env_jwt: When True (default), set ``ASAP_AGENT_JWT`` from the
+            minted demo token so NAT stdio clients need no ``_meta``.
+
+    Returns:
+        ``(protected_server, demo_identity)`` from mcp_auth_bridge.
+
+    Example:
+        server, identity = await build_and_prepare_server(inject_env_jwt=True)
+    """
+    module = _load_mcp_auth_bridge_server()
+    server, identity = await module.build_protected_server()
+    if inject_env_jwt:
+        inject_demo_jwt_env(identity.demo_jwt)
+        print(
+            f"WARNING: {_ENV_JWT_KEY} injected for NAT Path A (dev-only env JWT fallback). "
+            "Not production. NAT OAuth2/Keycloak is not used.",
+            file=sys.stderr,
+            flush=True,
+        )
+    else:
+        print(
+            f"WARNING: --no-env-jwt: {_ENV_JWT_KEY} not injected. "
+            "Protected tools require _meta.asap_agent_jwt or a pre-set env JWT.",
+            file=sys.stderr,
+            flush=True,
+        )
+    module._print_startup_instructions(identity)
+    return server, identity
+
+
+async def _run_stdio(*, inject_env_jwt: bool) -> None:
+    """Start the protected MCP server on stdio."""
+    route_observability_logs_to_stderr()
+    server, _identity = await build_and_prepare_server(inject_env_jwt=inject_env_jwt)
+    await server.run_stdio()
+
+
+def main() -> None:
+    """Parse CLI args and run the ASAP protected MCP server for NAT Path A."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "ASAP MCP Auth Bridge stdio server for NeMo Agent Toolkit Path A "
+            "(env JWT fallback for NAT mcp_client)"
+        ),
+    )
+    parser.add_argument(
+        "--no-env-jwt",
+        action="store_true",
+        help=(f"Do not inject minted demo JWT into {_ENV_JWT_KEY} (negative path / require _meta)"),
+    )
+    args = parser.parse_args()
+    asyncio.run(_run_stdio(inject_env_jwt=not args.no_env_jwt))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/nemo_agent_toolkit_asap/asap_mcp_server.py
+++ b/examples/nemo_agent_toolkit_asap/asap_mcp_server.py
@@ -99,15 +99,60 @@ def inject_demo_jwt_env(demo_jwt: str) -> None:
     os.environ[_ENV_JWT_KEY] = demo_jwt
 
 
+def _print_path_a_startup_banner(identity: Any, *, inject_env_jwt: bool) -> None:
+    """Print Path A warnings on stderr without dumping the minted JWT.
+
+    Provenance (PR #289 review): the mcp_auth_bridge helper
+    ``_print_startup_instructions`` prints the live Agent JWT. Calling it from
+    ``build_and_prepare_server`` leaked tokens into pytest/smoke captured stderr
+    (and into CI logs when assertions concatenate stderr). Keep a local banner
+    for interactive stdio only — never print ``identity.demo_jwt``.
+
+    Args:
+        identity: Demo identity from mcp_auth_bridge (agent_id for operators).
+        inject_env_jwt: Whether this process injects ``ASAP_AGENT_JWT``.
+    """
+    agent_id = getattr(
+        getattr(identity, "agent_session", None),
+        "agent_id",
+        "<unknown>",
+    )
+    if inject_env_jwt:
+        print(
+            f"WARNING: {_ENV_JWT_KEY} injected for NAT Path A (dev-only env JWT fallback). "
+            "Do not deploy / do not use in multi-tenant production. "
+            "NAT OAuth2/Keycloak is not used.",
+            file=sys.stderr,
+            flush=True,
+        )
+    else:
+        print(
+            f"WARNING: --no-env-jwt: {_ENV_JWT_KEY} not injected. "
+            "Protected tools require _meta.asap_agent_jwt or a pre-set env JWT.",
+            file=sys.stderr,
+            flush=True,
+        )
+    print(
+        f"ASAP Path A MCP server ready (agent_id={agent_id}). "
+        "Demo JWT is held in-process only — not printed.",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
 async def build_and_prepare_server(
     *,
     inject_env_jwt: bool = True,
+    print_instructions: bool = False,
 ) -> tuple[Any, Any]:
     """Build the protected MCP server and optionally inject ``ASAP_AGENT_JWT``.
 
     Args:
         inject_env_jwt: When True (default), set ``ASAP_AGENT_JWT`` from the
             minted demo token so NAT stdio clients need no ``_meta``.
+        print_instructions: When True, print a stderr banner (stdio ``main`` /
+            ``_run_stdio`` only). Default False so in-process pytest/smoke do
+            not dump operator noise or risk leaking tokens into CI logs.
 
     Returns:
         ``(protected_server, demo_identity)`` from mcp_auth_bridge.
@@ -119,27 +164,18 @@ async def build_and_prepare_server(
     server, identity = await module.build_protected_server()
     if inject_env_jwt:
         inject_demo_jwt_env(identity.demo_jwt)
-        print(
-            f"WARNING: {_ENV_JWT_KEY} injected for NAT Path A (dev-only env JWT fallback). "
-            "Not production. NAT OAuth2/Keycloak is not used.",
-            file=sys.stderr,
-            flush=True,
-        )
-    else:
-        print(
-            f"WARNING: --no-env-jwt: {_ENV_JWT_KEY} not injected. "
-            "Protected tools require _meta.asap_agent_jwt or a pre-set env JWT.",
-            file=sys.stderr,
-            flush=True,
-        )
-    module._print_startup_instructions(identity)
+    if print_instructions:
+        _print_path_a_startup_banner(identity, inject_env_jwt=inject_env_jwt)
     return server, identity
 
 
 async def _run_stdio(*, inject_env_jwt: bool) -> None:
     """Start the protected MCP server on stdio."""
     route_observability_logs_to_stderr()
-    server, _identity = await build_and_prepare_server(inject_env_jwt=inject_env_jwt)
+    server, _identity = await build_and_prepare_server(
+        inject_env_jwt=inject_env_jwt,
+        print_instructions=True,
+    )
     await server.run_stdio()
 
 

--- a/examples/nemo_agent_toolkit_asap/configs/config-mcp-client-stdio.yml
+++ b/examples/nemo_agent_toolkit_asap/configs/config-mcp-client-stdio.yml
@@ -1,0 +1,61 @@
+# NeMo Agent Toolkit ↔ ASAP Path A (experimental / local demo)
+#
+# NAT mcp_client (stdio) → ASAP protect_server (examples/nemo_agent_toolkit_asap/asap_mcp_server.py)
+#
+# Auth honesty:
+# - NAT does NOT send _meta.asap_agent_jwt
+# - ASAP child injects ASAP_AGENT_JWT at startup (dev-only allow_env_jwt_fallback)
+# - This is NOT NAT OAuth2 / Keycloak / mcp_oauth2
+#
+# Pin: nvidia-nat[mcp]==1.8.0, Python 3.13
+# Upstream pattern: NVIDIA/NeMo-Agent-Toolkit@v1.8.0 examples/MCP/simple_calculator_mcp
+#
+# Prerequisites (repo root):
+#   uv sync
+#   uv pip install 'nvidia-nat[mcp]==1.8.0'   # or: pip install -r examples/nemo_agent_toolkit_asap/requirements.txt
+#
+# ASAP-side smoke (no NAT / no NIM):
+#   uv run python examples/nemo_agent_toolkit_asap/smoke_asap_side.py --stdio
+#
+# Full NAT path (requires NIM / NVIDIA_API_KEY for react_agent):
+#   nat run --config_file examples/nemo_agent_toolkit_asap/configs/config-mcp-client-stdio.yml \
+#     --input "Call echo with message hello, then secure_action with action demo"
+
+function_groups:
+  asap_mcp:
+    _type: mcp_client
+    server:
+      transport: stdio
+      # Prefer `uv run` so the child uses the ASAP repo environment.
+      command: "uv"
+      args:
+        - "run"
+        - "python"
+        - "examples/nemo_agent_toolkit_asap/asap_mcp_server.py"
+      # Working directory must be the ASAP repo root when using relative args.
+      # If you launch `nat run` from another cwd, switch args to an absolute path
+      # or set env PYTHONPATH / use a wrapper script.
+    # Optional: restrict to known tools
+    # include:
+    #   - echo
+    #   - secure_action
+
+llms:
+  # Optional for full `nat run` react_agent path. Prefer ASAP smoke without NIM.
+  # Set NVIDIA_API_KEY in the environment when using NIM.
+  nim_llm:
+    _type: nim
+    model_name: nvidia/nemotron-3-nano-30b-a3b
+    temperature: 0.0
+    max_tokens: 1024
+    chat_template_kwargs:
+      enable_thinking: false
+
+workflow:
+  _type: react_agent
+  tool_names:
+    - asap_mcp
+  llm_name: nim_llm
+  verbose: true
+  retry_parsing_errors: true
+  max_retries: 3

--- a/examples/nemo_agent_toolkit_asap/requirements.txt
+++ b/examples/nemo_agent_toolkit_asap/requirements.txt
@@ -1,0 +1,6 @@
+# Optional NeMo Agent Toolkit pin for Path A (stdio mcp_client → ASAP protect_server).
+# Do NOT add this to the main ASAP pyproject required dependencies.
+# Install from repo root: uv pip install -r examples/nemo_agent_toolkit_asap/requirements.txt
+#
+# Python: 3.13 only for this joint example (intersection with ASAP).
+nvidia-nat[mcp]==1.8.0

--- a/examples/nemo_agent_toolkit_asap/run_demo.sh
+++ b/examples/nemo_agent_toolkit_asap/run_demo.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Launcher for NeMo Agent Toolkit ↔ ASAP Path A demo (v2.5.3 S1c).
+# Usage (from anywhere):
+#   ./examples/nemo_agent_toolkit_asap/run_demo.sh smoke|smoke-stdio|nat|help
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+usage() {
+  cat <<'EOF'
+Usage: run_demo.sh <command>
+
+  smoke         ASAP-side in-process smoke (no nvidia-nat, no NIM)
+  smoke-stdio   ASAP-side smoke + stdio MCPClient subprocess
+  nat           Run nat with configs/config-mcp-client-stdio.yml (needs nvidia-nat + NIM)
+  help          Show this help
+
+Examples:
+  ./examples/nemo_agent_toolkit_asap/run_demo.sh smoke
+  ./examples/nemo_agent_toolkit_asap/run_demo.sh smoke-stdio
+  NVIDIA_API_KEY=... ./examples/nemo_agent_toolkit_asap/run_demo.sh nat
+EOF
+}
+
+cmd="${1:-help}"
+
+case "${cmd}" in
+  smoke)
+    exec uv run python examples/nemo_agent_toolkit_asap/smoke_asap_side.py
+    ;;
+  smoke-stdio)
+    exec uv run python examples/nemo_agent_toolkit_asap/smoke_asap_side.py --stdio
+    ;;
+  nat)
+    if ! command -v nat >/dev/null 2>&1; then
+      echo "SKIP: 'nat' CLI not found. Install optional pin:" >&2
+      echo "  uv pip install -r examples/nemo_agent_toolkit_asap/requirements.txt" >&2
+      echo "ASAP-side smoke does not need NAT: ./examples/nemo_agent_toolkit_asap/run_demo.sh smoke" >&2
+      exit 0
+    fi
+    if [[ -z "${NVIDIA_API_KEY:-}" ]]; then
+      echo "WARNING: NVIDIA_API_KEY unset — NIM react_agent will likely fail." >&2
+      echo "Prefer ASAP smoke without NIM: ./examples/nemo_agent_toolkit_asap/run_demo.sh smoke" >&2
+    fi
+    exec nat run \
+      --config_file examples/nemo_agent_toolkit_asap/configs/config-mcp-client-stdio.yml \
+      --input "${NAT_INPUT:-Call echo with message hello, then secure_action with action demo}"
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    echo "Unknown command: ${cmd}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/examples/nemo_agent_toolkit_asap/smoke_asap_side.py
+++ b/examples/nemo_agent_toolkit_asap/smoke_asap_side.py
@@ -1,0 +1,172 @@
+"""ASAP-side smoke for NeMo Agent Toolkit Path A (no nvidia-nat required).
+
+Validates protect_server + env JWT fallback in-process, then optionally exercises
+stdio via the mcp_auth_bridge-style client patterns.
+
+Exit codes:
+    0 — all checks passed
+    1 — assertion / auth failure
+    2 — usage / import error
+
+Run from repo root::
+
+    uv run python examples/nemo_agent_toolkit_asap/smoke_asap_side.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+_EXAMPLE_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _EXAMPLE_DIR.parents[1]
+_SERVER_SCRIPT = _EXAMPLE_DIR / "asap_mcp_server.py"
+
+
+def _load_asap_mcp_server() -> ModuleType:
+    """Import ``asap_mcp_server`` from this example directory."""
+    spec = importlib.util.spec_from_file_location(
+        "nemo_asap_mcp_server_smoke",
+        _SERVER_SCRIPT,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {_SERVER_SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _text_from_call_result(result: dict[str, Any]) -> str:
+    """Extract concatenated text blocks from an MCP CallToolResult dict."""
+    parts: list[str] = []
+    for block in result.get("content", []):
+        if isinstance(block, dict) and block.get("type") == "text":
+            parts.append(str(block.get("text", "")))
+    return "".join(parts)
+
+
+async def run_inprocess_smoke() -> None:
+    """Prove public echo, auth_required without JWT, and env JWT happy path.
+
+    Example:
+        await run_inprocess_smoke()
+    """
+    from asap.mcp.auth.errors import AUTH_REQUIRED
+
+    module = _load_asap_mcp_server()
+
+    # Negative: no env JWT, no _meta → asap:auth_required
+    os.environ.pop("ASAP_AGENT_JWT", None)
+    server_neg, _identity_neg = await module.build_and_prepare_server(
+        inject_env_jwt=False,
+    )
+    denied = await server_neg._handle_tools_call(
+        {"name": "secure_action", "arguments": {"action": "denied"}},
+    )
+    if denied.get("isError") is not True:
+        raise AssertionError(
+            f"expected secure_action without JWT to error, got {denied!r}",
+        )
+    denied_text = _text_from_call_result(denied)
+    if AUTH_REQUIRED not in denied_text:
+        raise AssertionError(
+            f"expected {AUTH_REQUIRED!r} in error text, got {denied_text!r}",
+        )
+    print("OK: secure_action without JWT → asap:auth_required")
+
+    # Happy: inject env JWT (NAT Path A carriage)
+    server, identity = await module.build_and_prepare_server(inject_env_jwt=True)
+    echo = await server._handle_tools_call(
+        {"name": "echo", "arguments": {"message": "nat-path-a"}},
+    )
+    if echo.get("isError") is True:
+        raise AssertionError(f"echo failed: {echo!r}")
+    echo_text = _text_from_call_result(echo)
+    if "nat-path-a" not in echo_text:
+        raise AssertionError(f"echo missing payload, got {echo_text!r}")
+    print("OK: echo (public) succeeded")
+
+    secure = await server._handle_tools_call(
+        {"name": "secure_action", "arguments": {"action": "path-a"}},
+    )
+    if secure.get("isError") is True:
+        raise AssertionError(
+            f"secure_action with env JWT failed: {_text_from_call_result(secure)!r}",
+        )
+    secure_text = _text_from_call_result(secure)
+    if "executed: path-a" not in secure_text:
+        raise AssertionError(f"secure_action unexpected result: {secure_text!r}")
+    print("OK: secure_action with ASAP_AGENT_JWT env fallback succeeded")
+    print(f"OK: demo agent_id={identity.agent_session.agent_id}")
+
+
+async def run_stdio_client_smoke() -> None:
+    """Subprocess stdio smoke: spawn asap_mcp_server and call tools via MCPClient.
+
+    Example:
+        await run_stdio_client_smoke()
+    """
+    from asap.mcp.client import MCPClient
+
+    server_command = [sys.executable, str(_SERVER_SCRIPT)]
+    client = MCPClient(
+        server_command,
+        allowed_binaries=frozenset({os.path.basename(sys.executable)}),
+    )
+    async with client:
+        tools = await client.list_tools()
+        names = [t.name for t in tools]
+        if "echo" not in names or "secure_action" not in names:
+            raise AssertionError(f"expected echo+secure_action tools, got {names!r}")
+        print(f"OK: stdio tools/list → {names}")
+
+        # Server injects ASAP_AGENT_JWT; call without _meta (NAT behavior)
+        echo = await client.call_tool("echo", {"message": "stdio-smoke"})
+        if echo.is_error:
+            raise AssertionError(f"stdio echo failed: {echo.content!r}")
+        print("OK: stdio echo")
+
+        secure = await client.call_tool("secure_action", {"action": "stdio-smoke"})
+        if secure.is_error:
+            raise AssertionError(
+                f"stdio secure_action without _meta failed "
+                f"(env JWT should be injected by server): {secure.content!r}",
+            )
+        print("OK: stdio secure_action via server-injected ASAP_AGENT_JWT")
+
+
+def main() -> None:
+    """Run ASAP-side smoke checks (in-process always; stdio optional)."""
+    parser = argparse.ArgumentParser(
+        description="ASAP-side smoke for nemo_agent_toolkit_asap Path A",
+    )
+    parser.add_argument(
+        "--stdio",
+        action="store_true",
+        help="Also spawn asap_mcp_server over stdio and call tools via MCPClient",
+    )
+    args = parser.parse_args()
+    os.chdir(_REPO_ROOT)
+
+    async def _all() -> None:
+        await run_inprocess_smoke()
+        if args.stdio:
+            await run_stdio_client_smoke()
+
+    try:
+        asyncio.run(_all())
+    except Exception as exc:  # noqa: BLE001 — CLI smoke reports any failure
+        print(f"FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    print("ASAP-side Path A smoke passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/nemo_agent_toolkit_asap/smoke_asap_side.py
+++ b/examples/nemo_agent_toolkit_asap/smoke_asap_side.py
@@ -24,6 +24,9 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+from asap.mcp.auth.errors import AUTH_REQUIRED
+from asap.mcp.client import MCPClient
+
 _EXAMPLE_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = _EXAMPLE_DIR.parents[1]
 _SERVER_SCRIPT = _EXAMPLE_DIR / "asap_mcp_server.py"
@@ -58,8 +61,6 @@ async def run_inprocess_smoke() -> None:
     Example:
         await run_inprocess_smoke()
     """
-    from asap.mcp.auth.errors import AUTH_REQUIRED
-
     module = _load_asap_mcp_server()
 
     # Negative: no env JWT, no _meta → asap:auth_required
@@ -113,8 +114,6 @@ async def run_stdio_client_smoke() -> None:
     Example:
         await run_stdio_client_smoke()
     """
-    from asap.mcp.client import MCPClient
-
     server_command = [sys.executable, str(_SERVER_SCRIPT)]
     client = MCPClient(
         server_command,

--- a/tests/examples/test_nemo_agent_toolkit_asap.py
+++ b/tests/examples/test_nemo_agent_toolkit_asap.py
@@ -10,6 +10,7 @@ import importlib.util
 import os
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
 
@@ -27,15 +28,22 @@ _ENV_JWT_KEY = "ASAP_AGENT_JWT"
 
 
 @pytest.fixture(autouse=True)
-def _isolate_asap_agent_jwt_env(monkeypatch: MonkeyPatch) -> None:
+def _isolate_asap_agent_jwt_env() -> Iterator[None]:
     """Keep ``ASAP_AGENT_JWT`` from leaking across example tests.
 
-    Provenance (S1c C.7 / T3 review): ``build_and_prepare_server(inject_env_jwt=True)``
-    writes ``os.environ`` directly. Without isolation, reversed collection order
-    contaminates ``test_mcp_auth_bridge_example.py`` (stale JWT → bad_signature /
-    stdout JSON-RPC corruption when the sibling server inherits the env).
+    Provenance (S1c C.7 / T3 / PR #289): ``inject_demo_jwt_env`` writes
+    ``os.environ`` directly. ``monkeypatch.delenv`` alone is insufficient when the
+    key was already absent — pytest records no undo, so a later ``os.environ``
+    set survives teardown and contaminates ``test_mcp_auth_bridge_example.py``.
     """
-    monkeypatch.delenv(_ENV_JWT_KEY, raising=False)
+    previous = os.environ.pop(_ENV_JWT_KEY, None)
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(_ENV_JWT_KEY, None)
+        else:
+            os.environ[_ENV_JWT_KEY] = previous
 
 
 def _load_asap_mcp_server() -> ModuleType:
@@ -144,6 +152,35 @@ class TestNemoAsapMcpServer:
         )
         assert secure.get("isError") is not True
         assert "executed: granted" in str(secure["content"][0]["text"])
+
+    @pytest.mark.asyncio
+    async def test_inject_env_jwt_true_sets_env_without_printing_token(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``inject_env_jwt=True`` uses ``inject_demo_jwt_env``; no JWT on stderr.
+
+        Provenance (PR #289): covers the inject path in-process (smoke covers
+        subprocess). ``print_instructions`` defaults False so CI logs stay clean.
+        """
+        module = _load_asap_mcp_server()
+        server, identity = await module.build_and_prepare_server(
+            inject_env_jwt=True,
+            print_instructions=False,
+        )
+        assert os.environ.get(_ENV_JWT_KEY) == identity.demo_jwt
+
+        secure = await server._handle_tools_call(
+            {"name": "secure_action", "arguments": {"action": "inject-path"}},
+        )
+        assert secure.get("isError") is not True
+        assert "executed: inject-path" in str(secure["content"][0]["text"])
+
+        captured = capsys.readouterr()
+        assert identity.demo_jwt not in captured.err
+        assert identity.demo_jwt not in captured.out
+        assert "eyJ" not in captured.err
+        assert "eyJ" not in captured.out
 
     @pytest.mark.asyncio
     async def test_without_env_jwt_meta_still_works(

--- a/tests/examples/test_nemo_agent_toolkit_asap.py
+++ b/tests/examples/test_nemo_agent_toolkit_asap.py
@@ -1,0 +1,228 @@
+"""Smoke tests for examples/nemo_agent_toolkit_asap/ (S1c Path A).
+
+ASAP-side checks always run (no nvidia-nat). Optional NAT import is skipped
+when the optional extra is absent so main CI stays green.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from pytest import MonkeyPatch
+
+from asap.mcp.auth.errors import AUTH_REQUIRED
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLE_DIR = _REPO_ROOT / "examples" / "nemo_agent_toolkit_asap"
+_SERVER_SCRIPT = _EXAMPLE_DIR / "asap_mcp_server.py"
+_SMOKE_SCRIPT = _EXAMPLE_DIR / "smoke_asap_side.py"
+_CONFIG_YAML = _EXAMPLE_DIR / "configs" / "config-mcp-client-stdio.yml"
+_ENV_JWT_KEY = "ASAP_AGENT_JWT"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_asap_agent_jwt_env(monkeypatch: MonkeyPatch) -> None:
+    """Keep ``ASAP_AGENT_JWT`` from leaking across example tests.
+
+    Provenance (S1c C.7 / T3 review): ``build_and_prepare_server(inject_env_jwt=True)``
+    writes ``os.environ`` directly. Without isolation, reversed collection order
+    contaminates ``test_mcp_auth_bridge_example.py`` (stale JWT → bad_signature /
+    stdout JSON-RPC corruption when the sibling server inherits the env).
+    """
+    monkeypatch.delenv(_ENV_JWT_KEY, raising=False)
+
+
+def _load_asap_mcp_server() -> ModuleType:
+    """Import the Path A ASAP MCP server module from its file path."""
+    spec = importlib.util.spec_from_file_location(
+        "nemo_agent_toolkit_asap_mcp_server",
+        _SERVER_SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestNemoAsapExampleLayout:
+    """Filesystem / DX checks for the Path A example folder."""
+
+    def test_example_files_exist(self) -> None:
+        """Required Path A files are present."""
+        assert _SERVER_SCRIPT.is_file()
+        assert _SMOKE_SCRIPT.is_file()
+        assert _CONFIG_YAML.is_file()
+        assert (_EXAMPLE_DIR / "README.md").is_file()
+        assert (_EXAMPLE_DIR / ".env.example").is_file()
+        assert (_EXAMPLE_DIR / "requirements.txt").is_file()
+        assert (_EXAMPLE_DIR / "run_demo.sh").is_file()
+
+    def test_requirements_pin_mentions_nat_mcp(self) -> None:
+        """Optional requirements pin nvidia-nat[mcp]==1.8.0."""
+        text = (_EXAMPLE_DIR / "requirements.txt").read_text(encoding="utf-8")
+        assert "nvidia-nat[mcp]==1.8.0" in text
+
+    def test_yaml_is_stdio_mcp_client(self) -> None:
+        """NAT config uses mcp_client stdio pointing at asap_mcp_server."""
+        text = _CONFIG_YAML.read_text(encoding="utf-8")
+        assert "_type: mcp_client" in text
+        assert "transport: stdio" in text
+        assert "asap_mcp_server.py" in text
+        # No Keycloak / OAuth wiring in live config keys (comments may mention them)
+        live_lines = [
+            line for line in text.splitlines() if line.strip() and not line.lstrip().startswith("#")
+        ]
+        live = "\n".join(live_lines).lower()
+        assert "auth_provider" not in live
+        assert "keycloak" not in live
+        assert "mcp_oauth2" not in live
+
+
+class TestNemoAsapMcpServer:
+    """In-process ASAP Auth Bridge path for NAT Path A."""
+
+    def test_server_help_exits_zero(self) -> None:
+        """``--help`` exits 0 without starting stdio."""
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                str(_SERVER_SCRIPT.relative_to(_REPO_ROOT)),
+                "--help",
+            ],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "Path A" in result.stdout or "mcp_client" in result.stdout
+
+    @pytest.mark.asyncio
+    async def test_secure_action_without_jwt_auth_required(self) -> None:
+        """Protected tool without JWT returns ``asap:auth_required``."""
+        module = _load_asap_mcp_server()
+        server, _identity = await module.build_and_prepare_server(
+            inject_env_jwt=False,
+        )
+        result = await server._handle_tools_call(
+            {"name": "secure_action", "arguments": {"action": "test"}},
+        )
+        assert result["isError"] is True
+        assert AUTH_REQUIRED in str(result["content"][0]["text"])
+
+    @pytest.mark.asyncio
+    async def test_echo_and_env_jwt_happy_path(
+        self,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        """Public echo works; env JWT unlocks secure_action (NAT carriage)."""
+        module = _load_asap_mcp_server()
+        # Track JWT via monkeypatch (not raw os.environ) so teardown is reliable.
+        server, identity = await module.build_and_prepare_server(
+            inject_env_jwt=False,
+        )
+        monkeypatch.setenv(_ENV_JWT_KEY, identity.demo_jwt)
+        assert os.environ.get(_ENV_JWT_KEY) == identity.demo_jwt
+
+        echo = await server._handle_tools_call(
+            {"name": "echo", "arguments": {"message": "path-a"}},
+        )
+        assert echo.get("isError") is not True
+        assert "path-a" in str(echo["content"][0]["text"])
+
+        secure = await server._handle_tools_call(
+            {"name": "secure_action", "arguments": {"action": "granted"}},
+        )
+        assert secure.get("isError") is not True
+        assert "executed: granted" in str(secure["content"][0]["text"])
+
+    @pytest.mark.asyncio
+    async def test_without_env_jwt_meta_still_works(
+        self,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        """Without env JWT, secure_action needs ``_meta.asap_agent_jwt``."""
+        module = _load_asap_mcp_server()
+        monkeypatch.delenv(_ENV_JWT_KEY, raising=False)
+        server, identity = await module.build_and_prepare_server(
+            inject_env_jwt=False,
+        )
+        denied = await server._handle_tools_call(
+            {"name": "secure_action", "arguments": {"action": "x"}},
+        )
+        assert denied["isError"] is True
+        assert AUTH_REQUIRED in str(denied["content"][0]["text"])
+
+        ok = await server._handle_tools_call(
+            {
+                "name": "secure_action",
+                "arguments": {"action": "meta"},
+                "_meta": {"asap_agent_jwt": identity.demo_jwt},
+            },
+        )
+        assert ok.get("isError") is not True
+        assert "executed: meta" in str(ok["content"][0]["text"])
+
+
+class TestNemoAsapSmokeScript:
+    """Maintainer smoke script entrypoint."""
+
+    def test_smoke_asap_side_exits_zero(self) -> None:
+        """``smoke_asap_side.py`` passes without nvidia-nat."""
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                str(_SMOKE_SCRIPT.relative_to(_REPO_ROOT)),
+            ],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "ASAP-side Path A smoke passed" in result.stdout
+
+    def test_smoke_asap_side_stdio_exits_zero(self) -> None:
+        """Stdio smoke: env JWT + stderr logging does not corrupt JSON-RPC."""
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                str(_SMOKE_SCRIPT.relative_to(_REPO_ROOT)),
+                "--stdio",
+            ],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert "stdio secure_action via server-injected ASAP_AGENT_JWT" in result.stdout
+
+
+class TestNemoAsapOptionalNat:
+    """NAT import is optional — skip when nvidia-nat is not installed.
+
+    Main CI must not require ``nvidia-nat``; ASAP-side tests above always run.
+    """
+
+    def test_nat_optional_import_skips_cleanly(self) -> None:
+        """Absent ``nat`` → skip (expected in main CI); present → import ok."""
+        if importlib.util.find_spec("nat") is None:
+            pytest.skip("nvidia-nat optional — not installed (expected in main CI)")
+        nat = importlib.import_module("nat")
+        assert nat is not None


### PR DESCRIPTION
## Summary
- **S1b (D2 maintainer override):** research/experimental Microsoft Agent Framework interop guide (`docs/integrations/microsoft-agent-framework.md`); guide-only, no .NET sample/NuGet; S0 no-go evidence preserved with override recorded.
- **S1c (D7):** NeMo Agent Toolkit pin refresh + transport/auth gap analysis; Path A stdio demo (`examples/nemo_agent_toolkit_asap/`) using MCP Auth Bridge + dev-only `ASAP_AGENT_JWT` env fallback; public guide with honest limits; Path C third-party plugin explicitly out of ship.
- No protocol fork / no `src/asap/transport/` growth; MkDocs nav deferred to S3; main CI does not require `nvidia-nat`.

## Test plan
- [x] `uv run ruff check .` / `ruff format --check .` / `mypy src/ scripts/ tests/`
- [x] `uv run pytest --tb=short --cov=asap --cov-report=xml --cov-fail-under=85` (94.47%)
- [x] `uv run python scripts/lint_no_transport_growth.py`
- [x] `uv run pytest tests/examples/test_nemo_agent_toolkit_asap.py` (9 passed, 1 skipped without NAT)
- [x] Reversed-order example tests vs `test_mcp_auth_bridge_example.py` (env JWT isolation / C.7)
- [ ] CI green on this PR into `release/2.5.3`

## Review
T3 (Fable): **Approved with caveats** — C.7 applied (test env isolation); deferred stdout fix for reference `mcp_auth_bridge` to S2; GitHub `tree/main` links to S3 docs review.