### PR TITLE
feat(v2.5.4): S0–S2 scope lock, thin starters, and Build for agents guide

### DIFF
--- a/.github/workflows/starters-smoke.yml
+++ b/.github/workflows/starters-smoke.yml
@@ -1,0 +1,64 @@
+name: Starters smoke (v2.5.4)
+
+# Headless DIST-003 smokes for examples/starters/. Path-filtered to keep CI cheap.
+on:
+  push:
+    branches: [main, release/2.5.4]
+    paths:
+      - "examples/starters/**"
+      - "examples/openapi_petstore/**"
+      - "examples/mcp_auth_bridge/**"
+      - "packages/typescript/client/**"
+      - ".github/workflows/starters-smoke.yml"
+  pull_request:
+    branches: [main, release/2.5.4]
+    paths:
+      - "examples/starters/**"
+      - "examples/openapi_petstore/**"
+      - "examples/mcp_auth_bridge/**"
+      - "packages/typescript/client/**"
+      - ".github/workflows/starters-smoke.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  python-starters:
+    name: OpenAPI + MCP Auth Bridge smokes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
+      - name: OpenAPI provider smoke
+        run: |
+          uv sync --extra openapi
+          uv run python examples/starters/openapi-provider/run.py
+      - name: MCP Auth Bridge smoke
+        run: |
+          uv sync
+          uv run python examples/starters/mcp-auth-bridge/run.py
+
+  typescript-starter:
+    name: TypeScript consumer smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 9.15.4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install workspace and build client
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter @asap-protocol/client run build
+      - name: TypeScript consumer smoke
+        run: |
+          npm install --prefix examples/starters/typescript-consumer
+          node examples/starters/typescript-consumer/smoke.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 **ASAP Protocol** (Async Simple Agent Protocol) is a production-ready standard for agent-to-agent communication.
 - **Stack**: Python 3.13+, FastAPI, Pydantic v2.
 - **Transport**: JSON-RPC 2.0 over HTTP/WebSocket.
-- **Status**: v2.5.3 **shipped** (tag [`v2.5.3`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.3), 2026-07-16). **Current versions:** `pyproject.toml` **2.5.3** · PyPI `asap-protocol` **2.5.3** · PyPI `asap-compliance` **1.3.0** (tag [`v2.5.0.1`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.0.1)) · npm `@asap-protocol/client` **2.4.1**. Scope: [prd-v2.5.3-adapter-lab-ii.md](product/prd/prd-v2.5.3-adapter-lab-ii.md). Next adoption: Distribution Loop → **v2.5.4**; Formal Spec → **v2.5.5**. See `CHANGELOG.md` `[2.5.3]` and `docs/migration.md#upgrading-from-v252-to-v253`.
+- **Status**: v2.5.3 **shipped** (tag [`v2.5.3`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.3), 2026-07-16). **Current versions:** `pyproject.toml` **2.5.3** · PyPI `asap-protocol` **2.5.3** · PyPI `asap-compliance` **1.3.0** (tag [`v2.5.0.1`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.0.1)) · npm `@asap-protocol/client` **2.4.1**. Scope: [prd-v2.5.3-adapter-lab-ii.md](product/prd/prd-v2.5.3-adapter-lab-ii.md). **Current adoption:** Distribution Loop → **v2.5.4** ([PRD](product/prd/prd-v2.5.4-distribution-loop.md), [tasks](engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md)); Formal Spec → **v2.5.5**. See `CHANGELOG.md` `[2.5.3]` and `docs/migration.md#upgrading-from-v252-to-v253`.
 - **Framework Integrations**: LangChain, CrewAI, PydanticAI, LlamaIndex, SmolAgents, Vercel AI SDK, MCP (envelope + **MCP Auth Bridge** v2.5.0), OpenClaw, A2H.
 - **npm (TypeScript)**: The official client is **`@asap-protocol/client`** (scoped, **public** on npm for v2.4.x). Maintainer workflow: `.github/workflows/publish-typescript.yml`; context: `docs/maintainers/npm-publishing.md`.
 - **General contact** (humans coordinating on the protocol; not security): [info@asap-protocol.com](mailto:info@asap-protocol.com) — vulnerabilities: [SECURITY.md](SECURITY.md).
@@ -52,8 +52,8 @@ For coverage and pre-push gates, see [`.cursor/README.md`](.cursor/README.md#can
 - **MCP Auth Bridge**: `asap.adapters.mcp` (`protect_server`, `MCPAuthConfig`) — [docs/adapters/mcp-auth-bridge.md](docs/adapters/mcp-auth-bridge.md)
 
 ### 2. Development Status
-- **Active Sprint**: [engineering/tasks/v2.5.3/](engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md) — Adapter Lab II (**SHIPPED**)
-- **Adoption Roadmap**: v2.5.3 **Adapter Lab II** shipped (2026-07-16, tag `v2.5.3`); v2.5.2 **security follow-up** shipped (2026-07-08, tag `v2.5.2`); v2.5.1 **code quality patch** shipped (2026-06-26); v2.5.0 **MCP Auth Bridge** shipped (2026-06-24); `asap-compliance` **1.3.0** on PyPI (tag `v2.5.0.1`); **next adoption:** Distribution Loop (**v2.5.4** — [PRD](product/prd/prd-v2.5.4-distribution-loop.md)); `@asap-protocol/mcp-auth` (HTTP/SSE) still deferred.
+- **Active Sprint**: [engineering/tasks/v2.5.4/](engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md) — Distribution Loop (**ACTIVE**; `release/2.5.4` on origin — all sprint PRs merge into it)
+- **Adoption Roadmap**: v2.5.3 **Adapter Lab II** shipped (2026-07-16, tag `v2.5.3`); v2.5.2 **security follow-up** shipped (2026-07-08, tag `v2.5.2`); v2.5.1 **code quality patch** shipped (2026-06-26); v2.5.0 **MCP Auth Bridge** shipped (2026-06-24); `asap-compliance` **1.3.0** on PyPI (tag `v2.5.0.1`); **current adoption:** Distribution Loop (**v2.5.4** — [PRD](product/prd/prd-v2.5.4-distribution-loop.md), [tasks](engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md)); `@asap-protocol/mcp-auth` (HTTP/SSE) still deferred.
 - **Code Reviews**: `engineering/code-review/`
 
 ## Organization

--- a/docs/adapters/mcp-auth-bridge.md
+++ b/docs/adapters/mcp-auth-bridge.md
@@ -372,6 +372,7 @@ This adapter protects **native stdio `MCPServer`** (Mode A). MCP invoked inside 
 
 ## Related documentation
 
+- [MCP Auth Bridge starter](../../examples/starters/mcp-auth-bridge/) — thin smoke wrapper (`examples/starters/mcp-auth-bridge/`)
 - [MCP integration](../mcp-integration.md) — Mode A vs Mode B, migration notes
 - [NeMo Agent Toolkit](../integrations/nemo-agent-toolkit.md) — experimental Path A demo using `protect_server`
 - [Automation connector security](../guides/automation-connector-security.md) — secrets, TLS, grants; Mode A vs Mode B for connectors

--- a/docs/adapters/openapi.md
+++ b/docs/adapters/openapi.md
@@ -145,7 +145,7 @@ uv sync --extra openapi
 uv run python examples/openapi_petstore/main.py
 ```
 
-See also [Compliance testing](../guides/compliance-testing.md) and [CI compliance gate](../ci-compliance.md).
+See also [Compliance testing](../guides/compliance-testing.md), [CI compliance gate](../ci-compliance.md), and the thin [OpenAPI provider starter](../../examples/starters/openapi-provider/) (`examples/starters/openapi-provider/`).
 
 ## Common pitfalls
 

--- a/docs/guides/build-for-agents.md
+++ b/docs/guides/build-for-agents.md
@@ -20,7 +20,7 @@
 2. **Execute** — call skills over ASAP transport with typed envelopes and scoped identity.
 3. **Escalate** — request stronger approval or narrower grants when a capability needs it.
 
-Thin starters under `examples/starters/` wrap the canonical parent examples and apps. Prefer the starters for a fast smoke; use the parent paths for the full implementation. Starter index: [`examples/starters/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/starters).
+Thin starters under [`examples/starters/`](../../examples/starters/) wrap the canonical parent examples and apps. Prefer the starters for a fast smoke; use the parent paths for the full implementation.
 
 ## Thin starters
 
@@ -32,8 +32,8 @@ Turn an OpenAPI 3.x fragment into ASAP skills and an upstream proxy.
 
 | | |
 |--|--|
-| Starter | [`examples/starters/openapi-provider/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/starters/openapi-provider) |
-| Parent | [`examples/openapi_petstore/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/openapi_petstore) |
+| Starter | [`examples/starters/openapi-provider/`](../../examples/starters/openapi-provider/) |
+| Parent | [`examples/openapi_petstore/`](../../examples/openapi_petstore/) |
 | Docs | [OpenAPI adapter](../adapters/openapi.md) |
 
 ```bash
@@ -49,11 +49,12 @@ Prove Host/Agent identity and consumer APIs with `@asap-protocol/client` without
 
 | | |
 |--|--|
-| Starter | [`examples/starters/typescript-consumer/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/starters/typescript-consumer) |
-| Parent patterns | [`apps/example-nextjs/`](https://github.com/adriannoes/asap-protocol/tree/main/apps/example-nextjs) |
+| Starter | [`examples/starters/typescript-consumer/`](../../examples/starters/typescript-consumer/) |
+| Parent patterns | [`apps/example-nextjs/`](../../apps/example-nextjs/) |
 | Docs | [TypeScript SDK](../sdks/typescript.md) |
 
 ```bash
+pnpm install
 pnpm --filter @asap-protocol/client run build
 npm install --prefix examples/starters/typescript-consumer
 node examples/starters/typescript-consumer/smoke.mjs
@@ -67,8 +68,8 @@ Wrap a native stdio `MCPServer` with Agent JWT verification and capability grant
 
 | | |
 |--|--|
-| Starter | [`examples/starters/mcp-auth-bridge/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/starters/mcp-auth-bridge) |
-| Parent | [`examples/mcp_auth_bridge/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/mcp_auth_bridge) |
+| Starter | [`examples/starters/mcp-auth-bridge/`](../../examples/starters/mcp-auth-bridge/) |
+| Parent | [`examples/mcp_auth_bridge/`](../../examples/mcp_auth_bridge/) |
 | Docs | [MCP Auth Bridge](../adapters/mcp-auth-bridge.md) |
 
 ```bash
@@ -99,6 +100,6 @@ Do **not** pass JWTs on the CLI (`argv` leaks secrets). Prefer least-privilege g
 
 ## See also
 
-- [Starters index](https://github.com/adriannoes/asap-protocol/tree/main/examples/starters) (in-repo: `examples/starters/`)
+- [Starters index](../../examples/starters/) (`examples/starters/`)
 - [Docs home](../index.md)
 - [MCP integration overview](../mcp-integration.md)

--- a/docs/guides/build-for-agents.md
+++ b/docs/guides/build-for-agents.md
@@ -1,0 +1,104 @@
+# Build for agents
+
+> The next users of software are agents. ASAP gives them the machine-readable foundation they need: discoverable capabilities, scoped identity, compliance checks, and SDKs that turn existing APIs into agent-ready interfaces.
+
+**Audience:** API providers and agent/app builders.  
+**Status:** Maintained (v2.5.4 Distribution Loop). This guide is the public onboarding path into runnable starters and the adapters/SDKs behind them.
+
+## Who this is for
+
+| You are… | Start here |
+|----------|------------|
+| An **API provider** exposing HTTP/OpenAPI services to agents | [OpenAPI provider starter](#1-openapi-provider) → [OpenAPI adapter](../adapters/openapi.md) |
+| An **app/agent builder** calling ASAP from TypeScript | [TypeScript consumer starter](#2-typescript-consumer) → [TypeScript SDK](../sdks/typescript.md) |
+| Integrating **native MCP** with ASAP identity and grants | [MCP Auth Bridge starter](#3-mcp-auth-bridge) → [MCP Auth Bridge](../adapters/mcp-auth-bridge.md) |
+| New to ASAP agents end-to-end | [Building Your First Agent](../tutorials/first-agent.md) |
+
+## Adoption path
+
+1. **Discover** — advertise capabilities via manifests and (optionally) the Lite Registry.
+2. **Execute** — call skills over ASAP transport with typed envelopes and scoped identity.
+3. **Escalate** — request stronger approval or narrower grants when a capability needs it.
+
+Thin starters under `examples/starters/` wrap the canonical parent examples and apps. Prefer the starters for a fast smoke; use the parent paths for the full implementation. Starter index: [`examples/starters/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/starters).
+
+## Thin starters
+
+Starters are not a second source of truth. Each is a short entrypoint that re-invokes a parent demo. Run smokes from the **repository root** unless a starter README says otherwise.
+
+### 1. OpenAPI provider
+
+Turn an OpenAPI 3.x fragment into ASAP skills and an upstream proxy.
+
+| | |
+|--|--|
+| Starter | [`examples/starters/openapi-provider/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/starters/openapi-provider) |
+| Parent | [`examples/openapi_petstore/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/openapi_petstore) |
+| Docs | [OpenAPI adapter](../adapters/openapi.md) |
+
+```bash
+uv sync --extra openapi
+uv run python examples/starters/openapi-provider/run.py
+```
+
+Default smoke uses a **mocked** upstream (offline-friendly). Optional `--live` hits the public PetStore over **HTTPS**; the remote service may error — prefer the mock path for CI.
+
+### 2. TypeScript consumer
+
+Prove Host/Agent identity and consumer APIs with `@asap-protocol/client` without scaffolding a second web app.
+
+| | |
+|--|--|
+| Starter | [`examples/starters/typescript-consumer/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/starters/typescript-consumer) |
+| Parent patterns | [`apps/example-nextjs/`](https://github.com/adriannoes/asap-protocol/tree/main/apps/example-nextjs) |
+| Docs | [TypeScript SDK](../sdks/typescript.md) |
+
+```bash
+pnpm --filter @asap-protocol/client run build
+npm install --prefix examples/starters/typescript-consumer
+node examples/starters/typescript-consumer/smoke.mjs
+```
+
+Default smoke is **offline** (no API keys, no live gateway). Optional live discovery uses `ASAP_PROVIDER_URL` — set an **HTTPS** provider base URL for remote hosts; plain `http://` is acceptable only for local loopback. Do not commit real tokens; use env placeholders from the starter `.env.example`.
+
+### 3. MCP Auth Bridge
+
+Wrap a native stdio `MCPServer` with Agent JWT verification and capability grants (Mode A).
+
+| | |
+|--|--|
+| Starter | [`examples/starters/mcp-auth-bridge/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/starters/mcp-auth-bridge) |
+| Parent | [`examples/mcp_auth_bridge/`](https://github.com/adriannoes/asap-protocol/tree/main/examples/mcp_auth_bridge) |
+| Docs | [MCP Auth Bridge](../adapters/mcp-auth-bridge.md) |
+
+```bash
+uv sync
+uv run python examples/starters/mcp-auth-bridge/run.py
+```
+
+Do **not** pass JWTs on the CLI (`argv` leaks secrets). Prefer least-privilege grants: public tools for non-sensitive reads only; protect mutating tools with Agent JWT and narrow capability constraints. See the parent README and [MCP Auth Bridge](../adapters/mcp-auth-bridge.md) for production warnings (`allow_env_jwt_fallback` is demo-only).
+
+## Deeper docs
+
+| Topic | Link |
+|-------|------|
+| OpenAPI → ASAP skills | [OpenAPI adapter](../adapters/openapi.md) |
+| MCP Mode A protection | [MCP Auth Bridge](../adapters/mcp-auth-bridge.md) |
+| Browser / Node client | [TypeScript SDK](../sdks/typescript.md) |
+| Echo agent walkthrough | [Building Your First Agent](../tutorials/first-agent.md) |
+| Compliance checks | [Compliance Testing](compliance-testing.md) |
+| Connector security baseline | [Automation connector security](automation-connector-security.md) |
+
+## Security notes
+
+| Concern | Practice |
+|---------|----------|
+| **Secrets** | Load tokens and keys from the environment or a secrets manager. Never commit `.env` values or paste JWTs into READMEs/CI logs. |
+| **HTTPS/TLS** | Use `https://` for remote providers, upstream APIs, and advertised manifest origins. Local loopback HTTP is fine for demos. Prefer `require_https=True` on ASAP HTTP clients in production — [Security Guide](../security.md). |
+| **Least privilege** | Grant only the skills and constraints each agent needs. Map mutating verbs to stronger approval where appropriate — [Capabilities](../capabilities/index.md). |
+
+## See also
+
+- [Starters index](https://github.com/adriannoes/asap-protocol/tree/main/examples/starters) (in-repo: `examples/starters/`)
+- [Docs home](../index.md)
+- [MCP integration overview](../mcp-integration.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,8 @@ See [CLI reference](cli.md) (all commands, exit codes, `compliance-check`, `audi
 
 ## Documentation
 
+**See also:** [Build for agents](guides/build-for-agents.md) — agent-first onboarding into the three thin starters (OpenAPI provider, TypeScript consumer, MCP Auth Bridge).
+
 - [OpenAPI adapter](adapters/openapi.md) — derive ASAP skills and an upstream proxy from OpenAPI 3.x (`asap.adapters.openapi`)
 - [MCP Auth Bridge](adapters/mcp-auth-bridge.md) — opt-in Agent JWT + capability enforcement for native stdio `MCPServer` (`asap.mcp.auth.protect_server`)
 - [Workflow connectors](integrations/workflow-connectors.md) — n8n / Activepieces-style workflow HTTP APIs → ASAP skills via OpenAPI (Adapter Lab II)

--- a/docs/sdks/typescript.md
+++ b/docs/sdks/typescript.md
@@ -185,6 +185,8 @@ The **[`apps/example-nextjs`](https://github.com/adriannoes/asap-protocol/tree/m
 
 ## See also
 
+- [TypeScript consumer starter](../../examples/starters/typescript-consumer/) — thin Node identity smoke (`examples/starters/typescript-consumer/`)
 - [Transport overview](../transport.md) — HTTP/SSE endpoints and versioning
 - [Error handling (Python-centric)](../error-handling.md) — taxonomy and JSON-RPC mapping
 - [Vercel AI SDK (Python gateway)](../guides/vercel-ai-sdk.md) — complementary server-side tools router
+- [Build for agents](../guides/build-for-agents.md) — Dist Loop onboarding guide

--- a/engineering/tasks/README.md
+++ b/engineering/tasks/README.md
@@ -8,7 +8,7 @@ Sprint roadmaps and release checklists per protocol version. Pair each folder wi
 
 | Folder | PRD | Status |
 |--------|-----|--------|
-| *(none yet)* | [prd-v2.5.4-distribution-loop.md](../../product/prd/prd-v2.5.4-distribution-loop.md) | **Next** — create `engineering/tasks/v2.5.4/` at kickoff |
+| [v2.5.4/](./v2.5.4/tasks-v2.5.4-roadmap.md) | [prd-v2.5.4-distribution-loop.md](../../product/prd/prd-v2.5.4-distribution-loop.md) | **ACTIVE** — `release/2.5.4` on origin; all sprint PRs merge into it ([BRANCHING.md](./v2.5.4/BRANCHING.md)) |
 
 ---
 
@@ -42,10 +42,10 @@ Sprint roadmaps and release checklists per protocol version. Pair each folder wi
 
 | Version | PRD | Blocked by |
 |---------|-----|------------|
-| v2.5.4 | [prd-v2.5.4-distribution-loop.md](../../product/prd/prd-v2.5.4-distribution-loop.md) | v2.5.3 |
-| v2.5.5 | [prd-v2.5.5-formal-spec-interop.md](../../product/prd/prd-v2.5.5-formal-spec-interop.md) | v2.5.4 (soft) |
+| v2.5.5 | [prd-v2.5.5-formal-spec-interop.md](../../product/prd/prd-v2.5.5-formal-spec-interop.md) | v2.5.4 soft (docs-only may overlap); hard: v2.5.0 + identity model |
+| v3.0 | [prd-v3.0-economy.md](../../product/prd/prd-v3.0-economy.md) | Launch triggers (not Dist ship) |
 
-Create `engineering/tasks/v2.5.4/` etc. when each adoption release starts.
+Create `engineering/tasks/v{X}/` when each adoption release starts. Dist handoff checklist: [v2.5.4/release-checklist.md §5.1](./v2.5.4/release-checklist.md#51-handoff-inputs-for-v255-confirm-at-s5).
 
 ---
 

--- a/engineering/tasks/v2.5.4/BRANCHING.md
+++ b/engineering/tasks/v2.5.4/BRANCHING.md
@@ -1,0 +1,47 @@
+# v2.5.4 — Branching strategy
+
+## Integration branch
+
+**All** v2.5.4 feature/sprint branches merge into:
+
+```text
+release/2.5.4
+```
+
+| Rule | Detail |
+|------|--------|
+| Base for new work | Branch **from** `release/2.5.4` |
+| PR target | Open PRs **into** `release/2.5.4` — never into `main` mid-train |
+| Only path to `main` | **One** PR at S5: `release/2.5.4` → `main` (then tag `v2.5.4`) |
+| Rebase policy | Rebase each sprint branch on latest `release/2.5.4` before merge |
+
+**Status (2026-07-18):** `release/2.5.4` exists on origin (created at kickoff). Do **not** recreate it.
+
+**Do not** land sprint PRs directly on `main` until the full v2.5.4 release is ready.
+
+## Per-sprint workflow
+
+1. ~~Create `release/2.5.4` from `main`~~ — **done** (on origin).
+2. Branch from `release/2.5.4`: `feat/v2.5.4-s0-scope-lock`, `feat/v2.5.4-s1-starter-pack`, `feat/v2.5.4-s2-build-for-agents`, `feat/v2.5.4-s3-homepage-routing`, `feat/v2.5.4-s4-telemetry`, etc.
+3. Open PR **into `release/2.5.4`** (not `main`).
+4. After S5 checklist passes on `release/2.5.4`, open **one** PR: `release/2.5.4` → `main` (tag `v2.5.4`).
+
+Combined branches are allowed when efficient (for example S0+S1), but each PR still targets `release/2.5.4`. Prefer one functional change theme per PR when possible.
+
+## Merge order
+
+```
+S0 → S1 → S2 → S3 → S5 → main
+      └── S4 (parallel after S0; SHOULD; must not block S5 if deferred)
+```
+
+Every arrow above (except the final `→ main`) is a merge **into `release/2.5.4`**.
+
+S4 may merge any time after S0. Incomplete S4 requires an explicit deferral note on the roadmap before S5 marks DIST-004 N/A/deferred.
+
+## Naming
+
+```text
+feat/v2.5.4-s{N}-{slug}   →  PR base: release/2.5.4
+release/2.5.4             →  PR base: main   (S5 only)
+```

--- a/engineering/tasks/v2.5.4/docs-review-checklist.md
+++ b/engineering/tasks/v2.5.4/docs-review-checklist.md
@@ -42,9 +42,9 @@ Each new page MUST: English, HTTPS/TLS note where network is involved, explicit 
 |------|----------------|--------|
 | `docs/guides/build-for-agents.md` | Links to all three starters + key adapters/SDK | ☑ (S2) |
 | `examples/starters/README.md` | Links to guide + parent examples | ☑ (S1/S2) |
-| `docs/adapters/openapi.md` | Optional “See also” → OpenAPI starter | ☐ |
-| `docs/adapters/mcp-auth-bridge.md` | Optional “See also” → MCP starter | ☐ |
-| `docs/sdks/typescript.md` | Optional “See also” → TS consumer starter | ☐ |
+| `docs/adapters/openapi.md` | Optional “See also” → OpenAPI starter | ☑ |
+| `docs/adapters/mcp-auth-bridge.md` | Optional “See also” → MCP starter | ☑ |
+| `docs/sdks/typescript.md` | Optional “See also” → TS consumer starter | ☑ |
 | `docs/migration.md` | Section **Upgrading from v2.5.3 → v2.5.4** (S5 finalizes) | ☐ |
 | `README.md` (repo root) | Short pointer to starters/guide if README lists getting-started paths | ☐ |
 

--- a/engineering/tasks/v2.5.4/docs-review-checklist.md
+++ b/engineering/tasks/v2.5.4/docs-review-checklist.md
@@ -1,0 +1,101 @@
+# Docs review checklist — v2.5.4 Distribution Loop
+
+> **Purpose**: Single checklist so Distribution Loop docs and web routing land consistently across MkDocs, `docs/index.md`, starters, homepage CTAs, and DIST-006.  
+> **Owned by**: [sprint-S3-homepage-routing.md](./sprint-S3-homepage-routing.md) (web/CTA execution) + S2 (guide producer); S1 produces starters that this review wires.  
+> **Do not** invent pages here — only verify, link, and fix nav/stale copy.
+
+---
+
+## 1. New pages / packs expected this release
+
+| Page / pack | Producer sprint | Status |
+|-------------|-----------------|--------|
+| `examples/starters/README.md` + three starters | S1 | ☑ done (2026-07-18) |
+| `docs/guides/build-for-agents.md` | S2 | ☑ done (2026-07-18) |
+| Homepage hero / CTA copy (agent-first) | S3 | ☐ pending |
+| `docs/adapters/openapi.md`, `docs/adapters/mcp-auth-bridge.md`, `docs/sdks/typescript.md` | pre–v2.5.4 | ☐ exist (confirm linked) |
+
+Each new page MUST: English, HTTPS/TLS note where network is involved, explicit **status** (maintained / experimental / research), and DIST-006-safe copy.
+
+---
+
+## 2. MkDocs nav (`mkdocs.yml`)
+
+- [x] Guides: add `guides/build-for-agents.md`
+- [ ] Confirm Adapters (OpenAPI, MCP Auth Bridge) still listed
+- [ ] Confirm SDKs / tutorials still reachable for consumers linked from the guide
+- [ ] Smoke: `uv run mkdocs build` — document any pre-existing `--strict` warnings (do not normalize new failures)
+
+---
+
+## 3. Docs home (`docs/index.md`)
+
+- [x] Mention Distribution Loop / Build for agents when guide ships (See also)
+- [ ] Link `examples/starters/` or guide as executable entry
+- [ ] Keep version blurb accurate for train state (S5 owns final **2.5.4** string)
+
+---
+
+## 4. Cross-link pass
+
+| File | What to check | Status |
+|------|----------------|--------|
+| `docs/guides/build-for-agents.md` | Links to all three starters + key adapters/SDK | ☑ (S2) |
+| `examples/starters/README.md` | Links to guide + parent examples | ☑ (S1/S2) |
+| `docs/adapters/openapi.md` | Optional “See also” → OpenAPI starter | ☐ |
+| `docs/adapters/mcp-auth-bridge.md` | Optional “See also” → MCP starter | ☐ |
+| `docs/sdks/typescript.md` | Optional “See also” → TS consumer starter | ☐ |
+| `docs/migration.md` | Section **Upgrading from v2.5.3 → v2.5.4** (S5 finalizes) | ☐ |
+| `README.md` (repo root) | Short pointer to starters/guide if README lists getting-started paths | ☐ |
+
+---
+
+## 5. Taxonomy & naming
+
+| Folder | Use for |
+|--------|---------|
+| `docs/adapters/` | First-party ASAP packages (`asap.adapters.*`) |
+| `docs/integrations/` | Framework / ecosystem guides |
+| `docs/guides/` | Cross-cutting how-tos (**Build for agents** lives here) |
+| `examples/starters/` | Thin adoption wrappers (not deep demos) |
+| `examples/` (non-starters) | Canonical deep examples |
+
+---
+
+## 6. Web CTAs (`apps/web`)
+
+- [ ] Primary hero CTAs → guide and/or `examples/starters/`
+- [ ] Secondary marketplace CTAs (browse/register) still present
+- [ ] WhatsNew / Features / How it Works primary actions resolve to live URLs
+- [ ] `data-cta` IDs listed in `homepage-cta-ids.ts` remain stable or documented if extended
+- [ ] No pricing / fundraising / private GTM strings (DIST-006)
+
+---
+
+## 7. Quality
+
+- [ ] English only for public docs and starter READMEs
+- [ ] No secrets in examples (`.env.example` placeholders only)
+- [ ] Starter smoke commands documented and headless
+- [ ] Broken-link spot check for new URLs
+
+---
+
+## 8. Sign-off
+
+### S3 (docs/web surface)
+
+| Item | Owner | Status |
+|------|-------|--------|
+| §§1–7 for MUST surface | S3 (+ S1/S2 producers) | ☐ |
+| DIST-006 grep on touched public copy | S3 | ☐ |
+
+### S5 (version strings)
+
+| Item | Owner | Status |
+|------|-------|--------|
+| `docs/index.md` / README / migration version strings → **2.5.4** | S5 | ☐ |
+| Post-publish swap pending → shipped | S5 | ☐ |
+
+**Sign-off date:** _______________  
+**Signer:** _______________

--- a/engineering/tasks/v2.5.4/release-checklist.md
+++ b/engineering/tasks/v2.5.4/release-checklist.md
@@ -18,6 +18,29 @@
 | npm audit (web) | `cd apps/web && npm audit --omit=dev --audit-level=moderate` and `npm audit --audit-level=high` (blocking in CI `quality-web`; see `SECURITY.md`) | ☐ |
 | Web (if touched) | `npm run lint` / format check / `npx tsc --noEmit` / `npx vitest run` / `npm run build` in `apps/web/` | ☐ |
 | MkDocs (if docs/nav touched) | `uv run mkdocs build` | ☐ |
+| Starter smokes (DIST-003) | See §1.1 | ☐ |
+
+### 1.1 Starter smoke commands (DIST-003)
+
+Run from the repository root (each ≤60s headless):
+
+```bash
+# OpenAPI provider
+uv sync --extra openapi
+uv run python examples/starters/openapi-provider/run.py
+
+# MCP Auth Bridge
+uv sync
+uv run python examples/starters/mcp-auth-bridge/run.py
+
+# TypeScript consumer (fresh clone needs workspace install first)
+pnpm install
+pnpm --filter @asap-protocol/client run build
+npm install --prefix examples/starters/typescript-consumer
+node examples/starters/typescript-consumer/smoke.mjs
+```
+
+Optional CI: `.github/workflows/starters-smoke.yml` (path-filtered on `examples/starters/**`).
 
 ---
 
@@ -54,6 +77,7 @@
 - [ ] **Tag** `git tag -a v2.5.4` + push — triggers `.github/workflows/release.yml`
 - [ ] **Publish** — GitHub Release `v2.5.4`; PyPI `asap-protocol==2.5.4`; Docker/GHCR if applicable
 - [ ] Spot-check starter README smoke locally (optional maintainer follow-up)
+- [ ] **Public GitHub links** — after merge to `main`, confirm Dist Loop docs that use relative `examples/starters/` paths resolve on `main`; flip any remaining `tree/release/2.5.4/...` URLs to `tree/main/...` if introduced during the train
 
 ---
 

--- a/engineering/tasks/v2.5.4/release-checklist.md
+++ b/engineering/tasks/v2.5.4/release-checklist.md
@@ -1,0 +1,97 @@
+# Release checklist: v2.5.4 Distribution Loop
+
+**Roadmap:** [tasks-v2.5.4-roadmap.md](./tasks-v2.5.4-roadmap.md)  
+**PRD:** [prd-v2.5.4-distribution-loop.md](../../../product/prd/prd-v2.5.4-distribution-loop.md)  
+**Pattern:** [v2.5.3 release checklist](../v2.5.3/release-checklist.md)
+
+---
+
+## 1.0 Pre-tag verification
+
+| Step | Command | Status |
+|------|---------|--------|
+| Lint | `uv run ruff check .` | ☐ |
+| Format | `uv run ruff format --check .` | ☐ |
+| Types | `uv run mypy src/ scripts/ tests/` | ☐ |
+| Python tests | `uv run pytest --tb=short --cov=asap --cov-report=xml --cov-fail-under=85` | ☐ |
+| pip-audit | per `SECURITY.md` | ☐ |
+| npm audit (web) | `cd apps/web && npm audit --omit=dev --audit-level=moderate` and `npm audit --audit-level=high` (blocking in CI `quality-web`; see `SECURITY.md`) | ☐ |
+| Web (if touched) | `npm run lint` / format check / `npx tsc --noEmit` / `npx vitest run` / `npm run build` in `apps/web/` | ☐ |
+| MkDocs (if docs/nav touched) | `uv run mkdocs build` | ☐ |
+
+---
+
+## 2.0 Product DoD
+
+> **S5 owns this section.** Fill when MUST surface is merge-ready.
+
+- [ ] DIST-001 — homepage agent-first (D1)
+- [ ] DIST-002 — CTAs → docs/starters/examples
+- [ ] DIST-003 — three thin starters at locked paths
+- [ ] DIST-004 — telemetry ops green **or** deferred on roadmap
+- [ ] DIST-005 — `docs/guides/build-for-agents.md` shipped
+- [ ] DIST-006 — public copy gate passed
+- [ ] [docs-review-checklist.md](./docs-review-checklist.md) §§1–8 complete for shipped scope
+
+---
+
+## 3.0 Version & changelog gates
+
+- [ ] `pyproject.toml` → `version = "2.5.4"`
+- [ ] `src/asap/__init__.py` → `__version__ = "2.5.4"`
+- [ ] `CHANGELOG.md` → `## [2.5.4]`
+- [ ] `docs/migration.md` → v2.5.3 → v2.5.4
+- [ ] `README.md`, `docs/index.md`, `AGENTS.md`, `product/README.md`, `product/checkpoints.md`
+- [ ] npm `@asap-protocol/*` unchanged unless a package was intentionally bumped
+
+---
+
+## 4.0 Merge → tag → publish
+
+**Order:** merge PR → tag `v2.5.4` → confirm publish workflows → then §6 handoff copy.
+
+- [ ] **Merge** `release/2.5.4` → `main` — PR #____
+- [ ] **Tag** `git tag -a v2.5.4` + push — triggers `.github/workflows/release.yml`
+- [ ] **Publish** — GitHub Release `v2.5.4`; PyPI `asap-protocol==2.5.4`; Docker/GHCR if applicable
+- [ ] Spot-check starter README smoke locally (optional maintainer follow-up)
+
+---
+
+## 5.0 Train handoff
+
+| Next | Status |
+|------|--------|
+| **v2.5.5** Formal Spec / Interop | [PRD](../../../product/prd/prd-v2.5.5-formal-spec-interop.md) — create `engineering/tasks/v2.5.5/` when kicked off |
+| npm `@asap-protocol/mcp-auth` | Still backlog — [../v2.5.0/backlog-mcp-auth-typescript.md](../v2.5.0/backlog-mcp-auth-typescript.md) |
+| **v3.0** Economy | Vision only — [prd-v3.0-economy.md](../../../product/prd/prd-v3.0-economy.md); trigger-gated |
+
+### 5.1 Handoff inputs for v2.5.5 (confirm at S5)
+
+Mirror of [PRD §11](../../../product/prd/prd-v2.5.4-distribution-loop.md#11-handoff-inputs-for-v255-formal-spec). Soft inputs only.
+
+- [ ] Narrative D1 + `docs/guides/build-for-agents.md` linked from Spec kickoff notes
+- [ ] Three starter paths documented:
+  - [ ] `examples/starters/openapi-provider/`
+  - [ ] `examples/starters/typescript-consumer/`
+  - [ ] `examples/starters/mcp-auth-bridge/`
+- [ ] DIST-004 status: green **or** deferred (note on roadmap)
+- [ ] OOS reminder: no CLI scaffold, no public metrics UI, no pricing/GTM in Spec kickoff copy
+- [ ] Orphans unchanged: `mcp-auth` npm backlog; TSOA defer-unless-demand; fourth workflow starter not canonical
+- [ ] Point [prd-v2.5.5-formal-spec-interop.md](../../../product/prd/prd-v2.5.5-formal-spec-interop.md) / train index at shipped Dist artifacts
+- [ ] Optional: one-line Dist metrics → v3.0 trigger proxies (if S4 ran)
+
+**v2.5.4 train:** ☑ OPEN / ☐ CLOSED (after §6)
+
+---
+
+## 6.0 Post-publish: swap pending → shipped
+
+> Complete only after PyPI shows `asap-protocol==2.5.4` and the GitHub Release for `v2.5.4` is published.
+
+- [ ] `CHANGELOG.md` `[2.5.4]`: remove “pending tag/publish” status callout if used
+- [ ] `README.md`, `docs/index.md`, `docs/migration.md`: recommend `asap-protocol==2.5.4`
+- [ ] `AGENTS.md`, `product/checkpoints.md`, `product/README.md`: **shipped** + tag/release links
+- [ ] Hero / WhatsNew: drop “pending publish” wording if any
+- [ ] This checklist §§4–5 and [sprint-S5-release.md](./sprint-S5-release.md): check complete
+- [ ] [tasks-v2.5.4-roadmap.md](./tasks-v2.5.4-roadmap.md): Status **SHIPPED**; S5 Done; train CLOSED
+- [ ] Link GitHub Release + PyPI (+ GHCR) in the S5 sprint notes

--- a/engineering/tasks/v2.5.4/sprint-S0-scope-lock.md
+++ b/engineering/tasks/v2.5.4/sprint-S0-scope-lock.md
@@ -1,0 +1,70 @@
+# Sprint S0: Scope lock (v2.5.4)
+
+**PRD**: [prd-v2.5.4-distribution-loop.md](../../../product/prd/prd-v2.5.4-distribution-loop.md) §3 D1–D5, §4  
+**Branch**: `feat/v2.5.4-s0-s2-starters-guide` (combined S0+S1+S2) → **`release/2.5.4`**  
+**Depends on**: v2.5.3 shipped; PRD decisions locked  
+**Status**: Done (2026-07-18)
+
+**Trigger:** Maintainer kickoff of Distribution Loop.  
+**Enables:** S1 starters; S4 telemetry; S2/S3 after starter/guide paths exist.  
+**Depends on:** PRD D1–D5; baseline inventory in PRD §4.
+
+---
+
+## Goal
+
+Confirm locked decisions, confirm the integration branch, and list concrete gaps so S1–S4 do not reinvent Lab II work.
+
+---
+
+## Tasks
+
+- [x] **1.1 Integration branch**
+  - [x] `release/2.5.4` already on origin (2026-07-18) — do **not** recreate
+  - [x] Working branch: `feat/v2.5.4-s0-s2-starters-guide` (combined S0+S1+S2) → **`release/2.5.4`** (see [BRANCHING.md](./BRANCHING.md)); original slug `feat/v2.5.4-s0-scope-lock` unused
+  - [x] Set [tasks-v2.5.4-roadmap.md](./tasks-v2.5.4-roadmap.md) status to **ACTIVE**
+
+- [x] **1.2 Reconfirm locked decisions** (2026-07-18 — no maintainer overrides; no silent swaps)
+  - [x] **D1** — Build for agents primary; marketplace secondary — confirmed (PRD §3)
+  - [x] **D2** — Starters: OpenAPI · TypeScript consumer · MCP Auth Bridge — confirmed (PRD §3)
+  - [x] **D3** — Thin wrappers under `examples/starters/` — confirmed (PRD §3)
+  - [x] **D4** — Operationalize telemetry; no public live dashboard — confirmed (PRD §3)
+  - [x] **D5** — Versioned release `v2.5.4` (Python bump + CHANGELOG + migration) — confirmed (PRD §3)
+  - [x] No maintainer override recorded (defaults stand)
+
+- [x] **1.3 Baseline gap list** (verified 2026-07-18)
+  - [x] **Homepage marketplace-primary → S3** — hero / primary CTAs still marketplace-first; agent-first narrative + CTA routing deferred to S3
+  - [x] **No `examples/starters/` → S1** — directory absent; thin wrappers not yet created (do not invent Lab II parents)
+  - [x] **No `docs/guides/build-for-agents.md` → S2** — guide file absent; S2 owns publish + mkdocs nav
+  - [x] **Telemetry package coverage / schedule secrets → S4** — `scripts/telemetry/` exists; npm coverage and weekly-schedule secrets still S4 ops work; no public live dashboard (D4)
+  - [x] **Parent sources confirmed present** (ls 2026-07-18):
+    - `examples/openapi_petstore/` — present (README, main.py, openapi-fragment.json)
+    - `examples/mcp_auth_bridge/` — present (README, client.py, server.py)
+    - `apps/example-nextjs/` — present (Next.js consumer app)
+    - `scripts/telemetry/` — present (aggregate, collect_npm/pypi/github/registry)
+
+- [x] **1.4 DIST-006 gate setup**
+  - [x] Public-copy grep terms for release / docs review: `pricing`, `fundraising`, paid timing (e.g. “pay”, “paid”, “pricing tier”), private GTM phrases (campaign codenames, internal funnel jargon). Run before S5 publish and when touching homepage/guide copy (see [docs-review-checklist.md](./docs-review-checklist.md))
+  - [x] `product/strategy/` remains gitignored — confirmed: `git check-ignore -v product/strategy/` → `.gitignore:187:product/strategy/`
+
+---
+
+## Acceptance criteria
+
+- [x] `release/2.5.4` exists on origin (all sprint PRs merge **into** it)
+- [x] D1–D5 confirmed (or override documented)
+- [x] Gap list written in this file or linked note
+- [x] Roadmap sprint table: S0 → Done; train ACTIVE
+
+## Reviews
+
+| Date | Tier | Verdict | Report |
+|------|------|---------|--------|
+| 2026-07-18 | T2 | Approved with caveats (r2) | [review-v2.5.4-S0-S2-starters-guide-20260718-r2.md](../../../code-review/private/review-v2.5.4-S0-S2-starters-guide-20260718-r2.md) |
+| 2026-07-18 | C.7 | Rejected (r1) — fixes applied pending r2 | [review-v2.5.4-S0-S2-starters-guide-20260718.md](../../../code-review/private/review-v2.5.4-S0-S2-starters-guide-20260718.md) |
+
+## Relevant files
+
+- `product/prd/prd-v2.5.4-distribution-loop.md`
+- `engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md`
+- `engineering/tasks/v2.5.4/BRANCHING.md`

--- a/engineering/tasks/v2.5.4/sprint-S1-starter-pack.md
+++ b/engineering/tasks/v2.5.4/sprint-S1-starter-pack.md
@@ -57,7 +57,7 @@ Smoke evidence (2026-07-18, local):
 |---------|---------|--------|
 | OpenAPI | `uv run python examples/starters/openapi-provider/run.py` | PASS |
 | MCP Auth Bridge | `uv run python examples/starters/mcp-auth-bridge/run.py` | PASS |
-| TypeScript | `pnpm --filter @asap-protocol/client run build` → `npm install --prefix examples/starters/typescript-consumer` → `node examples/starters/typescript-consumer/smoke.mjs` | PASS |
+| TypeScript | `pnpm install` → `pnpm --filter @asap-protocol/client run build` → `npm install --prefix examples/starters/typescript-consumer` → `node …/smoke.mjs` | PASS |
 DIST-006 grep on `examples/starters/`: no pricing/fundraising/GTM matches. Optional live: `ASAP_PROVIDER_URL` in `.env.example` only.
 
 ---

--- a/engineering/tasks/v2.5.4/sprint-S1-starter-pack.md
+++ b/engineering/tasks/v2.5.4/sprint-S1-starter-pack.md
@@ -1,0 +1,87 @@
+# Sprint S1: Thin starter pack (v2.5.4)
+
+**PRD**: DIST-003 (D2, D3)  
+**Branch**: `feat/v2.5.4-s0-s2-starters-guide` (combined S0–S2) → **`release/2.5.4`**  
+**Depends on**: [S0](./sprint-S0-scope-lock.md)  
+**Status**: Done
+
+**Trigger:** S0 locks starter trio and thin-wrapper shape.  
+**Enables:** S2 guide links; S3 homepage CTAs.  
+**Depends on:** Parent examples/apps remain canonical sources.
+
+---
+
+## Goal
+
+Ship three **thin** starters under `examples/starters/` that wrap existing OpenAPI, TypeScript consumer, and MCP Auth Bridge paths—no new scaffold CLI.
+
+---
+
+## Design constraints
+
+- Prefer wrap/re-export or a short script that invokes the parent example over copying large trees.
+- Each starter: `README.md` (English) + entrypoint + `.env.example` only if secrets/config are required.
+- Smoke must be headless and finish in ≤60s with a single documented command.
+- HTTPS/TLS note where network is involved; no private GTM (DIST-006).
+- Full Next.js demo stays at `apps/example-nextjs/`; TypeScript starter may be a thin Node CLI derived from those patterns.
+
+---
+
+## Tasks
+
+- [x] **2.1 Starters index**
+  - [x] Create `examples/starters/README.md` listing the three starters + links to parent examples/docs
+
+- [x] **2.2 OpenAPI provider starter**
+  - [x] Path: `examples/starters/openapi-provider/`
+  - [x] Source: `examples/openapi_petstore/` (+ `docs/adapters/openapi.md`)
+  - [x] README smoke command; avoid second OpenAPI fragment source of truth
+
+- [x] **2.3 TypeScript consumer starter**
+  - [x] Path: `examples/starters/typescript-consumer/`
+  - [x] Source: `apps/example-nextjs/` patterns + `@asap-protocol/client` + `docs/sdks/typescript.md`
+  - [x] Prefer thin Node discover/execute smoke; README may point to full Next app
+  - [x] Do **not** base on Mastra / OpenAI Agents apps
+
+- [x] **2.4 MCP Auth Bridge starter**
+  - [x] Path: `examples/starters/mcp-auth-bridge/`
+  - [x] Source: `examples/mcp_auth_bridge/` (+ `docs/adapters/mcp-auth-bridge.md`)
+  - [x] Preserve Auth Bridge security pointers from parent README/docs
+
+- [x] **2.5 Smoke verification**
+  - [x] Document and run one smoke per starter (headless)
+  - [x] Note any optional secrets as env placeholders only (no real credentials)
+
+Smoke evidence (2026-07-18, local):
+| Starter | Command | Result |
+|---------|---------|--------|
+| OpenAPI | `uv run python examples/starters/openapi-provider/run.py` | PASS |
+| MCP Auth Bridge | `uv run python examples/starters/mcp-auth-bridge/run.py` | PASS |
+| TypeScript | `pnpm --filter @asap-protocol/client run build` → `npm install --prefix examples/starters/typescript-consumer` → `node examples/starters/typescript-consumer/smoke.mjs` | PASS |
+DIST-006 grep on `examples/starters/`: no pricing/fundraising/GTM matches. Optional live: `ASAP_PROVIDER_URL` in `.env.example` only.
+
+---
+
+## Acceptance criteria
+
+- [x] Three directories exist at the locked paths
+- [x] Index README present
+- [x] Each starter has a documented smoke that passes locally
+- [x] DIST-003 satisfied; DIST-006 clean on starter READMEs
+- [x] Parent examples remain the canonical deep implementations
+
+## Reviews
+
+| Date | Tier | Verdict | Report |
+|------|------|---------|--------|
+| 2026-07-18 | T2 | Approved with caveats (r2) | [review-v2.5.4-S0-S2-starters-guide-20260718-r2.md](../../../code-review/private/review-v2.5.4-S0-S2-starters-guide-20260718-r2.md) |
+| 2026-07-18 | C.7 | Rejected (r1) — fixes applied pending r2 | [review-v2.5.4-S0-S2-starters-guide-20260718.md](../../../code-review/private/review-v2.5.4-S0-S2-starters-guide-20260718.md) |
+
+## Relevant files
+
+- `examples/starters/**`
+- `examples/openapi_petstore/`
+- `examples/mcp_auth_bridge/`
+- `apps/example-nextjs/`
+- `packages/typescript/client`
+- `docs/adapters/openapi.md`, `docs/adapters/mcp-auth-bridge.md`, `docs/sdks/typescript.md`

--- a/engineering/tasks/v2.5.4/sprint-S2-build-for-agents-guide.md
+++ b/engineering/tasks/v2.5.4/sprint-S2-build-for-agents-guide.md
@@ -1,0 +1,64 @@
+# Sprint S2: Build for agents guide (v2.5.4)
+
+**PRD**: DIST-005 (D1 narrative)  
+**Branch**: `feat/v2.5.4-s0-s2-starters-guide` (combined S0–S2) → **`release/2.5.4`**  
+**Depends on**: [S1](./sprint-S1-starter-pack.md) (starter URLs)  
+**Status**: Done
+
+**Trigger:** Starter pack paths exist so the guide can link executable entry points.  
+**Enables:** S3 primary homepage CTA; docs-review surface.  
+**Depends on:** Task 2.0; PRD §6 canonical narrative.
+
+---
+
+## Goal
+
+Publish a public guide that states the agent-first story and routes readers into the three starters and key existing adapters/SDKs.
+
+---
+
+## Tasks
+
+- [x] **3.1 Draft guide**
+  - [x] Create `docs/guides/build-for-agents.md`
+  - [x] Lead with PRD §6 narrative (D1)
+  - [x] Audience: API providers and agent/app builders
+  - [x] Explicit status: **maintained**
+  - [x] Link: three starters, OpenAPI adapter, MCP Auth Bridge, TypeScript SDK, first-agent tutorial as needed
+  - [x] HTTPS/TLS / least-privilege notes where network or credentials appear
+  - [x] DIST-006: no pricing, fundraising, or private GTM
+
+- [x] **3.2 MkDocs wiring**
+  - [x] Add nav entry under Guides in `mkdocs.yml`
+  - [x] Smoke: `uv run mkdocs build` (document `--strict` caveats if pre-existing)
+    - `uv sync --extra docs && uv run mkdocs build` → **exit 0** (2026-07-18)
+    - `uv run mkdocs build --strict` still fails on **pre-existing** warnings (missing `api/*` + `contributing.md` nav stubs; out-of-docs link warnings) — same caveat as Lab II docs-review; **not** introduced by this guide
+
+- [x] **3.3 Cross-links (minimal)**
+  - [x] Starters index → guide
+  - [x] Optional “See also” on `docs/index.md` (full index polish may wait for docs checklist / S3)
+
+---
+
+## Acceptance criteria
+
+- [x] Guide file exists and is English, professional, public-safe
+- [x] Nav includes the guide
+- [x] Links to all three `examples/starters/*` resolve
+- [x] DIST-005 producer slice satisfied (guide + nav + starters index + docs/index); homepage link deferred to S3
+- [x] DIST-006 clean
+
+## Reviews
+
+| Date | Tier | Verdict | Report |
+|------|------|---------|--------|
+| 2026-07-18 | T2 | Approved with caveats (r2) | [review-v2.5.4-S0-S2-starters-guide-20260718-r2.md](../../../code-review/private/review-v2.5.4-S0-S2-starters-guide-20260718-r2.md) |
+| 2026-07-18 | C.7 | Rejected (r1) — fixes applied pending r2 | [review-v2.5.4-S0-S2-starters-guide-20260718.md](../../../code-review/private/review-v2.5.4-S0-S2-starters-guide-20260718.md) |
+
+## Relevant files
+
+- `docs/guides/build-for-agents.md`
+- `mkdocs.yml`
+- `docs/index.md`
+- `examples/starters/README.md`
+- [docs-review-checklist.md](./docs-review-checklist.md)

--- a/engineering/tasks/v2.5.4/sprint-S3-homepage-routing.md
+++ b/engineering/tasks/v2.5.4/sprint-S3-homepage-routing.md
@@ -1,0 +1,82 @@
+# Sprint S3: Homepage narrative & CTA routing (v2.5.4)
+
+**PRD**: DIST-001, DIST-002, DIST-005 (homepage link remainder), DIST-006  
+**Branch**: `feat/v2.5.4-s3-homepage-routing` → **`release/2.5.4`**  
+**Depends on**: [S1](./sprint-S1-starter-pack.md), [S2](./sprint-S2-build-for-agents-guide.md)  
+**Status**: Planned
+
+**Trigger:** Guide and starters available for primary CTAs.  
+**Enables:** S5 public web surface.  
+**Depends on:** [docs-review-checklist.md](./docs-review-checklist.md) web/CTA sections.
+
+---
+
+## Goal
+
+Apply D1 hierarchy on the homepage: agent-first primary story and CTAs into the guide/starters; keep marketplace browse/register secondary. Complete docs routing for homepage sections without a full design-system rewrite. **DIST-005 remainder:** link the homepage primary CTA → `docs/guides/build-for-agents.md` (S2 shipped the guide + MkDocs + starters-index + docs/index; homepage link is owned here with DIST-001/002).
+
+---
+
+## Design constraints
+
+- Copy and routing first; avoid full Design System Revamp scope.
+- Preserve stable `data-cta` IDs in `homepage-cta-ids.ts` (add only when necessary; do not rename casually).
+- Do not invent pages—link to shipped guide/starters/docs.
+- DIST-006 continuous review on all public strings touched.
+
+---
+
+## Tasks
+
+- [ ] **4.1 Hero & metadata (DIST-001 + DIST-005 remainder)**
+  - [ ] Update `HeroSection.tsx` / `HeroTerminal.tsx` for agent-first primary narrative
+  - [ ] Primary CTAs → `docs/guides/build-for-agents.md` (DIST-005 homepage half) and/or `examples/starters/`
+  - [ ] Secondary CTAs may remain Explore Agents / Register Agent
+  - [ ] Fix stale version strings (terminal/badge/metadata) toward train version policy
+  - [ ] Align `page.tsx` OG/metadata with D1 (not marketplace-only)
+
+- [ ] **4.2 Section routing (DIST-002)**
+  - [ ] WhatsNew / Features / How it Works: each primary action links to concrete docs, starter, or example
+  - [ ] Audit Lab II CTAs still live; fill gaps on feature/DX cards that lack `docsHref`
+  - [ ] Keep GitHub docs URLs on `main` (or documented tag policy)
+
+- [ ] **4.3 Telemetry IDs**
+  - [ ] Update/extend `homepage-cta-ids.ts` if new CTAs added
+  - [ ] Confirm `CtaClickTracker` / `data-cta` still fire
+
+- [ ] **4.4 DIST-006 copy gate**
+  - [ ] Grep/review homepage + related landing copy for pricing/fundraising/private GTM
+  - [ ] Do not pull content from `product/strategy/` or private PRDs
+
+- [ ] **4.5 Docs review web sections**
+  - [ ] Complete web/CTA items in [docs-review-checklist.md](./docs-review-checklist.md)
+
+---
+
+## Acceptance criteria
+
+- [ ] Hero matches D1 hierarchy
+- [ ] Primary CTAs resolve to live guide/starter/example URLs (including homepage → build-for-agents for DIST-005 remainder)
+- [ ] Marketplace paths remain available but secondary
+- [ ] `data-cta` coherent; no broken primary links
+- [ ] DIST-001, DIST-002, DIST-005 (homepage link), DIST-006 satisfied
+- [ ] Web quality gates pass when run (`lint`, `tsc`, vitest, build)
+
+## Reviews
+
+| Date | Tier | Verdict | Report |
+|------|------|---------|--------|
+| — | — | — | — |
+
+## Relevant files
+
+- `apps/web/src/app/page.tsx`
+- `apps/web/src/components/landing/HeroSection.tsx`
+- `apps/web/src/components/landing/HeroTerminal.tsx`
+- `apps/web/src/components/landing/HowItWorksSection.tsx`
+- `apps/web/src/components/landing/WhatsNewRibbon.tsx`
+- `apps/web/src/components/landing/FeaturesSection.tsx`
+- `apps/web/src/lib/telemetry/homepage-cta-ids.ts`
+- `apps/web/src/app/developer-experience/page.tsx` (only if CTA gaps)
+- `docs/guides/build-for-agents.md`
+- `examples/starters/README.md`

--- a/engineering/tasks/v2.5.4/sprint-S4-telemetry-operations.md
+++ b/engineering/tasks/v2.5.4/sprint-S4-telemetry-operations.md
@@ -1,0 +1,84 @@
+# Sprint S4: Telemetry operations (v2.5.4)
+
+**PRD**: DIST-004 (D4)  
+**Branch**: `feat/v2.5.4-s4-telemetry` → **`release/2.5.4`**  
+**Depends on**: [S0](./sprint-S0-scope-lock.md)  
+**Status**: Planned  
+**Priority**: SHOULD — may defer with explicit roadmap note; must not invent a public dashboard
+
+**Trigger:** S0 confirms operationalize-existing metrics (no live UI).  
+**Enables:** Maintainer adoption visibility; DIST-004 DoD.  
+**Depends on:** Existing `scripts/telemetry/`, `docs/maintainers/telemetry.md`, `/api/telemetry`.
+
+---
+
+## Goal
+
+Close gaps in the existing adoption telemetry pipeline (package coverage, runbook, CI dispatch policy, guide-view proxies). **Do not** build a public metrics page or new analytics stack.
+
+---
+
+## Design constraints
+
+- Output remains under `private/telemetry/` (gitignored).
+- Guide views = GitHub traffic/referrers + site→docs CTR proxies—not MkDocs analytics.
+- Re-enable scheduled workflow **only** after secrets are configured; until then `workflow_dispatch` + documented gap is acceptable.
+- Site CTR may use `TELEMETRY_SITE_METRICS_JSON` / drain; empty shell documented is OK.
+
+---
+
+## Tasks
+
+- [ ] **5.1 Expand collectors**
+  - [ ] npm: ensure aggregate covers `@asap-protocol/client`, `@asap-protocol/mastra`, `@asap-protocol/openai-agents`
+  - [ ] PyPI: ensure aggregate covers `asap-protocol`, `asap-compliance`
+  - [ ] Update `tests/scripts/test_collect_npm.py`, `test_collect_pypi.py`, `test_aggregate.py` as needed
+
+- [ ] **5.2 Guide-view proxy documentation**
+  - [ ] Document in `docs/maintainers/telemetry.md` that guide views use GitHub collectors + site CTA metrics
+  - [ ] Explicitly state MkDocs plugin is out of scope
+
+- [ ] **5.3 Runbook & CI**
+  - [ ] Refresh `docs/maintainers/telemetry.md` for weekly ops + required env vars (`TELEMETRY_GITHUB_TOKEN`, optional site endpoint/token)
+  - [ ] Confirm `.github/workflows/telemetry-weekly.yml` supports `workflow_dispatch`
+  - [ ] Run aggregate once (local or dispatch) → produces `private/telemetry/dashboard.md` (or document blocker)
+  - [ ] Do **not** enable cron until secrets verified
+
+- [ ] **5.4 No public UI**
+  - [ ] Verify no new `/metrics` (or similar) route under `apps/web`
+  - [ ] Keep `/api/telemetry` as existing ingestion only
+
+---
+
+## Skip / defer condition
+
+If secrets or capacity block completion, mark DIST-004 **deferred** on the roadmap with a one-paragraph note before S5. Do not invent a dashboard to force a green check.
+
+---
+
+## Acceptance criteria
+
+- [ ] npm ≥3 and PyPI ≥2 packages in aggregate defaults/config
+- [ ] Runbook describes proxies + how to run aggregate
+- [ ] At least one successful maintainer/CI dispatch **or** documented secrets gap
+- [ ] Tests for collectors/aggregate green
+- [ ] No new public metrics UI
+- [ ] DIST-004 satisfied **or** explicit deferral recorded
+
+## Reviews
+
+| Date | Tier | Verdict | Report |
+|------|------|---------|--------|
+| — | — | — | — |
+
+## Relevant files
+
+- `scripts/telemetry/collect_npm.py`
+- `scripts/telemetry/collect_pypi.py`
+- `scripts/telemetry/collect_github.py`
+- `scripts/telemetry/collect_registry.py`
+- `scripts/telemetry/aggregate.py`
+- `docs/maintainers/telemetry.md`
+- `.github/workflows/telemetry-weekly.yml`
+- `apps/web/src/app/api/telemetry/route.ts`
+- `tests/scripts/test_collect_npm.py`, `test_collect_pypi.py`, `test_aggregate.py`

--- a/engineering/tasks/v2.5.4/sprint-S5-release.md
+++ b/engineering/tasks/v2.5.4/sprint-S5-release.md
@@ -1,0 +1,55 @@
+# Sprint S5: Release v2.5.4
+
+**PRD**: Definition of Done / D5  
+**Branch**: work on **`release/2.5.4`** → PR to **`main`**  
+**Depends on**: S1–S3 MUST green; S4 green **or** deferred on roadmap  
+**Status**: Planned
+
+**Trigger:** Distribution Loop MUST items complete on the release branch.  
+**Enables:** v2.5.5 Formal Spec kickoff.  
+**Depends on:** [release-checklist.md](./release-checklist.md).
+
+**Release sequence:** **merge → tag → publish → handoff** — do not mark SHIPPED before publish.
+
+---
+
+## Tasks
+
+- [ ] **6.1 Version bumps**
+  - [ ] `pyproject.toml` / `src/asap/__init__.py` → **2.5.4**
+  - [ ] npm `@asap-protocol/*`: leave at current line unless a TS package intentionally changed
+
+- [ ] **6.2 Changelog & migration**
+  - [ ] `CHANGELOG.md` → `## [2.5.4]`
+  - [ ] `docs/migration.md` → upgrading from v2.5.3 → v2.5.4 (`#upgrading-from-v253-to-v254`)
+  - [ ] Update `AGENTS.md`, `product/README.md`, `docs/index.md`, `product/checkpoints.md`
+  - [ ] Confirm [docs-review-checklist.md](./docs-review-checklist.md) version-string sign-off
+
+- [ ] **6.3 Pre-push CI**
+  - [ ] `uv run ruff check .`
+  - [ ] `uv run ruff format --check .`
+  - [ ] `uv run mypy src/ scripts/ tests/`
+  - [ ] `uv run pytest --tb=short --cov=asap --cov-report=xml --cov-fail-under=85`
+  - [ ] pip-audit per `SECURITY.md` / `git-commits.mdc`
+  - [ ] If `apps/web/` changed: lint, `tsc`, vitest, build
+  - [ ] MkDocs build if docs/nav changed
+
+- [ ] **6.4 Merge → tag → publish**
+  - [ ] **Merge** PR `release/2.5.4` → `main`
+  - [ ] **Tag** `v2.5.4` + push (triggers release workflow)
+  - [ ] **Publish** — GitHub Release + PyPI `asap-protocol==2.5.4` (+ Docker/GHCR if applicable)
+  - [ ] Post-publish checklist ([release-checklist §6](./release-checklist.md#60-post-publish-swap-pending--shipped))
+
+- [ ] **6.5 Handoff**
+  - [ ] Mark this roadmap SHIPPED
+  - [ ] Complete [release-checklist §5.1](./release-checklist.md#51-handoff-inputs-for-v255-confirm-at-s5) (starter paths, guide, OOS, orphans)
+  - [ ] Point next work at [prd-v2.5.5-formal-spec-interop.md](../../../product/prd/prd-v2.5.5-formal-spec-interop.md)
+  - [ ] Remind: `@asap-protocol/mcp-auth` still on [v2.5.0 backlog](../v2.5.0/backlog-mcp-auth-typescript.md); Economy remains trigger-gated ([prd-v3.0-economy.md](../../../product/prd/prd-v3.0-economy.md))
+
+---
+
+## Acceptance criteria
+
+- [ ] [release-checklist.md](./release-checklist.md) §§1–6 complete
+- [ ] All DIST MUST items closed; DIST-004 closed or deferred
+- [ ] Train handoff to v2.5.5 documented

--- a/engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md
+++ b/engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md
@@ -1,0 +1,177 @@
+# Tasks: v2.5.4 Distribution Loop — Sprint Index
+
+**Status: ACTIVE** — PRD decisions locked 2026-07-18; S0 scope lock done; **`release/2.5.4` exists on origin** (all sprint branches merge into it). **Predecessor:** [v2.5.3](../v2.5.3/tasks-v2.5.3-roadmap.md) SHIPPED. **Next after ship:** [prd-v2.5.5-formal-spec-interop.md](../../../product/prd/prd-v2.5.5-formal-spec-interop.md).
+
+Based on [PRD v2.5.4 Distribution Loop](../../../product/prd/prd-v2.5.4-distribution-loop.md). **Every** sprint PR merges into **`release/2.5.4`** (see [BRANCHING.md](./BRANCHING.md)); only S5 opens one PR to `main`.
+
+## Prerequisites
+
+- [x] v2.5.3 Adapter Lab II shipped (2026-07-16)
+- [x] PRD D1–D5 locked (2026-07-18)
+- [x] Baseline inventory documented in PRD §4 (homepage, CTAs, examples, telemetry)
+- [x] `release/2.5.4` on origin (2026-07-18)
+- [x] Maintainer marks this folder **ACTIVE** (S0 scope lock done 2026-07-18)
+
+## Sprint plan
+
+| Sprint | Focus | PRD | Priority | Status |
+|--------|-------|-----|----------|--------|
+| **S0** | [Scope lock](./sprint-S0-scope-lock.md) | D1–D5, §4 baseline | P0 | Done |
+| **S1** | [Thin starter pack](./sprint-S1-starter-pack.md) | DIST-003 | P0 | Done |
+| **S2** | [Build for agents guide](./sprint-S2-build-for-agents-guide.md) | DIST-005 | P0 | Done |
+| **S3** | [Homepage narrative & CTA routing](./sprint-S3-homepage-routing.md) | DIST-001, DIST-002, DIST-005 (homepage link), DIST-006 | P0 | Planned |
+| **S4** | [Telemetry operations](./sprint-S4-telemetry-operations.md) | DIST-004 | P1 (SHOULD) | Planned |
+| **S5** | [Release v2.5.4](./sprint-S5-release.md) | DoD, D5 | P0 | Planned |
+
+## Dependency graph
+
+```
+S0 (scope lock)
+ │
+ ├──► S1 (starters) ──► S2 (guide) ──┐
+ │         │                         ├──► S3 (homepage + CTAs)
+ │         └─────────────────────────┘
+ │
+ └──► S4 (telemetry ops, parallel; SHOULD)
+                                        │
+                                        ▼
+                                      S5 (release)
+```
+
+S1 and S4 may run in parallel after S0. S2 needs starter paths from S1. S3 needs guide (S2) and starter URLs (S1). S5 requires all MUST items (S1–S3); S4 MAY defer with explicit roadmap note.
+
+## Parent tasks (high-level)
+
+- [x] **1.0 Scope lock (S0)**
+  - **Trigger:** Maintainer kickoff after PRD harden.
+  - **Enables:** S1 starters; S4 telemetry; branch train.
+  - **Depends on:** PRD D1–D5; v2.5.3 shipped.
+  - **Acceptance criteria:**
+    - [x] `release/2.5.4` exists on origin (sprint PRs merge into it)
+    - [x] D1–D5 reconfirmed in sprint notes (no silent swaps)
+    - [x] Baseline gaps listed for S1–S4
+    - [x] Roadmap status → ACTIVE
+
+- [x] **2.0 Thin starter pack (S1)**
+  - **Trigger:** S0 complete.
+  - **Enables:** S2 guide links; S3 primary CTAs.
+  - **Depends on:** Task 1.0; parent examples in tree.
+  - **Acceptance criteria:**
+    - [x] `examples/starters/openapi-provider/`
+    - [x] `examples/starters/typescript-consumer/`
+    - [x] `examples/starters/mcp-auth-bridge/`
+    - [x] Index README + headless smoke per starter
+    - [x] DIST-003 satisfied
+
+- [x] **3.0 Build for agents guide (S2)**
+  - **Trigger:** S1 starter paths known (may draft in parallel once paths locked in S0/S1).
+  - **Enables:** S3 hero CTA target; docs surface.
+  - **Depends on:** Task 2.0 (for live starter links).
+  - **Acceptance criteria:**
+    - [x] `docs/guides/build-for-agents.md` published
+    - [x] `mkdocs.yml` nav entry
+    - [x] Links to all three starters + key adapters
+    - [x] DIST-005 producer slice satisfied (guide + nav + starters index + docs/index); homepage link deferred to S3
+    - [x] DIST-006 copy clean
+
+- [ ] **4.0 Homepage narrative & CTA routing (S3)**
+  - **Trigger:** Guide + starters available for primary CTAs.
+  - **Enables:** S5 public web surface.
+  - **Depends on:** Tasks 2.0–3.0; [docs-review-checklist.md](./docs-review-checklist.md).
+  - **Acceptance criteria:**
+    - [ ] Hero / metadata follow D1 agent-first narrative
+    - [ ] Primary CTAs → guide and/or `examples/starters/`
+    - [ ] Homepage primary CTA → `docs/guides/build-for-agents.md` (DIST-005 homepage half)
+    - [ ] Marketplace browse/register remain secondary
+    - [ ] `data-cta` IDs coherent; live link audit
+    - [ ] DIST-001, DIST-002, DIST-005 (homepage link), DIST-006 satisfied
+
+- [ ] **5.0 Telemetry operations (S4)**
+  - **Trigger:** S0 complete (parallel with S1).
+  - **Enables:** DIST-004 DoD; does not block S5 if deferred.
+  - **Depends on:** Task 1.0; existing `scripts/telemetry/`.
+  - **Acceptance criteria:**
+    - [ ] npm collectors cover ≥3 scoped packages
+    - [ ] PyPI aggregate covers `asap-protocol` + `asap-compliance`
+    - [ ] Guide-view proxy documented (GitHub + site CTR)
+    - [ ] Runbook updated; `workflow_dispatch` green once (or secrets gap documented)
+    - [ ] **No** new public metrics UI
+    - [ ] DIST-004 satisfied **or** explicit defer on roadmap
+
+- [ ] **6.0 Release (S5)**
+  - **Trigger:** MUST sprints green on `release/2.5.4`.
+  - **Enables:** v2.5.5 Formal Spec kickoff.
+  - **Depends on:** Tasks 2.0–4.0; Task 5.0 or documented deferral; [release-checklist.md](./release-checklist.md).
+  - **Sequence:** **merge → tag → publish → handoff** (do not mark SHIPPED before publish).
+  - **Acceptance criteria:**
+    - [ ] Version **2.5.4**, CHANGELOG, migration note
+    - [ ] Pre-push CI green (ruff, mypy, pytest ≥85%, pip-audit; web gates if touched)
+    - [ ] Merge `release/2.5.4` → `main`
+    - [ ] Tag `v2.5.4` + PyPI / GitHub Release green
+    - [ ] Post-publish swap pending → shipped
+    - [ ] Handoff to v2.5.5
+
+## Definition of Done — v2.5.4
+
+- [ ] DIST-001 — homepage agent-first (D1)
+- [ ] DIST-002 — CTAs → docs/starters/examples
+- [ ] DIST-003 — three thin starters at locked paths
+- [ ] DIST-004 — telemetry ops documented/runnable **or** deferred
+- [ ] DIST-005 — `docs/guides/build-for-agents.md` shipped
+- [ ] DIST-006 — no private GTM/pricing/fundraising in public copy
+- [ ] [docs-review-checklist.md](./docs-review-checklist.md) signed
+- [ ] [release-checklist.md](./release-checklist.md) §§1–6 complete
+
+## Out of scope (defer)
+
+| Item | Where |
+|------|--------|
+| Full Design System Revamp | Separate design track |
+| `create-asap` / scaffold CLI | Post–v2.5.4 |
+| Public live metrics dashboard | PRD D4 |
+| MkDocs analytics plugin | PRD §3.2 proxies only |
+| `@asap-protocol/mcp-auth` | [../v2.5.0/backlog-mcp-auth-typescript.md](../v2.5.0/backlog-mcp-auth-typescript.md) |
+| Formal Spec / A2A | [prd-v2.5.5-formal-spec-interop.md](../../../product/prd/prd-v2.5.5-formal-spec-interop.md) (soft successor; see Dist PRD §11) |
+| Economy / pricing | [prd-v3.0-economy.md](../../../product/prd/prd-v3.0-economy.md) (trigger-gated) |
+| Workflow as 4th starter | Optional; `examples/workflow_asap_connector/` already public |
+| Orphan owners (mcp-auth, TSOA, …) | [prd-v2.5-roadmap.md](../../../product/prd/prd-v2.5-roadmap.md) parked table |
+
+## Relevant files (planned)
+
+### Likely new
+
+- `examples/starters/README.md`
+- `examples/starters/openapi-provider/`
+- `examples/starters/typescript-consumer/`
+- `examples/starters/mcp-auth-bridge/`
+- `docs/guides/build-for-agents.md`
+
+### Likely modify
+
+- `apps/web/src/components/landing/*` — hero, terminal, how-it-works, what's new, features
+- `apps/web/src/lib/telemetry/homepage-cta-ids.ts`
+- `apps/web/src/app/page.tsx` — metadata
+- `mkdocs.yml`, `docs/index.md`
+- `scripts/telemetry/collect_npm.py`, `aggregate.py`, related tests
+- `docs/maintainers/telemetry.md`
+- `.github/workflows/telemetry-weekly.yml` — dispatch/schedule policy only when secrets ready
+- `pyproject.toml`, `src/asap/__init__.py`, `CHANGELOG.md`, `docs/migration.md`
+- `AGENTS.md`, `product/checkpoints.md`, `product/README.md`
+
+### Reference
+
+- `examples/openapi_petstore/`, `examples/mcp_auth_bridge/`
+- `apps/example-nextjs/`, `packages/typescript/client`
+- `docs/adapters/openapi.md`, `docs/adapters/mcp-auth-bridge.md`, `docs/sdks/typescript.md`
+- `engineering/tasks/v2.5.3/` — prior train pattern
+
+## Change log
+
+| Date | Change |
+|------|--------|
+| 2026-07-18 | Train handoff §11 / release-checklist §5.1; orphan owners; Spec/Economy cross-links before kickoff |
+| 2026-07-18 | `release/2.5.4` on origin; [BRANCHING.md](./BRANCHING.md) locks all sprint PRs → integration branch |
+| 2026-07-18 | Initial sprint index from hardened PRD (D1–D5, DIST-001..006); S0–S5 |
+| 2026-07-18 | S0 complete: D1–D5 reconfirmed; gaps listed; status → ACTIVE; working branch `feat/v2.5.4-s0-s2-starters-guide` |
+| 2026-07-18 | S2 complete: `docs/guides/build-for-agents.md` + MkDocs nav + index/starters cross-links (DIST-005 producer slice; homepage link → S3) |
+| 2026-07-18 | C.7 review feedback: DIST-005 ownership clarified; TypeScript smoke package-boundary + HTTPS enforce |

--- a/examples/starters/README.md
+++ b/examples/starters/README.md
@@ -1,0 +1,17 @@
+# ASAP thin starters (v2.5.4)
+
+Thin wrappers around the canonical parent examples and apps. Prefer these entrypoints for a fast smoke; use the parent paths for the full implementation.
+
+For the adoption path (discover → execute → escalate), see [Build for Agents](../../docs/guides/build-for-agents.md).
+
+## Starters
+
+| Starter | Path | Parent | Docs |
+|---------|------|--------|------|
+| OpenAPI provider | [`openapi-provider/`](./openapi-provider/) | [`examples/openapi_petstore/`](../openapi_petstore/) | [`docs/adapters/openapi.md`](../../docs/adapters/openapi.md) |
+| TypeScript consumer | [`typescript-consumer/`](./typescript-consumer/) | [`apps/example-nextjs/`](../../apps/example-nextjs/) | [`docs/sdks/typescript.md`](../../docs/sdks/typescript.md) |
+| MCP Auth Bridge | [`mcp-auth-bridge/`](./mcp-auth-bridge/) | [`examples/mcp_auth_bridge/`](../mcp_auth_bridge/) | [`docs/adapters/mcp-auth-bridge.md`](../../docs/adapters/mcp-auth-bridge.md) |
+
+## Design
+
+Each starter is a short script that invokes the parent via subprocess (or a thin Node CLI for TypeScript). Parent trees remain the source of truth—do not treat starter directories as a second copy of OpenAPI fragments, server code, or Next.js apps.

--- a/examples/starters/mcp-auth-bridge/README.md
+++ b/examples/starters/mcp-auth-bridge/README.md
@@ -1,0 +1,35 @@
+# MCP Auth Bridge starter
+
+Thin wrapper around the Mode A native MCP protection demo
+(`asap.adapters.mcp.protect_server`). The parent client spawns the demo
+server, mints keys at runtime, and exercises `echo` (public) plus
+`secure_action` (Agent JWT via `_meta`).
+
+## Prerequisites
+
+- Python 3.13+
+- `uv`
+
+```bash
+uv sync
+```
+
+## Smoke
+
+From the repository root:
+
+```bash
+uv run python examples/starters/mcp-auth-bridge/run.py
+```
+
+## Security
+
+- Do **not** pass a real JWT on the CLI (`argv` leaks secrets).
+- Do **not** enable `allow_env_jwt_fallback` in production (parent example enables it for local docs only).
+- Keys and demo JWTs are minted in the child process; a token from another terminal will fail signature checks.
+
+## Related
+
+- Parent: [`examples/mcp_auth_bridge/`](../../mcp_auth_bridge/)
+- Adapter guide: [`docs/adapters/mcp-auth-bridge.md`](../../../docs/adapters/mcp-auth-bridge.md)
+- Starters index: [`../README.md`](../README.md)

--- a/examples/starters/mcp-auth-bridge/run.py
+++ b/examples/starters/mcp-auth-bridge/run.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 # examples/starters/mcp-auth-bridge → examples/
 _PARENT = Path(__file__).resolve().parents[2] / "mcp_auth_bridge" / "client.py"
+_SMOKE_TIMEOUT_SEC = 60
 
 
 def main() -> None:
@@ -24,10 +25,20 @@ def main() -> None:
             file=sys.stderr,
         )
         sys.exit(1)
-    completed = subprocess.run(
-        [sys.executable, str(_PARENT), *sys.argv[1:]],
-        check=False,
-    )
+    cmd = [sys.executable, str(_PARENT), *sys.argv[1:]]
+    try:
+        completed = subprocess.run(
+            cmd,
+            check=False,
+            timeout=_SMOKE_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"MCP Auth Bridge starter smoke exceeded {_SMOKE_TIMEOUT_SEC}s limit "
+            f"(DIST-003 headless bound). Command: {cmd!r}",
+            file=sys.stderr,
+        )
+        sys.exit(124)
     sys.exit(completed.returncode)
 
 

--- a/examples/starters/mcp-auth-bridge/run.py
+++ b/examples/starters/mcp-auth-bridge/run.py
@@ -1,0 +1,35 @@
+"""Thin starter: invoke the MCP Auth Bridge parent client via subprocess."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# examples/starters/mcp-auth-bridge → examples/
+_PARENT = Path(__file__).resolve().parents[2] / "mcp_auth_bridge" / "client.py"
+
+
+def main() -> None:
+    """Forward argv to ``examples/mcp_auth_bridge/client.py`` and exit with its code.
+
+    Example::
+
+        uv run python examples/starters/mcp-auth-bridge/run.py
+    """
+    if not _PARENT.is_file():
+        print(
+            f"Parent example not found at {_PARENT} "
+            f"(expected examples/mcp_auth_bridge/client.py relative to repo).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    completed = subprocess.run(
+        [sys.executable, str(_PARENT), *sys.argv[1:]],
+        check=False,
+    )
+    sys.exit(completed.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/starters/openapi-provider/README.md
+++ b/examples/starters/openapi-provider/README.md
@@ -1,0 +1,35 @@
+# OpenAPI provider starter
+
+Thin wrapper around the PetStore OpenAPI → ASAP demo. The parent owns
+`openapi-fragment.json` and the full script; this starter only re-invokes it.
+
+## Prerequisites
+
+- Python 3.13+
+- `uv`
+
+```bash
+uv sync --extra openapi
+```
+
+## Smoke (default: bundled fragment + mock upstream)
+
+From the repository root:
+
+```bash
+uv run python examples/starters/openapi-provider/run.py
+```
+
+## Live public PetStore (optional)
+
+Requires network access over **HTTPS**. The remote API may return errors; prefer the default mock smoke for CI and offline checks.
+
+```bash
+uv run python examples/starters/openapi-provider/run.py --live
+```
+
+## Related
+
+- Parent: [`examples/openapi_petstore/`](../../openapi_petstore/)
+- Adapter guide: [`docs/adapters/openapi.md`](../../../docs/adapters/openapi.md)
+- Starters index: [`../README.md`](../README.md)

--- a/examples/starters/openapi-provider/run.py
+++ b/examples/starters/openapi-provider/run.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 # examples/starters/openapi-provider → examples/
 _PARENT = Path(__file__).resolve().parents[2] / "openapi_petstore" / "main.py"
+_SMOKE_TIMEOUT_SEC = 60
 
 
 def main() -> None:
@@ -24,10 +25,20 @@ def main() -> None:
             file=sys.stderr,
         )
         sys.exit(1)
-    completed = subprocess.run(
-        [sys.executable, str(_PARENT), *sys.argv[1:]],
-        check=False,
-    )
+    cmd = [sys.executable, str(_PARENT), *sys.argv[1:]]
+    try:
+        completed = subprocess.run(
+            cmd,
+            check=False,
+            timeout=_SMOKE_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"OpenAPI starter smoke exceeded {_SMOKE_TIMEOUT_SEC}s limit "
+            f"(DIST-003 headless bound). Command: {cmd!r}",
+            file=sys.stderr,
+        )
+        sys.exit(124)
     sys.exit(completed.returncode)
 
 

--- a/examples/starters/openapi-provider/run.py
+++ b/examples/starters/openapi-provider/run.py
@@ -1,0 +1,35 @@
+"""Thin starter: invoke the OpenAPI PetStore parent example via subprocess."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# examples/starters/openapi-provider → examples/
+_PARENT = Path(__file__).resolve().parents[2] / "openapi_petstore" / "main.py"
+
+
+def main() -> None:
+    """Forward argv to ``examples/openapi_petstore/main.py`` and exit with its code.
+
+    Example::
+
+        uv run python examples/starters/openapi-provider/run.py
+    """
+    if not _PARENT.is_file():
+        print(
+            f"Parent example not found at {_PARENT} "
+            f"(expected examples/openapi_petstore/main.py relative to repo).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    completed = subprocess.run(
+        [sys.executable, str(_PARENT), *sys.argv[1:]],
+        check=False,
+    )
+    sys.exit(completed.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/starters/typescript-consumer/.env.example
+++ b/examples/starters/typescript-consumer/.env.example
@@ -1,0 +1,3 @@
+# Optional live discover/list path (leave unset for offline smoke).
+# Prefer HTTPS/TLS for remote providers.
+# ASAP_PROVIDER_URL=https://provider.example.com

--- a/examples/starters/typescript-consumer/README.md
+++ b/examples/starters/typescript-consumer/README.md
@@ -7,6 +7,7 @@ The full browser demo stays at [`apps/example-nextjs/`](../../../apps/example-ne
 ## Prerequisites
 
 - Node.js **≥ 18**
+- Workspace install (`pnpm install` at the repo root) so `packages/typescript/client` has its build toolchain (e.g. `tshy`)
 - Built client package (`packages/typescript/client` → `dist/`)
 
 ## Smoke (offline, default)
@@ -14,14 +15,15 @@ The full browser demo stays at [`apps/example-nextjs/`](../../../apps/example-ne
 From the **repository root** (headless, ≤60s, no API keys, no live gateway):
 
 ```bash
+pnpm install
 pnpm --filter @asap-protocol/client run build
 npm install --prefix examples/starters/typescript-consumer
 node examples/starters/typescript-consumer/smoke.mjs
 ```
 
-Builds `@asap-protocol/client`, installs the starter’s `file:` dependency, then runs the identity smoke. Expect `typescript-consumer smoke: PASS`.
+Installs workspace deps (required on a fresh clone), builds `@asap-protocol/client`, installs the starter’s `file:` dependency, then runs the identity smoke. Expect `typescript-consumer smoke: PASS`.
 
-Or from this directory after the client is built:
+Or from this directory after the workspace install and client build:
 
 ```bash
 npm install && npm run smoke
@@ -34,6 +36,7 @@ Do **not** use bare `pnpm run smoke` here — this starter lives outside the pnp
 Set `ASAP_PROVIDER_URL` to a provider base URL to also call `discoverProvider` and `listCapabilities`. See [`.env.example`](./.env.example).
 
 ```bash
+pnpm install
 pnpm --filter @asap-protocol/client run build
 npm install --prefix examples/starters/typescript-consumer
 ASAP_PROVIDER_URL=https://provider.example.com \

--- a/examples/starters/typescript-consumer/README.md
+++ b/examples/starters/typescript-consumer/README.md
@@ -1,0 +1,51 @@
+# TypeScript consumer starter
+
+Thin **Node CLI** smoke for [`@asap-protocol/client`](../../../packages/typescript/client/). It proves Host/Agent identity offline (same APIs as the Next demo) without scaffolding a second web app.
+
+The full browser demo stays at [`apps/example-nextjs/`](../../../apps/example-nextjs/). SDK reference: [`docs/sdks/typescript.md`](../../../docs/sdks/typescript.md).
+
+## Prerequisites
+
+- Node.js **≥ 18**
+- Built client package (`packages/typescript/client` → `dist/`)
+
+## Smoke (offline, default)
+
+From the **repository root** (headless, ≤60s, no API keys, no live gateway):
+
+```bash
+pnpm --filter @asap-protocol/client run build
+npm install --prefix examples/starters/typescript-consumer
+node examples/starters/typescript-consumer/smoke.mjs
+```
+
+Builds `@asap-protocol/client`, installs the starter’s `file:` dependency, then runs the identity smoke. Expect `typescript-consumer smoke: PASS`.
+
+Or from this directory after the client is built:
+
+```bash
+npm install && npm run smoke
+```
+
+Do **not** use bare `pnpm run smoke` here — this starter lives outside the pnpm workspace (`examples/` is not a workspace package).
+
+## Optional live path
+
+Set `ASAP_PROVIDER_URL` to a provider base URL to also call `discoverProvider` and `listCapabilities`. See [`.env.example`](./.env.example).
+
+```bash
+pnpm --filter @asap-protocol/client run build
+npm install --prefix examples/starters/typescript-consumer
+ASAP_PROVIDER_URL=https://provider.example.com \
+  node examples/starters/typescript-consumer/smoke.mjs
+```
+
+**HTTPS is required** for non-loopback hosts on both `ASAP_PROVIDER_URL` and the discovered `manifest.endpoints.asap`. Plain `http://` is allowed only for loopback (`127.0.0.1`, `localhost`, `::1`).
+
+## Storage note
+
+This CLI uses **`MemoryStorage`** (ephemeral). The Next.js demo uses **`LocalStorage`** so identity survives page reloads. For durable Node/CLI storage, see `FileStorage` / `KeychainStorage` under `@asap-protocol/client/storage-node` in the SDK docs.
+
+## Dependency
+
+`package.json` pins the monorepo client via a relative `file:` path (`examples/` is outside the pnpm workspace). After `npm install`, `smoke.mjs` imports `@asap-protocol/client` through the package boundary (not a direct `dist/` path).

--- a/examples/starters/typescript-consumer/package-lock.json
+++ b/examples/starters/typescript-consumer/package-lock.json
@@ -1,0 +1,65 @@
+{
+  "name": "@asap-protocol/starter-typescript-consumer",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@asap-protocol/starter-typescript-consumer",
+      "version": "0.0.0",
+      "dependencies": {
+        "@asap-protocol/client": "file:../../../packages/typescript/client"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "../../../packages/typescript/client": {
+      "name": "@asap-protocol/client",
+      "version": "2.4.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/ed25519": "^3.1.0",
+        "jose": "^6.0.10",
+        "ulid": "^3.0.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "9.18.0",
+        "@types/node": "^20.19.0",
+        "@vitest/coverage-v8": "4.1.5",
+        "agadoo": "3.0.0",
+        "ai": "^6.0.174",
+        "eslint": "9.18.0",
+        "tsd": "^0.33.0",
+        "tshy": "^3.3.2",
+        "typescript": "^5.8.3",
+        "typescript-eslint": "8.59.1",
+        "vitest": "^4.1.1",
+        "zod": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ai": "^6.0.0",
+        "keytar": "^7.9.0",
+        "zod": "^3.25.76 || ^4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "ai": {
+          "optional": true
+        },
+        "keytar": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@asap-protocol/client": {
+      "resolved": "../../../packages/typescript/client",
+      "link": true
+    }
+  }
+}

--- a/examples/starters/typescript-consumer/package.json
+++ b/examples/starters/typescript-consumer/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@asap-protocol/starter-typescript-consumer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Thin Node CLI smoke for @asap-protocol/client (v2.5.4 DIST-003)",
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@asap-protocol/client": "file:../../../packages/typescript/client"
+  },
+  "scripts": {
+    "smoke": "node ./smoke.mjs"
+  }
+}

--- a/examples/starters/typescript-consumer/smoke.mjs
+++ b/examples/starters/typescript-consumer/smoke.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Thin TypeScript consumer smoke (DIST-003 / D2 / D3).
+ *
+ * Offline by default: createHost + createAgent with MemoryStorage.
+ * Optional live path: set ASAP_PROVIDER_URL to discover + list capabilities.
+ *
+ * Non-loopback URLs must use HTTPS (TLS). No API keys required for the default path.
+ */
+import {
+  createHost,
+  createAgent,
+  MemoryStorage,
+  discoverProvider,
+  listCapabilities,
+} from "@asap-protocol/client";
+
+/**
+ * Require https: for remote hosts; allow http: only for loopback.
+ *
+ * @param {string} urlString
+ * @param {string} label
+ * @returns {URL}
+ */
+function assertHttpsOrLoopback(urlString, label) {
+  let url;
+  try {
+    url = new URL(urlString);
+  } catch {
+    throw new Error(
+      `${label} must be an absolute http(s) URL, got: ${JSON.stringify(urlString)}`,
+    );
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(
+      `${label} must use http: or https:, got protocol ${JSON.stringify(url.protocol)} for ${JSON.stringify(urlString)}`,
+    );
+  }
+
+  if (url.protocol === "https:") {
+    return url;
+  }
+
+  const host = url.hostname.toLowerCase();
+  const isLoopback =
+    host === "127.0.0.1" || host === "localhost" || host === "::1";
+  if (!isLoopback) {
+    throw new Error(
+      `${label} must use HTTPS for non-loopback hosts; got ${JSON.stringify(urlString)} (host=${host}). Loopback http://127.0.0.1 / localhost / ::1 is allowed.`,
+    );
+  }
+  return url;
+}
+
+async function runOfflineIdentity() {
+  const storage = new MemoryStorage();
+  const host = await createHost({ storage });
+  const agent = await createAgent(host, { mode: "delegated" });
+  return { host, agent };
+}
+
+async function runOptionalLive(agent) {
+  const raw = process.env.ASAP_PROVIDER_URL?.trim();
+  if (raw === undefined || raw.length === 0) {
+    return null;
+  }
+
+  assertHttpsOrLoopback(raw, "ASAP_PROVIDER_URL");
+
+  const manifest = await discoverProvider(raw);
+  const asapEndpoint = manifest.endpoints?.asap;
+  if (typeof asapEndpoint !== "string" || asapEndpoint.length === 0) {
+    throw new Error(
+      `manifest.endpoints.asap must be a non-empty string URL, got: ${JSON.stringify(asapEndpoint)}`,
+    );
+  }
+  const provider = assertHttpsOrLoopback(
+    asapEndpoint,
+    "manifest.endpoints.asap",
+  );
+  const agentJwt = await agent.signAgentJwt({ aud: provider.origin });
+  const listed = await listCapabilities(provider, { agentJwt });
+  return {
+    providerId: manifest.id,
+    providerName: manifest.name,
+    capabilityCount: listed.capabilities.length,
+  };
+}
+
+async function main() {
+  const { host, agent } = await runOfflineIdentity();
+  console.log(
+    `identity ok: host=${host.hostId} agent=${agent.agentId} mode=${agent.mode}`,
+  );
+
+  const live = await runOptionalLive(agent);
+  if (live !== null) {
+    console.log(
+      `live ok: provider=${live.providerId} (${live.providerName}) capabilities=${live.capabilityCount}`,
+    );
+  } else {
+    console.log("live skipped: ASAP_PROVIDER_URL unset (offline smoke)");
+  }
+
+  console.log("typescript-consumer smoke: PASS");
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`typescript-consumer smoke: FAIL — ${msg}`);
+  process.exit(1);
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - ADR-016 Versioning Policy: adr/ADR-016-versioning-policy.md
       - ADR-017 Failure Injection: adr/ADR-017-failure-injection-strategy.md
   - Guides:
+      - Build for agents: guides/build-for-agents.md
       - Identity Signing (v1.2): guides/identity-signing.md
       - Compliance Testing (v1.2): guides/compliance-testing.md
       - Migration v1.1 → v1.2: guides/migration-v1.1-to-v1.2.md

--- a/product/README.md
+++ b/product/README.md
@@ -47,10 +47,10 @@ product/
 | **v2.5.1 — Code quality patch** | **✅ Released (2026-06-26)** | `engineering/tasks/private/v2.5.1/` | Thermo-nuclear audit S0–S3 + P0 fixes; Adapter Lab II slipped |
 | **v2.5.2 — Security follow-up** | **✅ Released (2026-07-08)** | `prd-v2.5.2-security-follow-up.md` | #209 + CR #245–#249 + registry fixes (ex planned v2.5.4); tag [`v2.5.2`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.2) |
 | **v2.5.3 — Adapter Lab II** | **✅ Released (2026-07-16)** | `prd-v2.5.3-adapter-lab-ii.md` + [tasks](../engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md) | Workflow connectors, automation security, experimental MAF / NAT; tag [`v2.5.3`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.3) |
-| v2.5.4 — Distribution Loop | 🔭 Planned (after 2.5.3) | `prd-v2.5.4-distribution-loop.md` | Homepage, templates, metrics (ex v2.3.3) |
-| v2.5.5 — Formal Spec & Interop | 🔭 Planned | `prd-v2.5.5-formal-spec-interop.md` | RFC spec, introspection, privacy, cross-protocol |
-| v2.5.x train index | Active | `prd-v2.5-roadmap.md` | Full schedule + rescope log |
-| v3.0 — Economy | 🔭 Long-term | `prd-v3.0-economy.md` | Settlement, billing |
+| v2.5.4 — Distribution Loop | 🚧 Active (In progress) | `prd-v2.5.4-distribution-loop.md` + [tasks](../engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md) | Homepage, starters, metrics ops; handoff → Spec §11; `release/2.5.4` on origin |
+| v2.5.5 — Formal Spec & Interop | 🔭 Planned | `prd-v2.5.5-formal-spec-interop.md` | RFC spec, introspection, privacy, cross-protocol (soft Dist inputs) |
+| v2.5.x train index | Active | `prd-v2.5-roadmap.md` | Full schedule + orphan owners + rescope log |
+| v3.0 — Economy | 🔭 Long-term (triggers) | `prd-v3.0-economy.md` | Settlement, billing; ADR-21 free badge until launch |
 
 > **Strategic note**: Registry API Backend (PostgreSQL), Intent-Based Search, Orchestration Primitives, Delegated/Autonomous Mode formalization, and DeepEval remain deferred until their triggers materialize. **Adoption continuation** (Adapter Lab II, Distribution Loop) lives in the **v2.5.3–v2.5.4** train after the v2.5.2 security follow-up. Local strategy hub (when present): [strategy/roadmap.md](./strategy/roadmap.md). Public train: [prd/README.md](./prd/README.md).
 

--- a/product/checkpoints.md
+++ b/product/checkpoints.md
@@ -3,7 +3,7 @@
 > **Purpose**: Formal review points to update documentation with learnings (product follow-up after releases).
 > **Location**: Lives under **`product/`** because it drives PRD updates and retros, not day-to-day engineering execution.
 > **Created**: 2026-02-06
-> **Updated**: 2026-07-16 — **v2.5.3 shipped** (tag [`v2.5.3`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.3)); PyPI **2.5.3**. Train next: Distribution Loop → **v2.5.4**; Formal Spec → **v2.5.5**.
+> **Updated**: 2026-07-18 — **v2.5.3 shipped**; next execution = **v2.5.4** Distribution Loop ([tasks](../engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md), `release/2.5.4` on origin). Soft successor = **v2.5.5** Formal Spec; long-term = **v3.0** Economy (trigger-gated).
 
 ---
 
@@ -30,10 +30,11 @@ Use this section first; the checkpoint sections below add detail or archive.
 | **v2.5.0 — MCP Auth Bridge** | **Released** **2026-06-24** — `asap.adapters.mcp` (`protect_server`), stdio JWT carriage, compliance profile `mcp-auth-bridge`, [adapter guide](../docs/adapters/mcp-auth-bridge.md) ([`CHANGELOG.md`](../CHANGELOG.md#250---2026-06-24), [migration](../docs/migration.md#upgrading-from-v241-to-v250), [PRD](./prd/prd-v2.5.0-mcp-auth-bridge.md)). Tag **v2.5.0**; PyPI/Docker via [sprint-S5-release.md](../engineering/tasks/v2.5.0/sprint-S5-release.md). | **`asap-compliance` 1.3.0** on PyPI (tag **v2.5.0.1**); `@asap-protocol/mcp-auth` ([backlog](../engineering/tasks/v2.5.0/backlog-mcp-auth-typescript.md)). |
 | **v2.5.1 — Code quality patch** | **Released** **2026-06-26** — behavior-preserving refactor + six P0 fixes. PR [#244](https://github.com/adriannoes/asap-protocol/pull/244). Tag **v2.5.1**. ([`CHANGELOG.md`](../CHANGELOG.md#251---2026-06-25), [migration](../docs/migration.md#upgrading-from-v250-to-v251)). | Follow-ups #245–#249 **closed** in v2.5.2; Adapter Lab II → **v2.5.3**. |
 | **v2.5.2 — Security follow-up** | **Released** **2026-07-08** — #209 (operator auth, `extra="forbid"`, Redis JTI, web rate limits) + CR #245–#249 + registry #224/#227 + deps #258. PR [#281](https://github.com/adriannoes/asap-protocol/pull/281); tag **v2.5.2**; PyPI **2.5.2**. [PRD](./prd/prd-v2.5.2-security-follow-up.md), [`CHANGELOG`](../CHANGELOG.md#252---2026-07-08), [migration](../docs/migration.md#upgrading-from-v251). | CP-7 for 2.5.2. |
-| **v2.5.3 — Adapter Lab II** | **Merge-ready** **2026-07-14** — workflow connectors, automation security, experimental MAF / NAT guides, DX fixes. [PRD](./prd/prd-v2.5.3-adapter-lab-ii.md), [`CHANGELOG`](../CHANGELOG.md#253---2026-07-14), [migration](../docs/migration.md#upgrading-from-v252-to-v253); tasks [tasks-v2.5.3-roadmap.md](../engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md). | **Pending tag/publish**; PyPI still **2.5.2**; next **v2.5.4**. |
-| **After v2.5.3** | Train: Distribution Loop → **v2.5.4**, Formal Spec → **v2.5.5**. | Kickoff [prd-v2.5.4-distribution-loop.md](./prd/prd-v2.5.4-distribution-loop.md) when ready. |
+| **v2.5.3 — Adapter Lab II** | **Released** **2026-07-16** — workflow connectors, automation security, experimental MAF / NAT guides, DX fixes. Tag [`v2.5.3`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.3); PyPI **2.5.3**; PR [#291](https://github.com/adriannoes/asap-protocol/pull/291). [PRD](./prd/prd-v2.5.3-adapter-lab-ii.md), [`CHANGELOG`](../CHANGELOG.md#253---2026-07-14), [migration](../docs/migration.md#upgrading-from-v252-to-v253); tasks [tasks-v2.5.3-roadmap.md](../engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md). | Optional Lab II retro; fourth starter not required. |
+| **v2.5.4 — Distribution Loop** | **In progress** — decisions D1–D5 locked; S0–S2 producer done; tasks [tasks-v2.5.4-roadmap.md](../engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md) **ACTIVE**; `release/2.5.4` on origin; PRD [prd-v2.5.4-distribution-loop.md](./prd/prd-v2.5.4-distribution-loop.md) (§11 handoff → Spec). | Execute S3–S5; ship tag `v2.5.4`. |
+| **After Dist Loop** | Soft: Formal Spec → **v2.5.5**. Long-term: Economy → **v3.0** (triggers). | Create `engineering/tasks/v2.5.5/` at Spec kickoff; do not start Economy without triggers. |
 
-**Sources of truth for current execution**: [prd-v2.5-roadmap.md](./prd/prd-v2.5-roadmap.md), [prd-v2.5.3-adapter-lab-ii.md](./prd/prd-v2.5.3-adapter-lab-ii.md), [tasks-v2.5.3-roadmap.md](../engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md), [AGENTS.md](../AGENTS.md).
+**Sources of truth for current execution**: [prd-v2.5-roadmap.md](./prd/prd-v2.5-roadmap.md), [prd-v2.5.4-distribution-loop.md](./prd/prd-v2.5.4-distribution-loop.md), [tasks-v2.5.4-roadmap.md](../engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md), [BRANCHING.md](../engineering/tasks/v2.5.4/BRANCHING.md), [AGENTS.md](../AGENTS.md).
 
 ---
 
@@ -245,13 +246,14 @@ Track actual vs estimated to improve future planning:
 
 ## Related Documents
 
-- [PRD v2.0 — Marketplace roadmap](./prd/prd-v2.0-roadmap.md)
-- [PRD v2.3 — Adoption multiplier](./prd/prd-v2.3-scale.md)
 - [PRD v2.5.x train](./prd/prd-v2.5-roadmap.md)
+- [PRD v2.5.4 — Distribution Loop](./prd/prd-v2.5.4-distribution-loop.md) · [tasks](../engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md)
+- [PRD v2.5.5 — Formal Spec](./prd/prd-v2.5.5-formal-spec-interop.md)
+- [PRD v3.0 — Economy](./prd/prd-v3.0-economy.md)
 - [PRD v2.5.0 — MCP Auth Bridge](./prd/prd-v2.5.0-mcp-auth-bridge.md)
-- [Tasks v2.5.0 roadmap](../engineering/tasks/v2.5.0/tasks-v2.5.0-roadmap.md)
+- [PRD v2.3 — Adoption multiplier](./prd/prd-v2.3-scale.md)
+- [PRD v2.0 — Marketplace roadmap](./prd/prd-v2.0-roadmap.md)
 - [Product strategy ADRs (deferrals & pivots)](./decision-records/05-product-strategy.md)
-- [v2.0-marketplace-usage-foundation.md](../engineering/tasks/v2.0.0/v2.0-marketplace-usage-foundation.md) — Usage storage & control for v2.0
 - [lessons-learned/](../engineering/lessons-learned/)
 
 ---
@@ -274,4 +276,5 @@ Track actual vs estimated to improve future planning:
 | 2026-06-26 | **v2.5.1 ship + doc sync**: Status roll-up for the code quality patch (thermo-nuclear audit S0–S3 + six P0 fixes); README, `docs/index.md`, `docs/migration.md`, AGENTS.md, `apps/web` WhatsNewRibbon, `engineering/tasks/README.md` aligned with **2.5.1**; Adapter Lab II slipped to v2.5.2; follow-ups filed (#245–#249); velocity row for v2.5.1 added. |
 | 2026-07-08 | **Train rescope**: v2.5.2 = security follow-up; Adapter Lab II → v2.5.3; Distribution Loop → v2.5.4; Formal Spec → v2.5.5; PRDs renamed; [prd-v2.5.2-security-follow-up.md](./prd/prd-v2.5.2-security-follow-up.md) created. |
 | 2026-07-08 | **v2.5.2 ship**: tag [`v2.5.2`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.2); PyPI **2.5.2**; [#209](https://github.com/adriannoes/asap-protocol/issues/209) closed; status roll-up flipped to Released. |
+| 2026-07-18 | **Pre–v2.5.4 kickoff sync**: roll-up v2.5.3 → Released; v2.5.4 Ready + tasks; sources of truth → Dist Loop; Dist→Spec→Economy handoff documented in PRDs |
 | 2026-07-11 | **v2.5.3 task plan**: [tasks-v2.5.3-roadmap.md](../engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md) + PRD READY FOR KICKOFF (D1–D6). |

--- a/product/prd/README.md
+++ b/product/prd/README.md
@@ -11,9 +11,9 @@ Index of versioned PRDs. **Shipped** releases have retrospective PRDs; **planned
 | Version | File | Status |
 |---------|------|--------|
 | **v2.5.x train** | [prd-v2.5-roadmap.md](./prd-v2.5-roadmap.md) | Index |
-| v2.5.4 Distribution Loop | [prd-v2.5.4-distribution-loop.md](./prd-v2.5.4-distribution-loop.md) | Ready for kickoff |
-| v2.5.5 Formal Spec & Interop | [prd-v2.5.5-formal-spec-interop.md](./prd-v2.5.5-formal-spec-interop.md) | Planned |
-| v3.0 Economy | [prd-v3.0-economy.md](./prd-v3.0-economy.md) | Vision |
+| v2.5.4 Distribution Loop | [prd-v2.5.4-distribution-loop.md](./prd-v2.5.4-distribution-loop.md) · [tasks](../../engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md) | Active (tasks ACTIVE; `release/2.5.4` on origin) |
+| v2.5.5 Formal Spec & Interop | [prd-v2.5.5-formal-spec-interop.md](./prd-v2.5.5-formal-spec-interop.md) | Planned (soft-block on Dist; handoff in Dist §11) |
+| v3.0 Economy | [prd-v3.0-economy.md](./prd-v3.0-economy.md) | Vision draft (trigger-gated; Dist metrics = proxies) |
 
 ---
 

--- a/product/prd/prd-v2.5-roadmap.md
+++ b/product/prd/prd-v2.5-roadmap.md
@@ -5,7 +5,7 @@
 > **Version**: 2.5.x
 > **Status**: ACTIVE
 > **Created**: 2026-06-22
-> **Last Updated**: 2026-07-16
+> **Last Updated**: 2026-07-18
 >
 > **Predecessor**: [prd-v2.4.1-security-hardening.md](./prd-v2.4.1-security-hardening.md) (✅ shipped 2026-06-14)
 > **Successor (long-term)**: [prd-v3.0-economy.md](./prd-v3.0-economy.md)
@@ -42,12 +42,25 @@ Between **v2.4.1** (security patch) and **v3.0** (economy), the project needs a 
 | **v2.5.1** | Code quality patch | Thermo-nuclear audit S0–S3 + P0 correctness/security fixes | *(execution: `engineering/tasks/private/v2.5.1/`)* | **✅ Shipped** 2026-06-26 — tag [`v2.5.1`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.1) |
 | **v2.5.2** | Security & correctness follow-up | #209 (operator auth, `extra="forbid"`, Redis JTI, web rate limits) + CR #245–#249 + registry fixes | [prd-v2.5.2-security-follow-up.md](./prd-v2.5.2-security-follow-up.md) | **✅ Shipped** 2026-07-08 — tag [`v2.5.2`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.2) |
 | **v2.5.3** | Adapter Lab II | Enterprise/workflow adapters (ex v2.3.2) | [prd-v2.5.3-adapter-lab-ii.md](./prd-v2.5.3-adapter-lab-ii.md) | **✅ Shipped** 2026-07-16 — tag [`v2.5.3`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.3) · [tasks](../../engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md) |
-| **v2.5.4** | Distribution Loop | Homepage, templates, métricas (ex v2.3.3) | [prd-v2.5.4-distribution-loop.md](./prd-v2.5.4-distribution-loop.md) | **Ready for kickoff** |
-| **v2.5.5** | Formal Spec & Interop | RFC spec, introspection, privacy, cross-protocol | [prd-v2.5.5-formal-spec-interop.md](./prd-v2.5.5-formal-spec-interop.md) | Planned |
+| **v2.5.4** | Distribution Loop | Homepage, starters, métricas (ex v2.3.3) | [prd-v2.5.4-distribution-loop.md](./prd-v2.5.4-distribution-loop.md) · [tasks](../../engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md) | **Active** (tasks ACTIVE; S0–S2 producer done) |
+| **v2.5.5** | Formal Spec & Interop | RFC spec, introspection, privacy, cross-protocol | [prd-v2.5.5-formal-spec-interop.md](./prd-v2.5.5-formal-spec-interop.md) | Planned (soft-block on Dist; docs-only may overlap) |
 
-**Execution rule:** **v2.5.0–v2.5.3** shipped. **v2.5.4** is next (Distribution Loop). **v2.5.5** may overlap docs-only work.
+**Execution rule:** **v2.5.0–v2.5.3** shipped. **v2.5.4** is next (Distribution Loop; `release/2.5.4` on origin). **v2.5.5** may overlap docs-only work. **v3.0** remains trigger-gated ([prd-v3.0-economy.md](./prd-v3.0-economy.md)).
 
 **Patch tags (not minor releases):** [`v2.5.0.1`](https://github.com/adriannoes/asap-protocol/releases/tag/v2.5.0.1) republished **`asap-compliance` 1.3.0** only; `pyproject.toml` remained **2.5.0**. **`@asap-protocol/mcp-auth`** (npm) is still deferred — future npm patch TBD (do not confuse with tag `v2.5.0.1`).
+
+### Parked / orphan owners (not Dist MUST)
+
+| Item | Owner | Rule |
+|------|-------|------|
+| `@asap-protocol/mcp-auth` (npm) | [v2.5.0 backlog](../../engineering/tasks/v2.5.0/backlog-mcp-auth-typescript.md) | npm patch TBD — not v2.5.4 / not Spec MUST |
+| `@asap-protocol/openapi` (TSOA) | [prd-v2.5.5](./prd-v2.5.5-formal-spec-interop.md) §3.5 | **Default defer** unless demand at Spec kickoff |
+| Fourth starter (workflow) | Optional post–Dist | Lab II `examples/workflow_asap_connector/` already public |
+| Registry API (PostgreSQL) | Trigger: 500 agents / IssueOps bottleneck | Deferred; not a v2.5.x or v3.0 silent prereq |
+| Design System Revamp | Separate design track | Out of Dist |
+| `create-asap` / scaffold CLI | Post–v2.5.4 if demanded | Out of Dist |
+| Public metrics dashboard UI | — | Out of Dist (D4); maintainer telemetry only |
+| G5/G6 governance product | After Formal Spec (local strategy) | Do not schedule as v2.5.x MUST |
 
 ---
 
@@ -83,11 +96,13 @@ Narrativa pública: **ASAP não substitui MCP** — fornece a camada de identida
 
 | Feature | When |
 |---------|------|
-| Economy / billing | v3.0 |
+| Economy / billing | v3.0 (trigger-gated) |
 | Federated registry | v3.x+ |
 | gRPC binding | TBD |
 | Schema negotiation runtime (Agora-style) | Out of scope |
 | Registry API backend (PostgreSQL) | Deferred until 500-agent trigger |
+
+**Handoff chain:** Dist Loop §11 → Formal Spec soft inputs → Economy §8 proxies. See [prd-v2.5.4 §11](./prd-v2.5.4-distribution-loop.md#11-handoff-inputs-for-v255-formal-spec).
 
 ---
 
@@ -98,6 +113,7 @@ Narrativa pública: **ASAP não substitui MCP** — fornece a camada de identida
 - **Adoption foundation**: [prd-v2.3-scale.md](./prd-v2.3-scale.md)
 - **Legacy redirect**: [prd-v2.4-adoption.md](./prd-v2.4-adoption.md)
 - **Tasks**: [engineering/tasks/README.md](../../engineering/tasks/README.md)
+- **Economy (long-term)**: [prd-v3.0-economy.md](./prd-v3.0-economy.md)
 
 ---
 
@@ -105,6 +121,9 @@ Narrativa pública: **ASAP não substitui MCP** — fornece a camada de identida
 
 | Date | Change |
 |------|--------|
+| 2026-07-18 | v2.5.4 status → **Active** (tasks ACTIVE; S0–S2 producer done) |
+| 2026-07-18 | Parked/orphan owners table; Dist→Spec→Economy handoff pointer; v2.5.5 soft-block clarified |
+| 2026-07-18 | v2.5.4 tasks pack created — [tasks-v2.5.4-roadmap.md](../../engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md); PRD D1–D5 locked |
 | 2026-07-08 | Rescope: v2.5.2 = security follow-up; Adapter Lab II → v2.5.3; Distribution Loop → v2.5.4; Formal Spec → v2.5.5; document v2.5.1 as quality patch |
 | 2026-07-08 | **v2.5.2 shipped** — tag `v2.5.2`; PyPI 2.5.2; umbrella #209 closed |
 | 2026-07-11 | v2.5.3 status → Ready for kickoff; linked [tasks-v2.5.3-roadmap.md](../../engineering/tasks/v2.5.3/tasks-v2.5.3-roadmap.md) |

--- a/product/prd/prd-v2.5.4-distribution-loop.md
+++ b/product/prd/prd-v2.5.4-distribution-loop.md
@@ -3,12 +3,13 @@
 > **Product Requirements Document**
 >
 > **Version**: 2.5.4
-> **Status**: READY FOR KICKOFF (v2.5.3 Adapter Lab II shipped 2026-07-16)
+> **Status**: IN PROGRESS (v2.5.3 Adapter Lab II shipped 2026-07-16; decisions locked 2026-07-18; S0–S2 producer done)
 > **Created**: 2026-04-28 (as v2.3.3); **renumbered**: 2026-06-22 → v2.5.2; **2026-07-08 → v2.5.4**
-> **Last Updated**: 2026-07-16
+> **Last Updated**: 2026-07-18
 > **Parent train**: [prd-v2.5-roadmap.md](./prd-v2.5-roadmap.md)
 > **Predecessor**: [prd-v2.5.3-adapter-lab-ii.md](./prd-v2.5.3-adapter-lab-ii.md)
 > **Successor**: [prd-v2.5.5-formal-spec-interop.md](./prd-v2.5.5-formal-spec-interop.md)
+> **Tasks**: [engineering/tasks/v2.5.4/](../../engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md)
 >
 > **Migration note**: Formerly `product/prd/private/prd-v2.3.3-distribution-loop.md` (v2.3.3), then `prd-v2.5.2-distribution-loop.md`. v2.5.2 was reassigned to the security follow-up patch (2026-07-08).
 
@@ -16,7 +17,7 @@
 
 ## 1. Purpose
 
-v2.5.4 turns adoption work from v2.3.0–v2.5.3 into a **repeatable distribution loop**: homepage, docs routing, templates, and lightweight metrics so developers discover ASAP through executable paths.
+v2.5.4 turns adoption work from v2.3.0–v2.5.3 into a **repeatable distribution loop**: homepage, docs routing, thin starter templates, and lightweight metrics so developers discover ASAP through executable paths.
 
 ---
 
@@ -25,39 +26,160 @@ v2.5.4 turns adoption work from v2.3.0–v2.5.3 into a **repeatable distribution
 | Area | Requirement |
 |------|-------------|
 | Homepage | Hero, feature cards, "what's new", CTA for agent-first software |
-| Docs routing | Every homepage CTA → GitHub docs or runnable examples |
-| Templates | OpenAPI provider, TypeScript consumer, top adapter winner(s) |
-| Metrics | Site→docs clicks, npm/PyPI installs, registered agents, guide views |
+| Docs routing | Every homepage CTA → GitHub docs, starters, or runnable examples |
+| Templates | Thin starters: OpenAPI provider, TypeScript consumer, MCP Auth Bridge |
+| Metrics | Site→docs clicks, npm/PyPI installs, registered agents, guide-view proxies |
 | Narrative | Public "Build for agents" copy (no private GTM) |
 
 ---
 
-## 3. Requirements
+## 3. Locked decisions (D1–D5)
 
-| ID | Requirement | Priority |
-|----|-------------|----------|
-| DIST-001 | Update `apps/web` homepage for agent-first software story | MUST |
-| DIST-002 | Link homepage sections to concrete GitHub docs/examples | MUST |
-| DIST-003 | Starter templates for strongest adoption paths (incl. MCP Auth if v2.5.0 winner) | MUST |
-| DIST-004 | Lightweight adoption metrics dashboard | SHOULD |
-| DIST-005 | Public "Build for agents" guide | MUST |
-| DIST-006 | Keep pricing, paid timing, fundraising private | MUST |
+| ID | Decision | Locked value |
+|----|----------|--------------|
+| **D1** | Homepage narrative hierarchy | **"Build for agents" is primary**; marketplace remains proof/distribution (secondary CTAs to browse/register) |
+| **D2** | Canonical starters (exactly 3) | OpenAPI provider · TypeScript consumer · MCP Auth Bridge |
+| **D3** | Starter shape | **Thin wrappers** under `examples/starters/` derived from existing examples/apps; not a new scaffold CLI |
+| **D4** | Metrics DoD (DIST-004) | **Operationalize** existing `scripts/telemetry/` + maintainer dashboard markdown; **no** public live dashboard UI |
+| **D5** | Release shape | Versioned train: tag **`v2.5.4`**, bump Python package, `CHANGELOG.md`, migration note |
+
+### 3.1 Canonical starter destinations
+
+| Starter | Delivery path | Source (do not reinvent) |
+|---------|---------------|--------------------------|
+| OpenAPI provider | `examples/starters/openapi-provider/` | `examples/openapi_petstore/` + `docs/adapters/openapi.md` |
+| TypeScript consumer | `examples/starters/typescript-consumer/` | `apps/example-nextjs/` (consumer patterns) + `packages/typescript/client` + `docs/sdks/typescript.md` |
+| MCP Auth Bridge | `examples/starters/mcp-auth-bridge/` | `examples/mcp_auth_bridge/` + `docs/adapters/mcp-auth-bridge.md` |
+
+Thin starter = README with ≤1 smoke command + minimal entrypoint (prefer wrap/re-export of parent example over duplicated logic).
+
+### 3.2 Metric proxies (accepted)
+
+| PRD metric | Accepted proxy / source |
+|------------|-------------------------|
+| Site→docs clicks | `data-cta` + Vercel Analytics + `/api/telemetry`; optional `TELEMETRY_SITE_METRICS_JSON` |
+| npm installs | `scripts/telemetry/collect_npm.py` (≥ `@asap-protocol/client`, `@asap-protocol/mastra`, `@asap-protocol/openai-agents`) |
+| PyPI installs | `scripts/telemetry/collect_pypi.py` / aggregate (≥ `asap-protocol`, `asap-compliance`) |
+| Registered agents | `scripts/telemetry/collect_registry.py` → `registry.json` |
+| Guide views | GitHub traffic/referrers via `collect_github.py` + site→docs CTR; **not** a new MkDocs analytics plugin |
 
 ---
 
-## 4. Public narrative (draft)
+## 4. Baseline inventory (do not rebuild)
+
+Lab II and prior trains already shipped much of the distribution surface. v2.5.4 **extends** this; it does not replace it.
+
+| Area | Already present | Gap for this PRD |
+|------|-----------------|------------------|
+| Homepage shell | `apps/web/src/app/page.tsx` — Hero, WhatsNew, Features, HowItWorks | Hero still marketplace-primary; narrative D1 not applied |
+| CTA instrumentation | `apps/web/src/lib/telemetry/homepage-cta-ids.ts`, `CtaClickTracker` | Hero CTAs still point to browse/register; incomplete docs routing on some feature/DX cards |
+| Examples | `examples/openapi_petstore/`, `examples/mcp_auth_bridge/`, `examples/workflow_asap_connector/`, … | No `examples/starters/` pack |
+| TS consumer app | `apps/example-nextjs/` | Not packaged as a thin starter |
+| Telemetry | `scripts/telemetry/*`, `docs/maintainers/telemetry.md`, `.github/workflows/telemetry-weekly.yml`, `/api/telemetry` | Package coverage incomplete; schedule may need secrets; no public UI (by design) |
+| Public guide | Tutorials / adapters / integrations under `docs/` | No `docs/guides/build-for-agents.md` |
+
+---
+
+## 5. Requirements
+
+| ID | Requirement | Priority | Artifact | Acceptance (falsifiable) |
+|----|-------------|----------|----------|--------------------------|
+| **DIST-001** | Update `apps/web` homepage for agent-first software story | MUST | Hero, metadata, How it Works, What's new, feature framing | Primary hero copy matches §6; marketplace CTAs secondary; version badge/terminal not stale |
+| **DIST-002** | Link homepage sections to concrete GitHub docs/starters/examples | MUST | Landing CTAs + feature/DX docs links | Every primary homepage CTA resolves to a live docs/starter/example URL; `data-cta` IDs remain stable |
+| **DIST-003** | Starter templates for strongest adoption paths | MUST | `examples/starters/{openapi-provider,typescript-consumer,mcp-auth-bridge}/` | Exactly the D2 trio; each has README + headless smoke ≤60s |
+| **DIST-004** | Lightweight adoption metrics (operational) | SHOULD | Collectors + `private/telemetry/dashboard.md` + runbook + CI dispatch | Aggregate covers npm≥3 + PyPI≥2 packages; runbook documents weekly ops; **no** new `apps/web` metrics UI |
+| **DIST-005** | Public "Build for agents" guide | MUST | `docs/guides/build-for-agents.md` + `mkdocs.yml` | Guide published; linked from starters index (+ docs/index); homepage primary CTA link lands with S3 CTA routing (DIST-001/002) |
+| **DIST-006** | Keep pricing, paid timing, fundraising private | MUST | Public copy gate | Grep/review of homepage + new guide + starter READMEs finds no private GTM/pricing/fundraising |
+
+### 5.1 Dependencies
+
+| Requirement | Depends on |
+|-------------|------------|
+| DIST-001 / DIST-002 | DIST-005 paths known; DIST-003 starter URLs preferred for primary CTAs |
+| DIST-003 | D2/D3; parent examples remain canonical |
+| DIST-004 | Existing telemetry stack; secrets for scheduled CI optional until configured |
+| DIST-005 | D1 narrative; links to D2 starters |
+| DIST-006 | Continuous on every PR that touches public copy |
+
+---
+
+## 6. Public narrative (canonical)
 
 > The next users of software are agents. ASAP gives them the machine-readable foundation they need: discoverable capabilities, scoped identity, compliance checks, and SDKs that turn existing APIs into agent-ready interfaces.
 
+**Homepage hierarchy (D1):** lead with this story and CTAs into the guide + starters; keep Explore Agents / Register Agent as secondary proof of the open marketplace.
+
 ---
 
-## 5. Success metrics
+## 7. Success metrics
 
 | Metric | Target |
 |--------|--------|
-| Homepage CTAs → docs/examples | Present and trackable |
-| Starter templates | 3+ |
-| Adoption dashboard | Live or documented |
+| Homepage primary CTAs → docs/starters/examples | Present, live, and trackable via `data-cta` |
+| Starter templates | Exactly **3** at the D2 paths (thin wrappers) |
+| Adoption metrics | Documented + runnable aggregate (≥1 maintainer run or CI `workflow_dispatch`); dashboard markdown under `private/telemetry/` (gitignored) |
+| Release | Tag `v2.5.4` + PyPI `asap-protocol==2.5.4` |
+
+---
+
+## 8. Definition of Done
+
+- [ ] DIST-001 … DIST-003, DIST-005, DIST-006 green
+- [ ] DIST-004 green **or** explicit maintainer deferral recorded on the roadmap (SHOULD)
+- [ ] [docs-review-checklist](../../engineering/tasks/v2.5.4/docs-review-checklist.md) signed for shipped surface
+- [ ] [release-checklist](../../engineering/tasks/v2.5.4/release-checklist.md) §§1–6 complete (merge → tag → publish → handoff)
+- [ ] Public copy free of private GTM / pricing / fundraising
+
+---
+
+## 9. Out of scope (defer)
+
+| Item | Where / note |
+|------|----------------|
+| Full Design System Revamp | Separate design track; copy/routing only here |
+| Scaffold generator / `create-asap` CLI | Post–v2.5.4 if demanded |
+| Public live metrics dashboard UI | Explicitly out (D4) |
+| New MkDocs analytics plugin | Out; use GitHub + site CTR proxies |
+| `@asap-protocol/mcp-auth` npm package | [v2.5.0 backlog](../../engineering/tasks/v2.5.0/backlog-mcp-auth-typescript.md) |
+| Pricing, paid timing, fundraising, private GTM | Local `product/strategy/` only |
+| Formal Spec / A2A bridge | [prd-v2.5.5-formal-spec-interop.md](./prd-v2.5.5-formal-spec-interop.md) |
+| Fourth starter (workflow connector) | Optional follow-up; Lab II example already public |
+
+---
+
+## 10. Sprint mapping (tasks)
+
+| Sprint | Focus | PRD |
+|--------|-------|-----|
+| S0 | Scope lock (confirm D1–D5 + baseline) | §3–§4 |
+| S1 | Thin starter pack | DIST-003 |
+| S2 | Build for agents guide | DIST-005 |
+| S3 | Homepage narrative + CTA routing | DIST-001, DIST-002, DIST-005 (homepage link), DIST-006 |
+| S4 | Telemetry operations | DIST-004 |
+| S5 | Release v2.5.4 | DoD / D5 |
+
+See [tasks-v2.5.4-roadmap.md](../../engineering/tasks/v2.5.4/tasks-v2.5.4-roadmap.md).
+
+---
+
+## 11. Handoff inputs for v2.5.5 (Formal Spec)
+
+> Fill/confirm at S5 after ship. Dist Loop is a **soft** input to Formal Spec (narrative + examples), not a hard implementation gate. Docs-only Spec work may overlap Dist per [prd-v2.5-roadmap.md](./prd-v2.5-roadmap.md).
+
+| Input | Locked path / value | Spec use |
+|-------|---------------------|----------|
+| Canonical narrative (D1) | §6 paragraph + homepage hierarchy | Tone for SPEC examples; ASAP ≠ replace MCP |
+| Guide | `docs/guides/build-for-agents.md` | Public onboarding cited from Spec / COMPAT guide |
+| OpenAPI starter | `examples/starters/openapi-provider/` | Provider onboarding examples |
+| TypeScript starter | `examples/starters/typescript-consumer/` | Consumer / SDK examples |
+| MCP Auth starter | `examples/starters/mcp-auth-bridge/` | SPEC-009 narrative + COMPAT |
+| Metric proxies (optional) | `docs/maintainers/telemetry.md` + DIST-004 | Adoption evidence only; not Spec MUST |
+| OOS inherited (do not pull into Spec as Dist debt) | `create-asap` CLI, public metrics UI, Design System Revamp, fourth workflow starter, pricing/GTM | Stay deferred |
+| Still backlog (not Dist, not Spec MUST) | `@asap-protocol/mcp-auth` npm — [v2.5.0 backlog](../../engineering/tasks/v2.5.0/backlog-mcp-auth-typescript.md) | npm patch TBD |
+| TSOA `@asap-protocol/openapi` | Conditional P3 on [prd-v2.5.5](./prd-v2.5.5-formal-spec-interop.md) §3.5 | Defer unless demand at Spec kickoff |
+
+**Successor PRD:** [prd-v2.5.5-formal-spec-interop.md](./prd-v2.5.5-formal-spec-interop.md)
+**Economy (later):** [prd-v3.0-economy.md](./prd-v3.0-economy.md) — Dist metrics are candidate proxies for launch triggers; no pricing copy in Dist.
 
 ---
 
@@ -65,6 +187,9 @@ v2.5.4 turns adoption work from v2.3.0–v2.5.3 into a **repeatable distribution
 
 | Date | Change |
 |------|--------|
+| 2026-07-18 | Status → **IN PROGRESS**; DIST-005 acceptance clarifies homepage link lands with S3 CTA routing |
+| 2026-07-18 | §11 handoff inputs for v2.5.5; train cross-links tightened before kickoff |
+| 2026-07-18 | **Decisions locked** (D1–D5); baseline inventory; falsifiable DIST criteria; out of scope; sprint mapping; status remains READY FOR KICKOFF |
 | 2026-07-16 | Status → **READY FOR KICKOFF** (v2.5.3 shipped) |
 | 2026-07-08 | Renumbered v2.5.2 → **v2.5.4** (v2.5.2 = security follow-up) |
 | 2026-06-22 | Renumbered v2.3.3 → v2.5.2 |

--- a/product/prd/prd-v2.5.5-formal-spec-interop.md
+++ b/product/prd/prd-v2.5.5-formal-spec-interop.md
@@ -5,8 +5,9 @@
 > **Version**: 2.5.5
 > **Status**: PLANNED
 > **Created**: 2026-03-20 (origin in `prd-v2.4-adoption.md`); **rescoped**: 2026-06-22 → v2.5.3; **2026-07-08 → v2.5.5**
+> **Last Updated**: 2026-07-18
 > **Parent train**: [prd-v2.5-roadmap.md](./prd-v2.5-roadmap.md)
-> **Predecessor**: [prd-v2.5.4-distribution-loop.md](./prd-v2.5.4-distribution-loop.md)
+> **Predecessor**: [prd-v2.5.4-distribution-loop.md](./prd-v2.5.4-distribution-loop.md) (soft — narrative/examples)
 > **Successor**: [prd-v3.0-economy.md](./prd-v3.0-economy.md)
 
 ---
@@ -74,7 +75,7 @@ v2.5.5 closes the **standards-track loop** deferred since v2.3: formal RFC-style
 
 ### 3.5 TypeScript OpenAPI Adapter (P3 — conditional)
 
-Ship only if `@asap-protocol/openapi` did not land in v2.3:
+Ship only if demand at Spec kickoff **and** `@asap-protocol/openapi` still does not exist. **Default: defer** (Python OpenAPI adapter + Dist OpenAPI starter already cover the path).
 
 | ID | Requirement | Priority |
 |----|-------------|----------|
@@ -87,22 +88,38 @@ Ship only if `@asap-protocol/openapi` did not land in v2.3:
 
 Same as v2.5 train — economy, federated registry, gRPC. MCP Auth Bridge is **not** in this PRD (shipped in v2.5.0). Security follow-ups from v2.4.1 §8 shipped in **v2.5.2**.
 
+Also **not** this PRD: Distribution Loop homepage rewrite, starter pack, public metrics UI, `create-asap` CLI, `@asap-protocol/mcp-auth` npm (see Dist OOS + v2.5.0 backlog). Do not absorb Dist OOS as Spec MUST.
+
 ---
 
 ## 5. Prerequisites
 
-| Prerequisite | Source |
-|-------------|--------|
-| v2.5.0 MCP Auth Bridge shipped | Stable MCP adapter API for SPEC-009 |
-| v2.5.3/v2.5.4 adoption learnings | Optional narrative inputs for spec examples |
-| Identity/capability model stable | v2.2+ |
+| Prerequisite | Kind | Source |
+|--------------|------|--------|
+| v2.5.0 MCP Auth Bridge shipped | **Hard** (SPEC-009) | Stable MCP adapter API |
+| Identity/capability model stable | **Hard** | v2.2+ |
+| v2.5.4 Distribution Loop (or equivalent narrative + starters) | **Soft** | Optional examples — [PRD §11 handoff](./prd-v2.5.4-distribution-loop.md#11-handoff-inputs-for-v255-formal-spec) |
+| v2.5.3 Adapter Lab II guides | **Soft** | Optional workflow / NAT / MAF narrative |
+
+**Kickoff rule:** Docs-only Spec work **may overlap** Dist Loop. Implementation that needs Dist starter URLs should wait for Dist ship **or** cite Lab II parent examples temporarily.
+
+**Expected Dist inputs (when available):**
+
+| Artifact | Path |
+|----------|------|
+| Guide | `docs/guides/build-for-agents.md` |
+| Starters | `examples/starters/{openapi-provider,typescript-consumer,mcp-auth-bridge}/` |
+| Narrative | Dist PRD §6 / D1 |
 
 ---
 
 ## 6. Related documents
 
+- **Distribution Loop (predecessor, soft):** [prd-v2.5.4-distribution-loop.md](./prd-v2.5.4-distribution-loop.md)
 - **MCP Auth Bridge**: [prd-v2.5.0-mcp-auth-bridge.md](./prd-v2.5.0-mcp-auth-bridge.md)
 - **Security follow-up**: [prd-v2.5.2-security-follow-up.md](./prd-v2.5.2-security-follow-up.md)
+- **Train index**: [prd-v2.5-roadmap.md](./prd-v2.5-roadmap.md)
+- **Economy (successor, trigger-gated):** [prd-v3.0-economy.md](./prd-v3.0-economy.md)
 - **Legacy**: [prd-v2.4-adoption.md](./prd-v2.4-adoption.md)
 
 ---
@@ -111,5 +128,6 @@ Same as v2.5 train — economy, federated registry, gRPC. MCP Auth Bridge is **n
 
 | Date | Change |
 |------|--------|
+| 2026-07-18 | Hard vs soft prerequisites; Dist handoff paths; TSOA default defer; non-goals vs Dist OOS |
 | 2026-07-08 | Renumbered v2.5.3 → **v2.5.5** (train shift after v2.5.2 security ship) |
 | 2026-06-22 | Split from `prd-v2.4-adoption.md` §4.2–4.6; renumbered to v2.5.3 |

--- a/product/prd/prd-v3.0-economy.md
+++ b/product/prd/prd-v3.0-economy.md
@@ -5,7 +5,8 @@
 > **Version**: 3.0.0
 > **Status**: VISION DRAFT
 > **Created**: 2026-02-25
-> **Last Updated**: 2026-03-20
+> **Last Updated**: 2026-07-18
+> **Predecessor train**: [prd-v2.5-roadmap.md](./prd-v2.5-roadmap.md) (through Formal Spec [v2.5.5](./prd-v2.5.5-formal-spec-interop.md))
 
 ---
 
@@ -223,17 +224,23 @@ Before launching economy features:
 
 ## 8. Prerequisites from v2.x
 
-| Prerequisite | Source |
-|-------------|--------|
-| ASAP OAuth2 infrastructure | v1.1+ |
-| Per-runtime-agent identity & capabilities | v2.2 |
-| Registry API Backend (PostgreSQL) | v2.3 |
-| Audit Logging | v2.2 |
-| TypeScript SDK | v2.3 |
-| OpenAPI adapter (for easy service onboarding) | v2.4 |
-| Consumer SDK (credits API) | v2.1 (extended in v3.0) |
-| Usage Metering (`MeteringStore`) | v1.3+ |
-| 100+ Verified agent candidates | Growth trigger |
+| Prerequisite | Source | Notes (2026-07-18) |
+|-------------|--------|---------------------|
+| ASAP OAuth2 infrastructure | v1.1+ | Shipped |
+| Per-runtime-agent identity & capabilities | v2.2 | Shipped |
+| Audit Logging | v2.2 | Shipped |
+| Usage Metering (`MeteringStore`) | v1.3+ | Shipped |
+| TypeScript SDK | v2.3 | Shipped (`@asap-protocol/client`) |
+| OpenAPI adapter (provider onboarding) | **v2.3.0** (not v2.4) | Shipped; Dist thin starter under `examples/starters/openapi-provider/` |
+| Consumer / agent-first distribution | **v2.5.4** Distribution Loop | Soft: narrative + starters + metric proxies — [PRD](./prd-v2.5.4-distribution-loop.md) |
+| Formal Spec / interop narrative | **v2.5.5** (soft successor) | Standards-track; not a hard Economy gate |
+| Registry API Backend (PostgreSQL) | Deferred | **Not shipped.** Still gated by 500-agent / IssueOps trigger ([prd-v2.5-roadmap.md](./prd-v2.5-roadmap.md) non-goals). Credit ledger in §6.1 must not assume it exists yet. |
+| 100+ Verified agent candidates | Growth trigger | Candidate **proxies** from Dist DIST-004: registry count, npm/PyPI installs, site→docs CTR — not a substitute for the paid-badge trigger itself |
+| Legal/tax infrastructure | §6.4 | Required with revenue triggers |
+
+### 8.1 ADR-21 vs paid Verified Badge
+
+Until Economy launch triggers fire, public trust remains **merit-based / free** per ADR-21 ([05-product-strategy.md](../decision-records/05-product-strategy.md)). The **$49/mo** badge in this PRD is a **future** product change; do not preview pricing in v2.5.x public copy (Dist DIST-006).
 
 ---
 
@@ -248,11 +255,13 @@ Before launching economy features:
 
 ## 10. Related Documents
 
+- **v2.5.x train**: [prd-v2.5-roadmap.md](./prd-v2.5-roadmap.md)
+- **Distribution Loop (adoption metrics / narrative)**: [prd-v2.5.4-distribution-loop.md](./prd-v2.5.4-distribution-loop.md)
+- **Formal Spec (predecessor minor)**: [prd-v2.5.5-formal-spec-interop.md](./prd-v2.5.5-formal-spec-interop.md)
 - **Vision**: [prd-v2.0-roadmap.md](./prd-v2.0-roadmap.md) §3 (Economy Layer) and §5.3 (Pricing Strategy)
-- **Deferred scope (original backlog sections)**: [05-product-strategy.md](../decision-records/05-product-strategy.md) (see Questions 10, 15, 21–22 for deferrals)
-- **Previous Version**: [prd-v2.4-adoption.md](./prd-v2.4-adoption.md)
+- **Deferred scope (original backlog sections)**: [05-product-strategy.md](../decision-records/05-product-strategy.md) (see Questions 10, 15, 21–22 for deferrals; ADR-21 Verified Badge free until Economy)
+- **Legacy adoption redirect**: [prd-v2.4-adoption.md](./prd-v2.4-adoption.md)
 - **Crypto settlement extension**: [§6.2 Pluggable Settlement Architecture](#62-pluggable-settlement-architecture)
-- **Marketplace roadmap arc**: [prd-v2.0-roadmap.md](./prd-v2.0-roadmap.md)
 
 ---
 
@@ -260,6 +269,7 @@ Before launching economy features:
 
 | Date | Version | Change |
 |------|---------|--------|
+| 2026-07-18 | 0.3.1 | Prerequisites corrected (OpenAPI = v2.3; Registry API deferred); Dist metrics as trigger proxies; ADR-21 vs paid badge note; cross-links to v2.5.4/v2.5.5 |
 | 2026-02-25 | 0.1.0 | Vision DRAFT — consolidates deferred-backlog §4, §5 and vision-agent-marketplace §3 |
 | 2026-03-13 | 0.2.0 | Added §6.2 Pluggable Settlement Architecture (SettlementBackend Protocol). Q4 resolved: crypto settlement planned as v4.0+ in separate repo. Non-Goals updated. |
 | 2026-03-20 | 0.3.0 | Updated prerequisites: Registry API Backend is v2.3 (not v2.2). Added v2.2 identity/capabilities, v2.3 TypeScript SDK, v2.4 OpenAPI adapter as prerequisites. Updated previous version link to v2.4. |


### PR DESCRIPTION
## Summary
- Activate the v2.5.4 Distribution Loop train (D1–D5 locked, S0–S5 task plan, `BRANCHING.md` → `release/2.5.4`).
- Ship DIST-003 thin starters under `examples/starters/` (OpenAPI provider, TypeScript consumer, MCP Auth Bridge) with headless smokes.
- Publish DIST-005 producer slice: `docs/guides/build-for-agents.md`, MkDocs Guides nav, and docs/starters cross-links (homepage CTA remainder deferred to S3).

## Review follow-ups (addressed)
- Relative in-repo starter links (no `tree/main` 404s before S5); S5 checklist item to confirm/`tree/main` flip after merge.
- TypeScript smoke docs include `pnpm install` (fresh clone).
- Python starter wrappers enforce `timeout=60`.
- Path-filtered `.github/workflows/starters-smoke.yml` + release-checklist §1.1 smoke block.
- Adapter/SDK “See also” back-links to starters.

## Test plan
- [x] `uv sync --extra openapi && uv run python examples/starters/openapi-provider/run.py`
- [x] `uv sync && uv run python examples/starters/mcp-auth-bridge/run.py`
- [x] `pnpm install && pnpm --filter @asap-protocol/client run build && npm install --prefix examples/starters/typescript-consumer && node examples/starters/typescript-consumer/smoke.mjs`
- [x] `ASAP_PROVIDER_URL=http://example.com node examples/starters/typescript-consumer/smoke.mjs` exits non-zero (HTTPS guard)
- [x] `uv sync --extra docs && uv run mkdocs build`
- [x] Grep public copy: no pricing/fundraising/GTM in starters + guide
- [x] Confirm PR base is `release/2.5.4` (not `main`)
- [x] Confirm `Starters smoke` workflow runs on this PR

## Review
T2 re-review: **Approved with caveats** (homepage half of DIST-005 owned by S3). PR automation review follow-ups applied above.